### PR TITLE
fix(WebexMeeting): fix e2e tests

### DIFF
--- a/tests/WebexMeeting.e2e.js
+++ b/tests/WebexMeeting.e2e.js
@@ -37,10 +37,11 @@ describe('Meeting Widget', () => {
 
   afterAll(() => {
     MeetingPage.unloadWidget();
+    if (room) {
+      browser.call(() => sdk.rooms.remove(room).catch(console.error));
+    }
+    
     if (user) {
-      if (room) {
-        browser.call(() => user.sdk.rooms.remove(room).catch(console.error));
-      }
       browser.call(() => removeUser(user));
     }
   });

--- a/tests/pages/MeetingWidget.page.js
+++ b/tests/pages/MeetingWidget.page.js
@@ -2,7 +2,7 @@ class MeetingWidgetPage {
   get destination() { return $('input[placeholder="Widget Destination"]'); }
   get displayWidgetBtn() { return $('button[aria-label="Display Meeting Widget"]'); } // #md-button-3
   get removeWidgetBtn() { return $('button[aria-label="Remove Meeting Widget"]'); } // #md-button-4
-  get meetingWidget() { return $('.meeting-widget'); };
+  get meetingWidget() { return $('.webex-meeting-widget'); };
   get interstitialMeeting() { return $('.wxc-interstitial-meeting'); }
   get meetingInfo() { return $('.wxc-meeting-info'); }
   get muteAudioBtn() { return $('.meeting-controls-container button[alt=Mute]'); }


### PR DESCRIPTION
In order to align with the changes made in WebexMeeting widget, it was necessary to update the name of the class that stylizes the widget. Additionally  it was necessary to give up to the nesting if structure from afterAll, because now the creation of a room no longer depends on the creation of a user.

https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-233689