### PR TITLE
test(WebexMeeting): e2e test mute audio after join

### DIFF
--- a/tests/WebexMeeting.e2e.js
+++ b/tests/WebexMeeting.e2e.js
@@ -65,4 +65,14 @@ describe('Meeting Widget', () => {
     expect(MeetingPage.waitingForOthers).toBeVisible();
     MeetingPage.unloadWidget();
   });
+
+  it('mutes audio after joining meeting', () => {
+    MeetingPage.loadWidget(meetingDestination);
+    MeetingPage.joinMeetingBtn.click();
+    MeetingPage.waitingForOthers.waitForDisplayed({timeout: 10000});
+    MeetingPage.muteAudioBtn.click();
+    expect(MeetingPage.muteAudioBtn).not.toBeVisible();
+    expect(MeetingPage.unmuteAudioBtn).toBeVisible();
+    MeetingPage.unloadWidget();
+  });
 });


### PR DESCRIPTION
Create a E2E test to assert user can mute audio after joining a meeting via meetings widget
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223795