### PR TITLE
feat(WebexMeeting): add roster component in meeting widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3823,9 +3823,9 @@
       }
     },
     "@webex/component-adapter-interfaces": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.16.1.tgz",
-      "integrity": "sha512-w9QE19G1mjUY7gna++6PilhPjMtIj/b+QaTKAwibdWkCurQcDGd6/yYc70UzWawLFkjvsIDltf36YfvO+dWjGw=="
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@webex/component-adapter-interfaces/-/component-adapter-interfaces-1.17.0.tgz",
+      "integrity": "sha512-KdTY9xKl0+00uO1D+5jWaE1Y2z7DyaZH9L+6+LaFc17O7ptSgASUI9SHItHmIUIqRh1SkIPNNfcpUNbMllQsxA=="
     },
     "@webex/components": {
       "version": "1.61.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@momentum-ui/react": "^23.21.4",
     "@webex/components": "^1.60.0",
-    "@webex/sdk-component-adapter": "^1.33.2"
+    "@webex/sdk-component-adapter": "^1.33.2",
+    "@webex/component-adapter-interfaces": "^1.17.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/widgets/WebexMeeting/WebexMeeting.css
+++ b/src/widgets/WebexMeeting/WebexMeeting.css
@@ -1,7 +1,23 @@
-.meeting-widget {
+.webex-meeting-widget {
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
   height: 100%;
 }
+
+.webex-meeting-widget__body {
+  display: flex;
+  flex: 1;
+}
+
+.webex-meeting-widget__meeting {
+  flex: 1;
+  min-width: 0;
+}
+
+.webex-meeting-widget__roster {
+  width: 20rem;
+  padding: 0.625rem;
+}
+

--- a/src/widgets/WebexMeeting/WebexMeeting.jsx
+++ b/src/widgets/WebexMeeting/WebexMeeting.jsx
@@ -2,8 +2,12 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Spinner} from '@momentum-ui/react';
 import Webex from 'webex';
-import {WebexMeeting, WebexDataProvider, withMeeting} from '@webex/components';
+import {WebexMeeting, WebexMemberRoster, WebexDataProvider, withMeeting} from '@webex/components';
 import WebexSDKAdapter from '@webex/sdk-component-adapter';
+
+// Dependency from here is not explicity declared in package.json
+import {DestinationType, MeetingState} from '@webex/component-adapter-interfaces';
+
 
 import '@momentum-ui/core/css/momentum-ui.min.css';
 import '@webex/components/dist/css/webex-components.css';
@@ -15,9 +19,21 @@ const controls = (isActive) => isActive
   : ['mute-audio', 'mute-video', 'join-meeting'];
 
   const Content = withMeeting(function(props) {
-    return props.meeting.ID ?
-      <WebexMeeting meetingID={props.meeting.ID} controls={controls} />
-      : <Spinner />
+    return props.meeting.ID ? (
+      <div className="webex-meeting-widget__body">
+        <div className="webex-meeting-widget__meeting">
+          <WebexMeeting meetingID={props.meeting.ID} controls={controls} />
+        </div>
+        {props.meeting.showRoster && props.meeting.state === MeetingState.JOINED && ( 
+          <div className="webex-meeting-widget__roster">
+            <WebexMemberRoster 
+              destinationID={props.meeting.ID} 
+              destinationType={DestinationType.MEETING}
+            />
+          </div>
+        )}
+      </div>
+      ) : <Spinner />
   });
 
 
@@ -53,7 +69,7 @@ class WebexMeetingWidget extends Component {
 
   render() {
     return (
-      <div className="meeting-widget">
+      <div className="webex-meeting-widget">
         {this.state.adapterConnected ? (
           <WebexDataProvider adapter={this.adapter}>
             <Content {...this.props} />


### PR DESCRIPTION
Use the member roster component in the meeting widget. Show/hide when the participants control is clicked.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-227951