### PR TITLE
refactor(WebexMeeting): use withMeeting HOC in WebexMeeting widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1499,9 +1499,9 @@
       }
     },
     "@juggle/resize-observer": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.2.0.tgz",
-      "integrity": "sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.0.tgz",
+      "integrity": "sha512-P1v2nvK7z2gOLVM/bveIRLG9L99uEahTGgTltyF03zixZAjI9YmKLj5Z9MpS9wBIUt5WDoQORT2lXvLOIF89iA=="
     },
     "@marionebl/sander": {
       "version": "0.6.1",
@@ -4338,14 +4338,21 @@
       "integrity": "sha512-XSlgvKudRatq1gmgD0EZ5PjHp0SGbvrfqqfHUCIEufZMl4wEcvOHPmWzZe3H9CQSkaLKUa7Jf8ngOa8KMOYBWA=="
     },
     "@webex/components": {
-      "version": "1.45.6",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.45.6.tgz",
-      "integrity": "sha512-hABDcrGXlxR1oUYlUg8jO+1yyANGeEsDDJbsr9V6voiEcJC3mzQQ3z0SNlhD9wNNTkLFs2wESFd/u2KuTYNdxw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.60.0.tgz",
+      "integrity": "sha512-5RTnxebH1BiT8kEjdOkB8Bs5ZUkmQbHRg5JIVYSE5W47ULiNahq7PHCev1QfGeWk2Mt6WzzDbyFowREMEa4drA==",
       "requires": {
         "@juggle/resize-observer": "^3.2.0",
-        "@webex/component-adapter-interfaces": "^1.11.0",
+        "@webex/component-adapter-interfaces": "^1.16.1",
         "classnames": "^2.2.6",
         "date-fns": "^2.15.0"
+      },
+      "dependencies": {
+        "@webex/component-adapter-interfaces": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.16.1.tgz",
+          "integrity": "sha512-w9QE19G1mjUY7gna++6PilhPjMtIj/b+QaTKAwibdWkCurQcDGd6/yYc70UzWawLFkjvsIDltf36YfvO+dWjGw=="
+        }
       }
     },
     "@webex/helper-html": {
@@ -7001,9 +7008,9 @@
       }
     },
     "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
       "version": "4.2.3",
@@ -8224,9 +8231,9 @@
       }
     },
     "date-fns": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.1.tgz",
+      "integrity": "sha512-m1WR0xGiC6j6jNFAyW4Nvh4WxAi4JF4w9jRJwSI8nBmNcyZXPcP9VUQG+6gHQXAmqaGEKDKhOqAtENDC941UkA=="
     },
     "date-format": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@momentum-ui/react": "^23.21.4",
-    "@webex/components": "^1.45.6",
+    "@webex/components": "^1.60.0",
     "@webex/sdk-component-adapter": "^1.24.1"
   },
   "devDependencies": {

--- a/src/widgets/WebexMeeting/WebexMeeting.jsx
+++ b/src/widgets/WebexMeeting/WebexMeeting.jsx
@@ -2,12 +2,21 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Spinner} from '@momentum-ui/react';
 import Webex from 'webex';
-import {WebexMeeting, WebexDataProvider} from '@webex/components';
+import {WebexMeeting, WebexDataProvider, withMeeting} from '@webex/components';
 import WebexSDKAdapter from '@webex/sdk-component-adapter';
 
 import '@momentum-ui/core/css/momentum-ui.min.css';
 import '@webex/components/dist/css/webex-components.css';
 import './WebexMeeting.css';
+
+
+  //the enhanced meeting component
+  const Content = withMeeting(function(props) {
+    return props.meeting.ID ?
+      <WebexMeeting meetingID={props.meeting.ID} />
+      : <Spinner />
+  });
+
 
 /**
  * Webex meeting widget displays the default Webex meeting experience.
@@ -16,10 +25,9 @@ import './WebexMeeting.css';
  * @param {string} props.accessToken        access token to create the webex instance with
  * @returns {Object} JSX of the component
  */
-export default class WebexMeetingWidget extends Component {
+class WebexMeetingWidget extends Component {
   constructor(props) {
     super(props);
-
     const webex = new Webex({
       credentials: props.accessToken,
     });
@@ -45,7 +53,7 @@ export default class WebexMeetingWidget extends Component {
       <div className="meeting-widget">
         {this.state.adapterConnected ? (
           <WebexDataProvider adapter={this.adapter}>
-            <WebexMeeting meetingDestination={this.props.meetingDestination} />
+            <Content {...this.props} />
           </WebexDataProvider>
         ) : (
           <Spinner />
@@ -59,3 +67,5 @@ WebexMeetingWidget.propTypes = {
   accessToken: PropTypes.string.isRequired,
   meetingDestination: PropTypes.string.isRequired,
 };
+
+export default WebexMeetingWidget;


### PR DESCRIPTION
Create the meeting object and provide the meeting id to the meeting component, by using the withMeeting HOC in WebexMeetingWidget.

Link Jira: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223898

Depends on: #39
