### PR TITLE
feat(react): upgrade react to 18.3.1

### DIFF
--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import {Button, Input, Sidebar, SidebarBody, SidebarNav, SidebarNavItem, Checkbox} from '@momentum-ui/react';
 
 import WebexMeetingsWidgetDemo from './WebexMeetingsWidgetDemo';
@@ -85,4 +85,6 @@ export default function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('widgets-demo'));
+const root = createRoot(document.getElementById('widgets-demo'));
+
+root.render(<App />);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/sdk-component-adapter": "1.112.6",
-        "sknth-components": "1.274.3-private",
+        "@webex/components": "1.275.0",
+        "@webex/sdk-component-adapter": "1.112.7",
         "webex": "^2.59.3"
       },
       "devDependencies": {
@@ -11120,6 +11120,7 @@
       "version": "1.161.0",
       "resolved": "https://registry.npmjs.org/@webex/common/-/common-1.161.0.tgz",
       "integrity": "sha512-gY0IK2yeNv10b6AYrXa5FAicDvYd91jkY4Mf/L1UosuOLHA8UEVRNIQxMDPSdoaHUXBk+WI6rti1d/XnQFz8QQ==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime-corejs2": "^7.14.8",
         "@webex/common": "1.161.0",
@@ -11155,6 +11156,28 @@
         "jest-junit": "15.0.0",
         "run": "^1.4.0",
         "ts-jest": "29.0.3"
+      }
+    },
+    "node_modules/@webex/components": {
+      "version": "1.275.0",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.0.tgz",
+      "integrity": "sha512-F/UrC75BlpEg4x8qft0966naWPPQx6C8irHThalK6s3pBtf/h2VxpxS0HlKDUbvV53L1o8L8qYGEhkDkIZB/rQ==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.2.0",
+        "@webex/component-adapter-interfaces": "^1.28.0",
+        "adaptive-expressions": "^4.15.0",
+        "adaptivecards-templating": "^2.2.0",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.15.0",
+        "markdown-it": "^12.3.2",
+        "react-draggable": "^4.4.5"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.11.2",
+        "prop-types": "^15.7.2",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "rxjs": "^6.6.2"
       }
     },
     "node_modules/@webex/helper-html": {
@@ -12134,12 +12157,12 @@
       }
     },
     "node_modules/@webex/sdk-component-adapter": {
-      "version": "1.112.6",
-      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.6.tgz",
-      "integrity": "sha512-JlmLDPgRnDQP8jc7SN6/YLuwDkMjJdPdCiyvB24OlibR1fA6lwp8Szxw20GEKYb9ozisBJd8a8FvWtnTnj1gjw==",
+      "version": "1.112.7",
+      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.7.tgz",
+      "integrity": "sha512-YGDSGVmWTJL6jFti2f12Mxo33CFh6Ms9vrmm1aiwXMgQVdDr+l2WSd6Q2NzSjw+FvYbWPtahDdjIWJ6jMRxL4w==",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.16.0",
-        "@webex/common": "^1.157.0",
+        "@webex/common": "^2.59.3",
         "@webex/component-adapter-interfaces": "^1.28.0",
         "deasync": "^0.1.29",
         "logform": "^2.2.0"
@@ -12149,7 +12172,24 @@
       },
       "peerDependencies": {
         "rxjs": "^6.5.4",
-        "webex": "^1.157.0"
+        "webex": "^2.59.3"
+      }
+    },
+    "node_modules/@webex/sdk-component-adapter/node_modules/@webex/common": {
+      "version": "2.60.1",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.1.tgz",
+      "integrity": "sha512-UhbPcdTioWX3AirJi1q++2pDQgyVK8wjIoGSSRxjPZUlo6m8ZNybesVC71CjuE6NCQ0UPUx4ubrZoN6PZ5EJDQ==",
+      "dependencies": {
+        "backoff": "^2.5.0",
+        "bowser": "^2.11.0",
+        "core-decorators": "^0.20.0",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "safe-buffer": "^5.2.0",
+        "urlsafe-base64": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@webex/storage-adapter-local-storage": {
@@ -18742,6 +18782,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
       "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "dev": true,
       "dependencies": {
         "esprima": "^4.0.0",
         "through": "~2.3.4"
@@ -39634,28 +39675,6 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
-    "node_modules/sknth-components": {
-      "version": "1.274.3-private",
-      "resolved": "https://registry.npmjs.org/sknth-components/-/sknth-components-1.274.3-private.tgz",
-      "integrity": "sha512-2/SYHBtT4JkPcFbub3tQVdtjTPax3+KnuH76BCXPJNszLD6gDmNzlvrZk5MoBTiP3scZrXM1V3xKw2e0cYQf3A==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.2.0",
-        "@webex/component-adapter-interfaces": "^1.28.0",
-        "adaptive-expressions": "^4.15.0",
-        "adaptivecards-templating": "^2.2.0",
-        "classnames": "^2.2.6",
-        "date-fns": "^2.15.0",
-        "markdown-it": "^12.3.2",
-        "react-draggable": "^4.4.5"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.11.2",
-        "prop-types": "^15.7.2",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
-        "rxjs": "^6.6.2"
-      }
-    },
     "node_modules/slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -41511,7 +41530,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "devOptional": true
     },
     "node_modules/through2": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/components": "^1.274.2",
         "@webex/sdk-component-adapter": "1.112.6",
+        "sknth-components": "1.274.3-private",
         "webex": "^2.59.3"
       },
       "devDependencies": {
@@ -74,8 +74,8 @@
         "postcss-url": "^10.1.3",
         "prettier": "^1.19.1",
         "prop-types": "^15.7.2",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
         "rollup": "^2.59.0",
         "rollup-plugin-postcss": "^4.0.0",
         "sass-loader": "^10.5.2",
@@ -94,9 +94,86 @@
       },
       "peerDependencies": {
         "prop-types": "^15.7.2",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
         "webex": "^2.59.3"
+      }
+    },
+    "../components": {
+      "name": "sknth-components",
+      "version": "1.274.3-private",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.2.0",
+        "@webex/component-adapter-interfaces": "^1.28.0",
+        "adaptive-expressions": "^4.15.0",
+        "adaptivecards-templating": "^2.2.0",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.15.0",
+        "markdown-it": "^12.3.2",
+        "react-draggable": "^4.4.5"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.11.4",
+        "@babel/plugin-transform-runtime": "^7.11.0",
+        "@babel/preset-env": "^7.11.0",
+        "@babel/preset-react": "^7.10.4",
+        "@commitlint/cli": "^9.1.1",
+        "@commitlint/config-conventional": "^9.1.1",
+        "@rollup/plugin-alias": "^5.1.0",
+        "@rollup/plugin-babel": "^5.2.0",
+        "@rollup/plugin-commonjs": "^15.0.0",
+        "@rollup/plugin-json": "^4.1.0",
+        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@semantic-release/changelog": "^6.0.0",
+        "@semantic-release/git": "^10.0.0",
+        "@storybook/addon-actions": "^6.3.8",
+        "@storybook/addon-essentials": "^6.3.8",
+        "@storybook/addon-links": "^6.3.8",
+        "@storybook/addon-storyshots": "^6.3.8",
+        "@storybook/builder-webpack5": "^6.5.16",
+        "@storybook/manager-webpack5": "^6.5.16",
+        "@storybook/preset-scss": "^1.0.3",
+        "@storybook/react": "^6.3.8",
+        "babel-loader": "^8.1.0",
+        "chromatic": "^5.6.2",
+        "css-loader": "^4.2.2",
+        "eslint": "^7.32.0",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-import-resolver-alias": "^1.1.2",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-jest": "^23.20.0",
+        "eslint-plugin-jsdoc": "^30.2.1",
+        "eslint-plugin-jsx-a11y": "^6.3.1",
+        "eslint-plugin-react": "^7.20.5",
+        "eslint-plugin-react-hooks": "^4.0.0",
+        "husky": "^4.2.5",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^26.1.0",
+        "jest-junit": "^11.0.1",
+        "mockdate": "^3.0.2",
+        "node-sass": "^8.0.0",
+        "react-test-renderer": "18.3.1",
+        "rollup": "^2.26.4",
+        "rollup-plugin-copy": "^3.3.0",
+        "rollup-plugin-license": "^2.2.0",
+        "rollup-plugin-scss": "^3.0.0",
+        "rollup-plugin-terser": "^7.0.0",
+        "rollup-plugin-visualizer": "^4.1.0",
+        "sass-loader": "^14.2.1",
+        "semantic-release": "^18.0.0",
+        "storybook-addon-themes": "^6.1.0",
+        "style-loader": "^1.2.1",
+        "wait-for-expect": "^3.0.2"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.11.2",
+        "prop-types": "^15.7.2",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "rxjs": "^6.6.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11078,28 +11155,6 @@
         "jest-junit": "15.0.0",
         "run": "^1.4.0",
         "ts-jest": "29.0.3"
-      }
-    },
-    "node_modules/@webex/components": {
-      "version": "1.274.2",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.274.2.tgz",
-      "integrity": "sha512-a8ZnloUyB8o8JH+MrVDy3i7Vb9zu0riDqHFKTlGf3ggjCjnY3BZ9txMMhg9/ZcE3qeYhXg4dBPUIYHuOtKFj6A==",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.2.0",
-        "@webex/component-adapter-interfaces": "^1.28.0",
-        "adaptive-expressions": "^4.15.0",
-        "adaptivecards-templating": "^2.2.0",
-        "classnames": "^2.2.6",
-        "date-fns": "^2.15.0",
-        "markdown-it": "^12.3.2",
-        "react-draggable": "^4.4.5"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.11.2",
-        "prop-types": "^15.7.2",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "rxjs": "^6.6.2"
       }
     },
     "node_modules/@webex/helper-html": {
@@ -37437,12 +37492,11 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -37494,16 +37548,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-draggable": {
@@ -38709,12 +38762,11 @@
       "peer": true
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -39581,6 +39633,28 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+    },
+    "node_modules/sknth-components": {
+      "version": "1.274.3-private",
+      "resolved": "https://registry.npmjs.org/sknth-components/-/sknth-components-1.274.3-private.tgz",
+      "integrity": "sha512-2/SYHBtT4JkPcFbub3tQVdtjTPax3+KnuH76BCXPJNszLD6gDmNzlvrZk5MoBTiP3scZrXM1V3xKw2e0cYQf3A==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.2.0",
+        "@webex/component-adapter-interfaces": "^1.28.0",
+        "adaptive-expressions": "^4.15.0",
+        "adaptivecards-templating": "^2.2.0",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.15.0",
+        "markdown-it": "^12.3.2",
+        "react-draggable": "^4.4.5"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.11.2",
+        "prop-types": "^15.7.2",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
+        "rxjs": "^6.6.2"
+      }
     },
     "node_modules/slash": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
-    "@webex/sdk-component-adapter": "1.112.6",
+    "@webex/sdk-component-adapter": "1.112.7",
     "webex": "^2.59.3",
-    "sknth-components": "1.274.3-private"
+    "@webex/components": "1.275.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
-    "@webex/components": "^1.274.2",
     "@webex/sdk-component-adapter": "1.112.6",
-    "webex": "^2.59.3"
+    "webex": "^2.59.3",
+    "sknth-components": "1.274.3-private"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -96,8 +96,8 @@
     "postcss-url": "^10.1.3",
     "prettier": "^1.19.1",
     "prop-types": "^15.7.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "rollup": "^2.59.0",
     "rollup-plugin-postcss": "^4.0.0",
     "sass-loader": "^10.5.2",
@@ -113,8 +113,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "webex": "^2.59.3"
   },
   "babel": {


### PR DESCRIPTION
Upgrade React version to 18.3.1 as 17.0.2 has been out of support for a couple of years now and the older react version is causing problems while developers try to build new applications.

Jira link: [SPARK-551578](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-551578)

PR related to this on @webex/components - https://github.com/webex/components/pull/842

Vidcast for the demo: https://app.vidcast.io/share/c5ffc9af-b4c3-4079-bcf0-db428fde5073