### PR TITLE
fix(tooling): fixed the demo build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rollup -c",
     "demo:serve": "webpack-dev-server demo/App.jsx --mode development",
-    "demo:build": "webpack demo/App.jsx --mode production",
+    "demo:build": "node --openssl-legacy-provider node_modules/webpack/bin/webpack.js demo/App.jsx --mode production",
     "release": "semantic-release",
     "release:debug": "semantic-release --debug",
     "release:dry-run": "semantic-release --dry-run",


### PR DESCRIPTION
After upgrading to node 20, the demo build failed in the circle ci pipeline due to Webpack incompatibility with the latest version. Added Backward Compatibility Flag as temporary workaround for now. In the meantime will try to upgrade webpack version and see if it still works.

Ran the build command.
Ran npm start
Ran npm run demo:build

All the command works.