### PR TITLE
test(WebexMeeting): e2e test mute video after join

### DIFF
--- a/tests/WebexMeeting.e2e.js
+++ b/tests/WebexMeeting.e2e.js
@@ -75,4 +75,13 @@ describe('Meeting Widget', () => {
     expect(MeetingPage.unmuteAudioBtn).toBeVisible();
     MeetingPage.unloadWidget();
   });
+
+  it('mutes video after joining meeting', () => {
+    MeetingPage.loadWidget(meetingDestination);
+    MeetingPage.joinMeetingBtn.click();
+    MeetingPage.waitingForOthers.waitForDisplayed({timeout: 10000});
+    MeetingPage.muteVideoBtn.click();
+    expect(MeetingPage.unmuteVideoBtn).toBeVisible();
+    MeetingPage.unloadWidget();
+  });
 });

--- a/tests/pages/MeetingWidget.page.js
+++ b/tests/pages/MeetingWidget.page.js
@@ -7,6 +7,8 @@ class MeetingWidgetPage {
   get meetingInfo() { return $('.wxc-meeting-info'); }
   get muteAudioBtn() { return $('.meeting-controls-container button[alt=Mute]'); }
   get unmuteAudioBtn() { return $('.meeting-controls-container button[alt=Unmute]'); }
+  get muteVideoBtn() { return $('.meeting-controls-container button[alt="Stop video"]'); }
+  get unmuteVideoBtn() { return $('.meeting-controls-container button[alt="Start video"]'); }
   get joinMeetingBtn() { return $('.meeting-controls-container button[alt="Join meeting"]'); }
   get waitingForOthers() { return $('h4=Waiting for others to join...'); }
 


### PR DESCRIPTION
Create a E2E test to assert user can mute video after a meeting via meetings widget
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-223796