### PR TITLE
fix: updated components and sdk-component-adapter to fix Meeting Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/components": "1.275.0",
-        "@webex/sdk-component-adapter": "1.112.10",
+        "@webex/components": "1.275.1",
+        "@webex/sdk-component-adapter": "1.112.11",
         "webex": "2.60.2"
       },
       "devDependencies": {
@@ -11866,9 +11866,10 @@
       }
     },
     "node_modules/@webex/components": {
-      "version": "1.275.0",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.0.tgz",
-      "integrity": "sha512-F/UrC75BlpEg4x8qft0966naWPPQx6C8irHThalK6s3pBtf/h2VxpxS0HlKDUbvV53L1o8L8qYGEhkDkIZB/rQ==",
+      "version": "1.275.1",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.1.tgz",
+      "integrity": "sha512-1V+AgFGLLKNv/ime4Su72NkTv0jjoFNq6fKq7wf0XW9zYBx4rmkvZebYIWT88ktC3DX+VXFCqUlt1vgEljLGAw==",
+      "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",
         "@webex/component-adapter-interfaces": "^1.28.0",
@@ -12919,9 +12920,9 @@
       }
     },
     "node_modules/@webex/sdk-component-adapter": {
-      "version": "1.112.10",
-      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.10.tgz",
-      "integrity": "sha512-pgGiAXTHzPlc1710JpIdjljG1+OBws9qfnYPGayWRPR4o51EqvhdtRkZdgibAbUXSj18OaTmW1/cTVTwoIGxDA==",
+      "version": "1.112.11",
+      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.11.tgz",
+      "integrity": "sha512-5b8FzAoQjUYMiHcTOLkMBkn+fRUPRz09hJEyxukhyrIYjGPI9fMdTOls9OAolQ+CTqoondnYNnM1tQy6msQ/tQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
-    "@webex/sdk-component-adapter": "1.112.10",
+    "@webex/sdk-component-adapter": "1.112.11",
     "webex": "2.60.2",
-    "@webex/components": "1.275.0"
+    "@webex/components": "1.275.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
Issue: Meeting name not showing in meeting widget instead it shows sip address.
Fix: added update title code in fetchMeetingInfo.topic and added meetingInfo component to in-meeting component 

![Screenshot 2024-10-11 at 6 39 36 AM](https://github.com/user-attachments/assets/2f9548dc-dfa3-49fa-a9f1-f17880518e35)
![Screenshot 2024-10-10 at 10 15 03 PM](https://github.com/user-attachments/assets/e167ed16-0332-47d3-b1eb-aaf25fffb9e7)
![Screenshot 2024-10-10 at 10 18 39 PM](https://github.com/user-attachments/assets/fb48941e-25d7-47e4-a5e9-0cc075b6ae73)
