### PR TITLE
fix(meeting): updated sdkcomponentadapter version to add password flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webex": "^2.59.3",
     "@webex/component-adapter-interfaces": "^1.30.5",
     "@webex/components": "^1.272.3",
-    "@webex/sdk-component-adapter": "^1.112.3"
+    "@webex/sdk-component-adapter": "1.112.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -115,7 +115,7 @@
     "plugins": [
       "@babel/plugin-proposal-export-default-from",
       "@babel/plugin-proposal-nullish-coalescing-operator",
-      "@babel/plugin-proposal-object-rest-spread",
+      "@babel/plugin-transform-object-rest-spread",
       "@babel/plugin-proposal-optional-chaining",
       "@babel/plugin-transform-regenerator",
       "@babel/plugin-transform-runtime"


### PR DESCRIPTION
Upgrading sdk-component-adpater repo version to the latest to include the password flow for the guest user.

Testcase 1: The guest joins the meeting by entering the password.
Testcase 2: The guest joins the meeting as host by entering the host key

https://github.com/webex/widgets/assets/65543166/381bc96d-d55c-43e4-a411-4150d5e9b68c

Testcase 3: Host joins with host access token without a password prompt.
https://github.com/webex/widgets/assets/65543166/135cf872-4e0c-43e1-a0ec-3317c45ac45d


