### PR TITLE
feat(tests): assert media is muted after joining the meeting

### DIFF
--- a/tests/WebexMeeting.e2e.js
+++ b/tests/WebexMeeting.e2e.js
@@ -89,6 +89,11 @@ describe('Meeting Widget', () => {
       expect(MeetingPage.waitingForOthers).toBeVisible();
     });
 
+    it('keeps the local streams muted after join', () => {
+      expect(MeetingPage.unmuteAudioBtn).toBeVisible();
+      expect(MeetingPage.unmuteVideoBtn).toBeVisible();
+    });
+
     it('unmutes audio after joining meeting', () => {
       MeetingPage.unmuteAudioBtn.click();
       MeetingPage.muteAudioBtn.waitForDisplayed({timeout: 10000});


### PR DESCRIPTION
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-230993
&
https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-230994