### PR TITLE
test(WebexMeeting): e2e test mute audio after join

### DIFF
--- a/tests/WebexMeeting.e2e.js
+++ b/tests/WebexMeeting.e2e.js
@@ -56,4 +56,22 @@ describe('Meeting Widget', () => {
     expect(MeetingPage.unmuteAudioBtn).toBeVisible();
     MeetingPage.unloadWidget();
   });
+
+  it('displays "Waiting for others" after joining meeting', () => {
+    MeetingPage.loadWidget(meetingDestination);
+    expect(MeetingPage.waitingForOthers).not.toExist();
+    MeetingPage.joinMeetingBtn.click();
+    MeetingPage.waitingForOthers.waitForDisplayed({timeout: 10000});
+    expect(MeetingPage.waitingForOthers).toBeVisible();
+    MeetingPage.unloadWidget();
+  });
+
+  it('mutes audio after joining meeting', () => {
+    MeetingPage.loadWidget(meetingDestination);
+    MeetingPage.joinMeetingBtn.click();
+    MeetingPage.waitingForOthers.waitForDisplayed({timeout: 10000});
+    MeetingPage.muteAudioBtn.click();
+    expect(MeetingPage.unmuteAudioBtn).toBeVisible();
+    MeetingPage.unloadWidget();
+  });
 });

--- a/tests/pages/MeetingWidget.page.js
+++ b/tests/pages/MeetingWidget.page.js
@@ -7,6 +7,8 @@ class MeetingWidgetPage {
   get meetingInfo() { return $('.wxc-meeting-info'); }
   get muteAudioBtn() { return $('.meeting-controls-container button[alt=Mute]'); }
   get unmuteAudioBtn() { return $('.meeting-controls-container button[alt=Unmute]'); }
+  get joinMeetingBtn() { return $('.meeting-controls-container button[alt="Join meeting"]'); }
+  get waitingForOthers() { return $('h4=Waiting for others to join...'); }
 
   loadWidget(meetingDestination) {
     this.destination.setValue(meetingDestination);


### PR DESCRIPTION
Create a E2E test to assert user can mute audio after joining a meeting via meetings widget
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223795