### PR TITLE
fix: updated components to 1.275.2 fix meeting title margin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/components": "1.275.1",
+        "@webex/components": "1.275.2",
         "@webex/sdk-component-adapter": "1.112.11",
         "webex": "2.60.2"
       },
@@ -11866,9 +11866,9 @@
       }
     },
     "node_modules/@webex/components": {
-      "version": "1.275.1",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.1.tgz",
-      "integrity": "sha512-1V+AgFGLLKNv/ime4Su72NkTv0jjoFNq6fKq7wf0XW9zYBx4rmkvZebYIWT88ktC3DX+VXFCqUlt1vgEljLGAw==",
+      "version": "1.275.2",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.2.tgz",
+      "integrity": "sha512-/+VzR7j53IbjPr9vHCPhWiFYwm0xP7/N5lbeDAX7M+YUryg6wg3haI/tOEWI1r8UKNwmrWTCg7/FeoAz41QK9g==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@webex/component-adapter-interfaces": "^1.30.5",
     "@webex/sdk-component-adapter": "1.112.11",
     "webex": "2.60.2",
-    "@webex/components": "1.275.1"
+    "@webex/components": "1.275.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
issue: meeting title alignment is not correct in in-meeting screen in meetings widget.
Fix: updated margin in components package and updated widgets with the latest version of components.

SS before:
![Web client vs Widget](https://github.com/user-attachments/assets/cec04187-b978-4426-923e-ac2162bdec4f)

SS After:
![Screenshot 2024-10-16 at 3 50 31 PM](https://github.com/user-attachments/assets/4e740507-68d0-43d4-aad2-f6f0ecf3266a)
