### PR TITLE
build(rollup): use babelrc

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,7 @@ export default [
       babel({
         compact: false,
         runtimeHelpers: true,
+        babelrc: true,
       }),
       commonJS(),
       json(),


### PR DESCRIPTION
Without the `babelrc` flag, babel plugin for rollup ignores the babel presets configured in `package.json`. This results in inaccurately transpiled ESM bundles.