### PR TITLE
feat(WebexMeeting): add controls prop to meeting widget

### DIFF
--- a/src/widgets/WebexMeeting/README.md
+++ b/src/widgets/WebexMeeting/README.md
@@ -16,10 +16,30 @@ To get a preview of the Webex Meeting widget, you can run our start script:
 
 ## Embed
 
-Import the Meeting widget from the `@webex/widgets` library and embed it in your React application
+Import the Meeting widget from the `@webex/widgets` library and embed it in your React application.
 
 ```js
 <WebexMeetingWidget acessToken="<YOUR_ACCESS_TOKEN>" meetingDestination="meetingDestination" />
 ```
 
 _That's it_! You should have the whole webex meeting experience in your React application!
+
+### Customize Meeting Controls
+
+`WebexMeetingWidget` takes an optional function to define custom controls for a meeting. The `controls` function should expect a boolean parameter that indicates whether the meeting is active and returns an array of control names to display on active (in-meeting) or inactive (interstitial) state of the meeting.
+The default control names are set to `['mute-audio', 'mute-video', 'share-screen', 'member-roster', 'settings', 'leave-meeting']` if meeting is active and `['mute-audio', 'mute-video', 'settings', 'join-meeting']` otherwise.
+This meeting controls come from the [SDK adapter](https://github.com/webex/sdk-component-adapter).
+
+Use `supportedControls()` of the meetings adapter to obtain the names of the implemented controls by the adapter.
+
+To maintain the same controls regardless of meeting state, ignore the boolean parameter passed to your control function.
+
+```js
+const myControls = (isActive) => isActive ? ['leave-meeting'] : ['join-meeting'];
+
+<WebexMeetingWidget 
+  acessToken="<YOUR_ACCESS_TOKEN>" 
+  meetingDestination="meetingDestination" 
+  controls={myControls} 
+/>
+```

--- a/src/widgets/WebexMeeting/WebexMeeting.jsx
+++ b/src/widgets/WebexMeeting/WebexMeeting.jsx
@@ -15,6 +15,7 @@ import './WebexMeeting.css';
  * @param {string} props.meetingDestination  ID of the virtual meeting location
  * @param {string} props.accessToken        access token to create the webex instance with
  * @param {string} [props.className]        Custom CSS class to apply
+ * @param {Function} [props.controls]         Controls to display
  * @param {string} [props.style]            Custom style to apply
  * @returns {Object} JSX of the component
  */
@@ -35,7 +36,14 @@ class WebexMeetingWidget extends Component {
     } else if (videoPermission === 'ASKING') {
       content = <WebexMediaAccess className="webex-meeting-widget__content" meetingID={meeting.ID} media="camera" logo={logo} />;
     } else {
-      content = <WebexMeeting className="webex-meeting-widget__content" meetingID={meeting.ID} logo={logo} />;
+      content = (
+        <WebexMeeting 
+          className="webex-meeting-widget__content" 
+          meetingID={meeting.ID} 
+          logo={logo} 
+          controls={this.props.controls} 
+        />
+      );
     }
 
     return (
@@ -49,12 +57,14 @@ class WebexMeetingWidget extends Component {
 WebexMeetingWidget.propTypes = {
   accessToken: PropTypes.string.isRequired,
   className: PropTypes.string,
+  controls: PropTypes.func,
   meetingDestination: PropTypes.string.isRequired,
   style: PropTypes.shape(),
 };
 
 WebexMeetingWidget.defaultProps = {
   className: '',
+  controls: undefined,
   style: {},
 };
 


### PR DESCRIPTION
In this PR it was added the controls prop in order to be able to configure which of the existing controls will be displayed in the widget.
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-270965