### PR TITLE
test(WebexMeeting): e2e test mute video before join

### DIFF
--- a/tests/WebexMeeting.e2e.js
+++ b/tests/WebexMeeting.e2e.js
@@ -57,6 +57,14 @@ describe('Meeting Widget', () => {
     MeetingPage.unloadWidget();
   });
 
+  it('mutes video before joining meeting', () => {
+    MeetingPage.loadWidget(meetingDestination);
+    MeetingPage.muteVideoBtn.click();
+    expect(MeetingPage.muteVideoBtn).not.toBeVisible();
+    expect(MeetingPage.unmuteVideoBtn).toBeVisible();
+    MeetingPage.unloadWidget();
+  });
+
   it('displays "Waiting for others" after joining meeting', () => {
     MeetingPage.loadWidget(meetingDestination);
     expect(MeetingPage.waitingForOthers).not.toExist();

--- a/tests/pages/MeetingWidget.page.js
+++ b/tests/pages/MeetingWidget.page.js
@@ -7,6 +7,8 @@ class MeetingWidgetPage {
   get meetingInfo() { return $('.wxc-meeting-info'); }
   get muteAudioBtn() { return $('.meeting-controls-container button[alt=Mute]'); }
   get unmuteAudioBtn() { return $('.meeting-controls-container button[alt=Unmute]'); }
+  get muteVideoBtn() { return $('.meeting-controls-container button[alt="Stop video"]'); }
+  get unmuteVideoBtn() { return $('.meeting-controls-container button[alt="Start video"]'); }
   get joinMeetingBtn() { return $('.meeting-controls-container button[alt="Join meeting"]'); }
   get waitingForOthers() { return $('h4=Waiting for others to join...'); }
 


### PR DESCRIPTION
Create a E2E test to assert user can disable video before joining a meeting via meetings widget

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223787