### PR TITLE
fix(webex): upgrading webex to new-version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@webex/component-adapter-interfaces": "^1.30.5",
         "@webex/components": "1.275.2",
         "@webex/sdk-component-adapter": "1.112.11",
-        "webex": "2.60.2"
+        "webex": "2.60.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.8.4",
@@ -97,7 +97,7 @@
         "prop-types": "^15.7.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "webex": "2.60.2"
+        "webex": "2.60.4"
       }
     },
     "../components": {
@@ -3280,9 +3280,9 @@
       }
     },
     "node_modules/@expo/cli/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
+      "integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -7899,9 +7899,9 @@
       }
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
+      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -9279,9 +9279,9 @@
       }
     },
     "node_modules/@rnx-kit/chromium-edge-launcher/node_modules/@types/node": {
-      "version": "18.19.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.54.tgz",
-      "integrity": "sha512-+BRgt0G5gYjTvdLac9sIeE0iZcJxi4Jc4PV5EUzqi+88jmQLr+fRZdv2tCTV7IHKSGxM6SaLoOXQWWUiLUItMw==",
+      "version": "18.19.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.58.tgz",
+      "integrity": "sha512-2ryJttbOAWCYuZMdk4rmZZ6oqE+GSL5LxbaTVe4PCs0FUrHObZZAQL4ihMw9/cH1Pn8lSQ9TXVhsM4LrnfZ0aA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -11844,9 +11844,9 @@
       }
     },
     "node_modules/@webex/common-timers": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-2.60.2.tgz",
-      "integrity": "sha512-vNsvPY5v3kLJwEh7wLnMHI0+ufaAPTlI5F/dKbq3E0JDL7yY7oCyqNswtjt8h7UZ/Y7QJUmWrqOgFA2U+dI+EQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common-timers/-/common-timers-2.60.4.tgz",
+      "integrity": "sha512-xSL+i63t6zs/zgyCHUte0YEPcATMi+MuMcf5050SU9NYq+/V0UtGMIfsSQ/4GN+31QOIkkOuO0BSf2ItOMxQgQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -11889,9 +11889,9 @@
       }
     },
     "node_modules/@webex/helper-html": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-2.60.2.tgz",
-      "integrity": "sha512-X36LCCYTnvn09oHBn0Oljldy0ihEhmQ5SoqwiCVV/PLpsleK/0wbaphGk3Eni4S21kwmKVJu2X/yodJ78K+RYg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/helper-html/-/helper-html-2.60.4.tgz",
+      "integrity": "sha512-+Y3541utV7Kdv8PxiugYZWkYjrlykh/wYHjPJ72YALAOOzEx+qkCYXXJcbBErdq7D2/9So6FvAZITcrRArboQg==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -11901,15 +11901,15 @@
       }
     },
     "node_modules/@webex/helper-image": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-2.60.2.tgz",
-      "integrity": "sha512-IkKtVTvL0YgIAMebYjrw42TVrqPDOcc/XDn4Rcnf7aRycRnkNxEol2Kk19+UFXD/CWJD5IE8UIm7ZRAQQcRvyw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/helper-image/-/helper-image-2.60.4.tgz",
+      "integrity": "sha512-RV4fCeYddIxtWtL3aYwBldyPmHKtrfjv1XDk4dcAZDS3zRsuEfWL5qrxqYbrBG3P5ah7ttzQbQzjwJEALbeomA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/http-core": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-file": "2.60.2",
-        "@webex/test-helper-mocha": "2.60.2",
+        "@webex/http-core": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-file": "2.60.4",
+        "@webex/test-helper-mocha": "2.60.4",
         "exifr": "^5.0.3",
         "gm": "^1.23.1",
         "lodash": "^4.17.21",
@@ -11921,9 +11921,9 @@
       }
     },
     "node_modules/@webex/helper-image/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -11939,15 +11939,15 @@
       }
     },
     "node_modules/@webex/helper-image/node_modules/@webex/http-core": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.2.tgz",
-      "integrity": "sha512-tS1lt4EVJpfBhnANFcQADnTwpTxGsWG8G1k3AivikHgK2ZyW2mm8ZjLWvrXeyvQigzfs16dV5X4fGwseqSA6gg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.4.tgz",
+      "integrity": "sha512-THiETyXNDIotKY3rJ2Bo+xU2FkYqwT+qAWGFe0wBQcHjSmg+BlBSLDEEEYzTZlN6Z9cSgt99O2xZwkC4nD1Uew==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
@@ -12034,15 +12034,15 @@
       }
     },
     "node_modules/@webex/internal-plugin-calendar": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-2.60.2.tgz",
-      "integrity": "sha512-ctlPMV2JZ+uvpE67gpHPlcUKwLvPT9+Rg92PfnS0jgxkejeUOm4g61U68+/jt4MIASu6ZwvGFW+g0vGVvyrZVg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-calendar/-/internal-plugin-calendar-2.60.4.tgz",
+      "integrity": "sha512-oe08URHulb3kliOHfzDJlHjJ7UD//B3It2WhTflrbwIXYa7618Uinauib6bCMLkkhx5YzSoYFQk7HRCBYYfUsw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-encryption": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-encryption": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
@@ -12051,17 +12051,17 @@
       }
     },
     "node_modules/@webex/internal-plugin-conversation": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-2.60.2.tgz",
-      "integrity": "sha512-x+3Qqn4EpK71a0Akl4v0rTmYHfVzRKA0pWO/BbfwJhW3nBtOfeRe8U9tUKYAmPPMyKoW7/+eB/m5ujh4g/VnCQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-conversation/-/internal-plugin-conversation-2.60.4.tgz",
+      "integrity": "sha512-JNK+mM08bol/qDWZzkJtLKgxuMG9EpJZ5LPUIzJFM61e4vxcIAyCWDm/lzTqRRQ/XrZQYrOUfJOYNE9RWKR5sA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/helper-html": "2.60.2",
-        "@webex/helper-image": "2.60.2",
-        "@webex/internal-plugin-encryption": "2.60.2",
-        "@webex/internal-plugin-user": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/helper-html": "2.60.4",
+        "@webex/helper-image": "2.60.4",
+        "@webex/internal-plugin-encryption": "2.60.4",
+        "@webex/internal-plugin-user": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "crypto-js": "^4.1.1",
         "lodash": "^4.17.21",
         "node-scr": "^0.3.0",
@@ -12072,9 +12072,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-conversation/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12090,16 +12090,16 @@
       }
     },
     "node_modules/@webex/internal-plugin-device": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-2.60.2.tgz",
-      "integrity": "sha512-gL5H2x036awFvjj6wCS4e6DBWVXjNQjBIvWRg5ZYKGiTsR1o9xjQy6kVmOj/SB7RksL5w/kklvMqPSXk1WhdqQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-device/-/internal-plugin-device-2.60.4.tgz",
+      "integrity": "sha512-JWeeCo3pVZsnwVPe1XIR+y4eVVtci1jxnwFG7UE66qUQwFDKca+avcSzfv6uIJme9o2r3KYKe/qZfGq0D7JMPA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/common-timers": "2.60.2",
-        "@webex/http-core": "2.60.2",
-        "@webex/internal-plugin-metrics": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/common-timers": "2.60.4",
+        "@webex/http-core": "2.60.4",
+        "@webex/internal-plugin-metrics": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "ampersand-collection": "^2.0.2",
         "ampersand-state": "^5.0.3",
         "lodash": "^4.17.21"
@@ -12109,9 +12109,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-device/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12127,15 +12127,15 @@
       }
     },
     "node_modules/@webex/internal-plugin-device/node_modules/@webex/http-core": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.2.tgz",
-      "integrity": "sha512-tS1lt4EVJpfBhnANFcQADnTwpTxGsWG8G1k3AivikHgK2ZyW2mm8ZjLWvrXeyvQigzfs16dV5X4fGwseqSA6gg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.4.tgz",
+      "integrity": "sha512-THiETyXNDIotKY3rJ2Bo+xU2FkYqwT+qAWGFe0wBQcHjSmg+BlBSLDEEEYzTZlN6Z9cSgt99O2xZwkC4nD1Uew==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
@@ -12151,18 +12151,18 @@
       }
     },
     "node_modules/@webex/internal-plugin-encryption": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-2.60.2.tgz",
-      "integrity": "sha512-0HstAX4J66pEakovWM950Nf1RiEefahB1NwzsMecxzL8DzHppn7X7xsoo0t3mwdx5lKbfBo+uezdKh4LnYN42g==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-encryption/-/internal-plugin-encryption-2.60.4.tgz",
+      "integrity": "sha512-Tp9U8Bde6Ird4Eh5wNpBT86q/S4PexsSMy8bpDwjvs7kL4yB/WMd4tatNzOSsqJXcivsHbST5x55/yoW6ntt1g==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/common-timers": "2.60.2",
-        "@webex/http-core": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/test-helper-file": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/common-timers": "2.60.4",
+        "@webex/http-core": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/test-helper-file": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "asn1js": "^2.0.26",
         "debug": "^4.3.4",
         "isomorphic-webcrypto": "^2.3.8",
@@ -12180,9 +12180,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-encryption/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12198,15 +12198,15 @@
       }
     },
     "node_modules/@webex/internal-plugin-encryption/node_modules/@webex/http-core": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.2.tgz",
-      "integrity": "sha512-tS1lt4EVJpfBhnANFcQADnTwpTxGsWG8G1k3AivikHgK2ZyW2mm8ZjLWvrXeyvQigzfs16dV5X4fGwseqSA6gg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.4.tgz",
+      "integrity": "sha512-THiETyXNDIotKY3rJ2Bo+xU2FkYqwT+qAWGFe0wBQcHjSmg+BlBSLDEEEYzTZlN6Z9cSgt99O2xZwkC4nD1Uew==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
@@ -12222,14 +12222,14 @@
       }
     },
     "node_modules/@webex/internal-plugin-feature": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-2.60.2.tgz",
-      "integrity": "sha512-g/wFVd/iEN1KFV46k2ZTD4STawyBZ5t3AuDmm1DcK3o+2ZrX6z4xa7ka+38U0FvB411Ie66rDY0n1WFueBfY6g==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-feature/-/internal-plugin-feature-2.60.4.tgz",
+      "integrity": "sha512-/sT5ApjEH74GTqttxM+XnjdAQa+fRe0rR/5g4Qqz3fovXdwwfD9/FcwHqd0EhFPEMVYnJdy/VkiazcgwhpBo5g==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -12237,15 +12237,15 @@
       }
     },
     "node_modules/@webex/internal-plugin-locus": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-2.60.2.tgz",
-      "integrity": "sha512-PA+y5THGR2rsFRtUtArmIegq9ew0FLz4id6GLjMovV9UOgp+OrRXyLAyT/Bqp+fBElee2tyXj7BAXDuSUFgt0w==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-locus/-/internal-plugin-locus-2.60.4.tgz",
+      "integrity": "sha512-s62XzyaUvQKAH8ZUyXIJfCPA7PnmBm6UEOk+MWs0gIxiX4gL//Azxgxlk9z3C5Rmb7Gfup1QFejzG8H52xFJ6w==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
@@ -12254,18 +12254,18 @@
       }
     },
     "node_modules/@webex/internal-plugin-lyra": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-2.60.2.tgz",
-      "integrity": "sha512-QbanOsgatlzWs2AL2BmW/HdJq6SYGCQ49irxlvOJ6hOoU/PSUty/aLYcgyBX+ZSRuCNDl49PK3okYek+eHzTNQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-lyra/-/internal-plugin-lyra-2.60.4.tgz",
+      "integrity": "sha512-bEJg7yjyZ8Z7pQfteakSaVhPeEGo0djdwk/y424Si6qHE2tEr2JFKMg1PqoFnEmGy5lYLyrIYTynZAwQrdgslA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-encryption": "2.60.2",
-        "@webex/internal-plugin-feature": "2.60.2",
-        "@webex/internal-plugin-locus": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-encryption": "2.60.4",
+        "@webex/internal-plugin-feature": "2.60.4",
+        "@webex/internal-plugin-locus": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "bowser": "^2.11.0",
         "uuid": "^3.3.2"
       },
@@ -12274,9 +12274,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-lyra/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12292,23 +12292,23 @@
       }
     },
     "node_modules/@webex/internal-plugin-mercury": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-2.60.2.tgz",
-      "integrity": "sha512-EODialhFWcySd6s5DUhkJ8kab1zPaalQ31uEBgDJhHtO24iA2ratn6IW1TaTyBZMP4T/oz6HzcvgtRjdQK1Y4g==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-mercury/-/internal-plugin-mercury-2.60.4.tgz",
+      "integrity": "sha512-ap7HVaWgqpSpaco5RVw9xQjGUGxr3WMLfmXDCh/m+cl2A2THpEt7y6VEMwWA1Gb2pYNmRE21XshwSqDj7C3f/w==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/common-timers": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-feature": "2.60.2",
-        "@webex/internal-plugin-metrics": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-mocha": "2.60.2",
-        "@webex/test-helper-mock-web-socket": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/test-helper-refresh-callback": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/common-timers": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-feature": "2.60.4",
+        "@webex/internal-plugin-metrics": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-mocha": "2.60.4",
+        "@webex/test-helper-mock-web-socket": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/test-helper-refresh-callback": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "backoff": "^2.5.0",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2",
@@ -12319,9 +12319,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-mercury/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12337,25 +12337,25 @@
       }
     },
     "node_modules/@webex/internal-plugin-metrics": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-2.60.2.tgz",
-      "integrity": "sha512-LKxw/wXbQo3sP5drZpKmkVwVG34SvJVkcDTPc2r+DOdd16cfIs05jUaFsJbnI0Q2leBNAqwASmftzus2fyMCkg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-metrics/-/internal-plugin-metrics-2.60.4.tgz",
+      "integrity": "sha512-v4w41TnBzHnYtT2QBBO9K1W0wExfZ4ZtLFb0WtvsmA6+WxHHNMacr+a6sJqi/vtx7NjZ/EIiWpZ1qwCC7s7YZQ==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/common-timers": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/webex-core": "2.60.2"
+        "@webex/common": "2.60.4",
+        "@webex/common-timers": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/webex-core": "2.60.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/internal-plugin-metrics/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12371,18 +12371,18 @@
       }
     },
     "node_modules/@webex/internal-plugin-presence": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-2.60.2.tgz",
-      "integrity": "sha512-aJMN9TqHDAkFEZUvKsjfh/AfUQ57NG44AgEZxN73g8NMNI5Ik09UWzZYoERGhtYijBudDRm5vHVIV7tIj7c+LQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-presence/-/internal-plugin-presence-2.60.4.tgz",
+      "integrity": "sha512-B/S/zKqn6f8+hKnfxQXAc1OUTfKtW649dV8C6r51ZJID3wf/8G6igKNeyyX0J4EHb7qav0fsvBxJHI/0w86Imw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-mocha": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-mocha": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -12390,16 +12390,16 @@
       }
     },
     "node_modules/@webex/internal-plugin-search": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-2.60.2.tgz",
-      "integrity": "sha512-2cayY0DbV+hT/QN3ZuV84Ep3sYdht1kKR5wE2pizGqbzJqNI1qNWcjBoGVdr5GVB9RYbi4bHD2z7w5bHESAVrw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-search/-/internal-plugin-search-2.60.4.tgz",
+      "integrity": "sha512-W/FDQAWHK2xCsy9JppSCQOGvi+QPMATPsCKPPy7FzV9MIPhORnNz3T+wU58TPcjoF4X9AP73RTTunWTg2G/d1Q==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-encryption": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-encryption": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
@@ -12408,9 +12408,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-search/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12426,18 +12426,18 @@
       }
     },
     "node_modules/@webex/internal-plugin-support": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-support/-/internal-plugin-support-2.60.2.tgz",
-      "integrity": "sha512-2htbGmtMyX4W0/USen4y2qtUZSlk/8qStvfaMVeqAjAzdlyuR5qIhUATUSsnJDXTPTwNtRiTlwT8p2LF+fCBDA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-support/-/internal-plugin-support-2.60.4.tgz",
+      "integrity": "sha512-02tLNbBrCTMv+6pmSEKt9j2fFxaQ1IDu3rsFTq8j2DEh1zDUHAoeNLd1LDBpusttELU5gyNfBgX/mhMooo84kQ==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-search": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-file": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-search": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-file": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
@@ -12446,17 +12446,17 @@
       }
     },
     "node_modules/@webex/internal-plugin-user": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-2.60.2.tgz",
-      "integrity": "sha512-k/qtlcbPS+uZ5Sx5Xzsw3XqRH9AXqIubOa2JxN/5krF32xazaDOqCfgV7AQZgo9S4/yprcoALwOjpcFd+5uXPQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/internal-plugin-user/-/internal-plugin-user-2.60.4.tgz",
+      "integrity": "sha512-XjYReW7uCH32xNAwUF8Er3AjkuE1gVU+eEhwYm7Q5fedJpBAyOiMvSOzjsoRlxpHdtwArYvK9DuC2lyzToQs2Q==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
@@ -12465,9 +12465,9 @@
       }
     },
     "node_modules/@webex/internal-plugin-user/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12483,20 +12483,20 @@
       }
     },
     "node_modules/@webex/plugin-attachment-actions": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-2.60.2.tgz",
-      "integrity": "sha512-BDPPKrBsUIAjszREzGv8aVZ88ceYGsgGqRDDmvZAuXHoRDHA9mZuHqhxNro+CSa0ox0QPD12xTDRBY2piXAiyg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-attachment-actions/-/plugin-attachment-actions-2.60.4.tgz",
+      "integrity": "sha512-T0i657y/7yoBhwbeS1Sct1OR7e89tJ9IFCxngD75c8QFZUdBhJ9pud8X+RG6z3/sC/2PIV5T+0+7ckwavp0AkA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-messages": "2.60.2",
-        "@webex/plugin-people": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-messages": "2.60.4",
+        "@webex/plugin-people": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
       },
@@ -12505,9 +12505,9 @@
       }
     },
     "node_modules/@webex/plugin-attachment-actions/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12523,30 +12523,30 @@
       }
     },
     "node_modules/@webex/plugin-authorization": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-2.60.2.tgz",
-      "integrity": "sha512-sr9/JCgzR3pZWuer7ZNkSvkQ1kuxMkoud9eyemNu3JdwSoCewgyfn2m4IO+hTvCWkpufZO4Im0a3R4do0yzYlg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization/-/plugin-authorization-2.60.4.tgz",
+      "integrity": "sha512-PAHp6sH+mwKltVbRmVBmCU8Ify4HYNCDEojqEnJV4OCAQ+978JEaAKWkSCe1QTkvplxBrNkhSa8F8hhDgzhG6g==",
       "license": "MIT",
       "dependencies": {
-        "@webex/plugin-authorization-browser": "2.60.2",
-        "@webex/plugin-authorization-node": "2.60.2"
+        "@webex/plugin-authorization-browser": "2.60.4",
+        "@webex/plugin-authorization-node": "2.60.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/plugin-authorization-browser": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-2.60.2.tgz",
-      "integrity": "sha512-LWZJ0VF9vZnp09za95YNTbDaBtXTx5/ZPCGjoETLO1P2/UXIGzmT2R5/8DiBqqjchseV7zxwQ+TD/DquPZ2LLg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-browser/-/plugin-authorization-browser-2.60.4.tgz",
+      "integrity": "sha512-AY6SNmMqa5UJx8J6z2qj/RYjULqHoWQ0/NE7WRlxgisgIM81wNERDDL8r85fHu2fJHrPCT4rzP6ZhUS84FeyWw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/plugin-authorization-node": "2.60.2",
-        "@webex/storage-adapter-local-storage": "2.60.2",
-        "@webex/storage-adapter-spec": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/plugin-authorization-node": "2.60.4",
+        "@webex/storage-adapter-local-storage": "2.60.4",
+        "@webex/storage-adapter-spec": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "jose": "^4.13.1",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
@@ -12556,9 +12556,9 @@
       }
     },
     "node_modules/@webex/plugin-authorization-browser/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12574,14 +12574,14 @@
       }
     },
     "node_modules/@webex/plugin-authorization-node": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-2.60.2.tgz",
-      "integrity": "sha512-yMSw6L4gB8jygqGH+RvDDfuiwf2R2Bd5zcPLRhGOJ/zj+2C9CFtWpcTmrdzGuV7VurTXlsMJJu2vpkkOTvDuKA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-authorization-node/-/plugin-authorization-node-2.60.4.tgz",
+      "integrity": "sha512-57AkhuOPrqNhMTukUWVqMk5nfhupjbR6TZaqPvVhY78qth/pfLgWIm+AU1RAkr7s5tyEhNvcMZ/F3H6OyaGLbQ==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^3.3.2"
       },
@@ -12590,9 +12590,9 @@
       }
     },
     "node_modules/@webex/plugin-authorization-node/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12608,19 +12608,19 @@
       }
     },
     "node_modules/@webex/plugin-device-manager": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-2.60.2.tgz",
-      "integrity": "sha512-svzfhaWzMCjJNhrog+KufmVsLiIqlalYewd6AhFltJIBq3OAQgu7tgRw65AoN4rgVEej2/L+UfEuOx/s9PKovw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-device-manager/-/plugin-device-manager-2.60.4.tgz",
+      "integrity": "sha512-diliGa7aAo1MmzNDDfbILAg7AErN3uoDBFkDIf+8t6ynYXcrtd0tTNdexkKm0sFRJT2H667RN6EErff1lcrC9w==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-calendar": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-lyra": "2.60.2",
-        "@webex/internal-plugin-search": "2.60.2",
-        "@webex/plugin-authorization": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-calendar": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-lyra": "2.60.4",
+        "@webex/internal-plugin-search": "2.60.4",
+        "@webex/plugin-authorization": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21",
         "uuid": "^3.3.2"
       },
@@ -12629,16 +12629,16 @@
       }
     },
     "node_modules/@webex/plugin-logger": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-2.60.2.tgz",
-      "integrity": "sha512-AX5qQ+9HTV+lT/qTrQG9O2BLflXGhyfrHupuRLyndfTpn6tQGMc2ijSDAENfz/EN+bQARtHZct0sTqzgLPe6rA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-logger/-/plugin-logger-2.60.4.tgz",
+      "integrity": "sha512-8h5Ymo8oMAXbfEoTNt9LcMnMtqZrNhjNnDz+fE5Fk6HVAS2guHHN+U/khrCZvmn/+rpm19ghEPn2/ZTnLHL9+Q==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-mocha": "2.60.2",
-        "@webex/test-helper-mock-webex": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-mocha": "2.60.4",
+        "@webex/test-helper-mock-webex": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -12646,9 +12646,9 @@
       }
     },
     "node_modules/@webex/plugin-logger/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12664,20 +12664,20 @@
       }
     },
     "node_modules/@webex/plugin-meetings": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-2.60.2.tgz",
-      "integrity": "sha512-GFCJnhdbokhV9wv5rIFrTfZB6t414UkM1+pwLi6S8QYnqeAZPSKOextqMZpw5OtRZj6ucYWz7bPGvl3Phvy+/w==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-meetings/-/plugin-meetings-2.60.4.tgz",
+      "integrity": "sha512-4KKez/+CSn5KtxK0z7FVJg6+1bZgloEqQvUhZsdveODCISr/AyoIbrXLI7wfcVRQRM1lcTQVJO0UodSBB/7zpA==",
       "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
       "dependencies": {
-        "@webex/common": "2.60.2",
+        "@webex/common": "2.60.4",
         "@webex/internal-media-core": "0.0.7-beta",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-metrics": "2.60.2",
-        "@webex/internal-plugin-support": "2.60.2",
-        "@webex/internal-plugin-user": "2.60.2",
-        "@webex/plugin-people": "2.60.2",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-metrics": "2.60.4",
+        "@webex/internal-plugin-support": "2.60.4",
+        "@webex/internal-plugin-user": "2.60.4",
+        "@webex/plugin-people": "2.60.4",
         "@webex/ts-sdp": "1.0.1",
-        "@webex/webex-core": "2.60.2",
+        "@webex/webex-core": "2.60.4",
         "bowser": "^2.11.0",
         "btoa": "^1.2.1",
         "dotenv": "^4.0.0",
@@ -12694,9 +12694,9 @@
       }
     },
     "node_modules/@webex/plugin-meetings/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12721,19 +12721,19 @@
       }
     },
     "node_modules/@webex/plugin-memberships": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-2.60.2.tgz",
-      "integrity": "sha512-YE9fp0B2ImjF4rlRpPTsgtj5hjN8pD5r+KzY4bCqQ85GSYJtu2jX3HsrfTkHwcA2paOrRD382R1AuuJBWAoMvQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-memberships/-/plugin-memberships-2.60.4.tgz",
+      "integrity": "sha512-0AhdtM6U6+jsHTxlQSq5AHCPwCqGDE8W8o6tlSVMGKnF37jKt7o3Jm/FQy2Dz5VNhr1AuwnsnO2p1WLek8YCGg==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-messages": "2.60.2",
-        "@webex/plugin-people": "2.60.2",
-        "@webex/plugin-rooms": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-messages": "2.60.4",
+        "@webex/plugin-people": "2.60.4",
+        "@webex/plugin-rooms": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
       },
@@ -12742,9 +12742,9 @@
       }
     },
     "node_modules/@webex/plugin-memberships/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12760,19 +12760,19 @@
       }
     },
     "node_modules/@webex/plugin-messages": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-2.60.2.tgz",
-      "integrity": "sha512-bmwGVOjA58+GcFdVCJOGdCE4RHDbohDLjR9OytFgI9b5rbh1ovi4DRwbV/QZ/RwDJxm783PtxfA/a11y739nqg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-messages/-/plugin-messages-2.60.4.tgz",
+      "integrity": "sha512-DWMCY/nhN5Yqe/Mh3QBUNBlO6SXyA9+R+cwrvcENivtQ26smLsDPv69TLvV9XLbBa9NhgL7mT5XT9Fnys0Odsw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-people": "2.60.2",
-        "@webex/plugin-rooms": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-people": "2.60.4",
+        "@webex/plugin-rooms": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
       },
@@ -12781,9 +12781,9 @@
       }
     },
     "node_modules/@webex/plugin-messages/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12799,23 +12799,23 @@
       }
     },
     "node_modules/@webex/plugin-people": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-2.60.2.tgz",
-      "integrity": "sha512-phTpthOpFDVTLTAxIDWpsZF6JnRtIuwOfI7aKKF6i30jbF8ISURzPFzJG3NskKTzeGQT7VEG+lFX+ZYKxrmafQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-people/-/plugin-people-2.60.4.tgz",
+      "integrity": "sha512-OTVM+jgU6MZ59URHPDG/YMFMI/eo3eO0MDtd9GP8Sq7as21inBrOJFlzYJ8OD3etmHULH2fX8DENKgW9tn+MUw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/webex-core": "2.60.2"
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/webex-core": "2.60.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/plugin-people/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12831,19 +12831,19 @@
       }
     },
     "node_modules/@webex/plugin-rooms": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-2.60.2.tgz",
-      "integrity": "sha512-cyc4O9LdlXIqLCR0rHFAyd+dRpzCMTj1Q3byXCFPrXne0ao6833BVvKenaaH3pG8RE5Tnp2GXnMHnY3iz++pAA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-rooms/-/plugin-rooms-2.60.4.tgz",
+      "integrity": "sha512-p9JRVUDGs0rtlZXahpr4RGck1PNYvt2lGjLNN9R2w6ZkfERVy4YXkraPdeLkDvpxO1URdNF9OMXlJdAfzq0jFw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-conversation": "2.60.2",
-        "@webex/internal-plugin-mercury": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-memberships": "2.60.2",
-        "@webex/plugin-messages": "2.60.2",
-        "@webex/plugin-people": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-conversation": "2.60.4",
+        "@webex/internal-plugin-mercury": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-memberships": "2.60.4",
+        "@webex/plugin-messages": "2.60.4",
+        "@webex/plugin-people": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "debug": "^4.3.4",
         "lodash": "^4.17.21"
       },
@@ -12852,9 +12852,9 @@
       }
     },
     "node_modules/@webex/plugin-rooms/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -12870,34 +12870,34 @@
       }
     },
     "node_modules/@webex/plugin-team-memberships": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-2.60.2.tgz",
-      "integrity": "sha512-VTFztxprBipx9172CMd5c2JZw1veeaLZLaIWBEw/rxeORwr+xFwVIJkiSTOh0tp2B9bEyBoWGXzwUyLirQIFtw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-team-memberships/-/plugin-team-memberships-2.60.4.tgz",
+      "integrity": "sha512-IKhL0z5Nj7BMQOHFLrhC9fq5KS3Dy5qgqsFr0DPRuh/Hj89C86N3PzP1/0+P6nVOeZRwp2ZbNdhToWjmC/9L5Q==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-rooms": "2.60.2",
-        "@webex/plugin-teams": "2.60.2",
-        "@webex/webex-core": "2.60.2"
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-rooms": "2.60.4",
+        "@webex/plugin-teams": "2.60.4",
+        "@webex/webex-core": "2.60.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/plugin-teams": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-2.60.2.tgz",
-      "integrity": "sha512-b3GFP5O8InMFU7miLFN0rOmzhUALSYb5YaRutkvkigynE7atz23owb/8ZEJu6aJpB0wRPLA0/ySqifag6spvnA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-teams/-/plugin-teams-2.60.4.tgz",
+      "integrity": "sha512-ByHY4xRUdjFgcxxgIbIH8ZMre5KL0tt5tBXlD6WIQsTmAQZy9gV2q058/QQ7ZYrmPXIRHoeS5llbiXyU9gYTCA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-memberships": "2.60.2",
-        "@webex/plugin-rooms": "2.60.2",
-        "@webex/test-helper-chai": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-memberships": "2.60.4",
+        "@webex/plugin-rooms": "2.60.4",
+        "@webex/test-helper-chai": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -12905,15 +12905,15 @@
       }
     },
     "node_modules/@webex/plugin-webhooks": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-2.60.2.tgz",
-      "integrity": "sha512-NVql0HQstUAOOAiuTofI35J33X0bs28DaBW3x+5KXEL5RbW81+F4BEbQDmJ2Pshy6PCm/CbfqE5S1wCVtravtA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/plugin-webhooks/-/plugin-webhooks-2.60.4.tgz",
+      "integrity": "sha512-R79c8fsMGMrI+WmLlhE/zRxw0xuHlBu9ShSxxe0Uy4JrKp2FPtmGJ5H8vETGypJrdWrOa3LrNjWS/zTm2Cm86Q==",
       "license": "MIT",
       "dependencies": {
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-rooms": "2.60.2",
-        "@webex/webex-core": "2.60.2"
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-rooms": "2.60.4",
+        "@webex/webex-core": "2.60.4"
       },
       "engines": {
         "node": ">=14"
@@ -12955,38 +12955,38 @@
       }
     },
     "node_modules/@webex/storage-adapter-local-storage": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-2.60.2.tgz",
-      "integrity": "sha512-I8PPDGW6kTxHmxzOzIg9HdlFl8GCH5a72RBcvnVLQdYLC4PGImnla2FNk1vGMn6WQdBZEGW7tbRo9PbctM1rPw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-local-storage/-/storage-adapter-local-storage-2.60.4.tgz",
+      "integrity": "sha512-B8LEEbhPOB/bWl3/4ClWRQSpbXDWb4g6JWXZBzD4BcUqDolkGNSVtoh9ZlEsUBlQQ0CKBbvJCwn3GBVXL5tf+g==",
       "license": "MIT",
       "dependencies": {
-        "@webex/storage-adapter-spec": "2.60.2",
-        "@webex/test-helper-mocha": "2.60.2",
-        "@webex/webex-core": "2.60.2"
+        "@webex/storage-adapter-spec": "2.60.4",
+        "@webex/test-helper-mocha": "2.60.4",
+        "@webex/webex-core": "2.60.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/storage-adapter-spec": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-spec/-/storage-adapter-spec-2.60.2.tgz",
-      "integrity": "sha512-SATlrwlM8LrHkTpmBPVr2W1VeAByZxHcKyv5WTsD31XG86IvHE9+OlA1/bWZ6qWZ78BDY1RThqgFLr3tIK4A0A==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/storage-adapter-spec/-/storage-adapter-spec-2.60.4.tgz",
+      "integrity": "sha512-LNQmhe9SiXyUZ3O5pZ+2BmtmaNJjn4xwMu8lgISWwOSdEf5RVZt1/sURcVMddAz9XmHD4kgcIdIiq0W/nIeSrA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/test-helper-chai": "2.60.2"
+        "@webex/test-helper-chai": "2.60.4"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/test-helper-chai": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-chai/-/test-helper-chai-2.60.2.tgz",
-      "integrity": "sha512-gDHXpoc+sT0OjqH/QHrAxuEutvwWtX4khWW1Fza7uGYt/m7cwLaLdyUnE3s/0SrPA7OQykW9J30V9AOevW3ahg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-chai/-/test-helper-chai-2.60.4.tgz",
+      "integrity": "sha512-xYwXynR7xQYTUchOv8yZDNAVbp7sR4BliBrC1cdXoDP7jCNfVk5v/Dzka0XPKlm44RaIJMAMRT9hYBjONBdArg==",
       "license": "MIT",
       "dependencies": {
-        "@webex/test-helper-file": "2.60.2",
+        "@webex/test-helper-file": "2.60.4",
         "check-error": "^1.0.2",
         "lodash": "^4.17.21"
       },
@@ -12995,13 +12995,13 @@
       }
     },
     "node_modules/@webex/test-helper-file": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-file/-/test-helper-file-2.60.2.tgz",
-      "integrity": "sha512-EhtUPfcPRPHAJ2zwDlbm5A/7zsZ6IU+v0k/Rm4wZrPuGglmtHd6uByQxCtimuKdJmAhRIMLfGCspYg7H0mGiSQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-file/-/test-helper-file-2.60.4.tgz",
+      "integrity": "sha512-0xwi7HJwMtph+qKMNI56cez96HXpTG0U4U/qbbIRC9uTjOdpWuVaydWAHSXKIHQP7kdldre8onwWqgklhdy4OA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/test-helper-make-local-url": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/test-helper-make-local-url": "2.60.4",
         "es6-promise": "^4.2.8",
         "file-type": "^16.0.1",
         "xhr": "^2.5.0"
@@ -13011,9 +13011,9 @@
       }
     },
     "node_modules/@webex/test-helper-file/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -13029,18 +13029,18 @@
       }
     },
     "node_modules/@webex/test-helper-make-local-url": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-make-local-url/-/test-helper-make-local-url-2.60.2.tgz",
-      "integrity": "sha512-Hf6onYOlQCr/aA7mVDTNCaCxeVLYzcQelB4Yl8C8+P23OaSDNfB6tZKYLXDx8TMM9Q3VSuffubzORnPLJTrIsg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-make-local-url/-/test-helper-make-local-url-2.60.4.tgz",
+      "integrity": "sha512-poZXUjbjxGIgZxOduDoZ0WlpaWPK+oP3Y9WaOwqjIQAL7ScWv+4sOF4RlyNTCpV+HhTNC3nw7Bcz362JoyXdkQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/test-helper-mocha": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-mocha/-/test-helper-mocha-2.60.2.tgz",
-      "integrity": "sha512-zlZ3j8g5fyB5ZWZzQXKk81ddQBfaxBByIVs+dbh8JAF5jy0BKgysiNir3G/Wdu9nru6RGWGCXyPsXV3A7E2e7g==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-mocha/-/test-helper-mocha-2.60.4.tgz",
+      "integrity": "sha512-uLZXEX3pYDMpfx2m3H9Yb11gdxdlZWMVC+/RDDJI4dxJjIya7LfNrkJKL9eYK4mnDH1jz2fpuOk0FaOAC0DUtg==",
       "license": "MIT",
       "dependencies": {
         "bowser": "^2.11.0"
@@ -13050,18 +13050,18 @@
       }
     },
     "node_modules/@webex/test-helper-mock-web-socket": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-mock-web-socket/-/test-helper-mock-web-socket-2.60.2.tgz",
-      "integrity": "sha512-7qU168TAgZwaV1wwZe8Fv3Eat+iA65wPRAVQLc/Qcl0ZRbu0tRHyGwFdPgfPaL9KoOCdIyTzLU2btgfDmMxTlQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-mock-web-socket/-/test-helper-mock-web-socket-2.60.4.tgz",
+      "integrity": "sha512-K7ie9Fl/vlt3DFKIkCuG6Wrsfhg1jdv+QiWiZiCXPcN24o9ByXI0/w5flHZaNafJLGnBTb3HJMlUnqb+6H4KLQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/test-helper-mock-webex": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-mock-webex/-/test-helper-mock-webex-2.60.2.tgz",
-      "integrity": "sha512-9//KM8xCFuLKCR84WPFwgQGe7R/Ng/miJtRhVd6pCgW6dL+bGtVQpk31/c3vGq4rCfjaoO+tT6LsEjhJfyfB/g==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-mock-webex/-/test-helper-mock-webex-2.60.4.tgz",
+      "integrity": "sha512-1STh8Xykf8U62uFssUcd0Q0PiWE3dmqzehpZfVbvrJeF+uNRww/g2+23ARr4C1DEYLxolck8B2ZsIGaNIX4OMw==",
       "license": "MIT",
       "dependencies": {
         "ampersand-state": "^5.0.3",
@@ -13073,18 +13073,18 @@
       }
     },
     "node_modules/@webex/test-helper-refresh-callback": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-refresh-callback/-/test-helper-refresh-callback-2.60.2.tgz",
-      "integrity": "sha512-2VgjejDS/x0AvscWKAnsLkcTLQuXDpDG7CkCdRR//Nv8XIX0B6OG7uU0juTFjZeczdIoRJcX1m/Lk5Wxt2igeQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-refresh-callback/-/test-helper-refresh-callback-2.60.4.tgz",
+      "integrity": "sha512-7pNy+KgJH5MUe7NedOFuJ63uiiBNzTJhBCid6jTwTy24x5jHVS46XIoE69Eg64mgekxcbcVEMFZdegilA0TKMQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@webex/test-helper-retry": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-retry/-/test-helper-retry-2.60.2.tgz",
-      "integrity": "sha512-uxbBrANdNHNmeHsanHSi7IyL53jB6Y6LFeZfA0wZodzrGA8DGPAaW7DHTgP+LzC+6vPtZP9m6ZezSmO0lrqtTA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-retry/-/test-helper-retry-2.60.4.tgz",
+      "integrity": "sha512-4dbWVaXTyzWja0l91p9lHOS+iyDBuJ/OleraJEIbOjA0AX9dbk/KMzlEzdLUmPgHaxAPPQ8veJkJn7VetIdU4A==",
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.2.8"
@@ -13094,13 +13094,13 @@
       }
     },
     "node_modules/@webex/test-helper-test-users": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-helper-test-users/-/test-helper-test-users-2.60.2.tgz",
-      "integrity": "sha512-9FIN7a7nUyHrZZvakg+j09h3OlBdVCU4Oa4piX9b0S8lnqFAEMeljxyaiVrvZedmGQH3b8fbPQwZEqe0+a+pmw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-helper-test-users/-/test-helper-test-users-2.60.4.tgz",
+      "integrity": "sha512-JX/pYKvHbXhP4P0rjaQZemgJSAs4yhyBJJoaYvCG9c1clj4dObuGFU91wuS0pYzK9n3NEN+nYPeBS6fkmkTrnw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/test-helper-retry": "2.60.2",
-        "@webex/test-users": "2.60.2",
+        "@webex/test-helper-retry": "2.60.4",
+        "@webex/test-users": "2.60.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -13111,9 +13111,9 @@
       }
     },
     "node_modules/@webex/test-helper-test-users/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -13129,15 +13129,15 @@
       }
     },
     "node_modules/@webex/test-helper-test-users/node_modules/@webex/http-core": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.2.tgz",
-      "integrity": "sha512-tS1lt4EVJpfBhnANFcQADnTwpTxGsWG8G1k3AivikHgK2ZyW2mm8ZjLWvrXeyvQigzfs16dV5X4fGwseqSA6gg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.4.tgz",
+      "integrity": "sha512-THiETyXNDIotKY3rJ2Bo+xU2FkYqwT+qAWGFe0wBQcHjSmg+BlBSLDEEEYzTZlN6Z9cSgt99O2xZwkC4nD1Uew==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
@@ -13153,13 +13153,13 @@
       }
     },
     "node_modules/@webex/test-helper-test-users/node_modules/@webex/test-users": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/test-users/-/test-users-2.60.2.tgz",
-      "integrity": "sha512-No6KDxcvSZ2NKq4zOfKA31qb97bYCFbgu/8+K92JRJWOkkswp4W9d1rN55kFbNfgut/EeBY7KOL4ci/E4NBaMg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/test-users/-/test-users-2.60.4.tgz",
+      "integrity": "sha512-yyeZXFC8GpOg1MNo7pHmtdDA1b79WU1zC942MPZ5Cg9mDSmNzgSXhx769Xw24t6oVDHL5b8G+PSNOjdjhrl1iA==",
       "license": "MIT",
       "dependencies": {
-        "@webex/http-core": "2.60.2",
-        "@webex/test-helper-mocha": "2.60.2",
+        "@webex/http-core": "2.60.4",
+        "@webex/test-helper-mocha": "2.60.4",
         "btoa": "^1.2.1",
         "lodash": "^4.17.21",
         "node-random-name": "^1.0.1",
@@ -13194,17 +13194,17 @@
       "license": "ISC"
     },
     "node_modules/@webex/webex-core": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-2.60.2.tgz",
-      "integrity": "sha512-ZSD6M+/bxxVG57D3hMwWG/rxwSggtKI41kfaXpx1fP7UmQS7yYzhmJIb5MPm2m89/Hq+87hJQJj7Q9UPwEO6nA==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/webex-core/-/webex-core-2.60.4.tgz",
+      "integrity": "sha512-A5iXmJu50B9sGgqE7/wf0zShF5bmovsEjzii+xw2Y9REAn4KD86zyUsOuV5gVfgAR7aZx40MnTXXwB/wJV1+Vw==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/common-timers": "2.60.2",
-        "@webex/http-core": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/storage-adapter-spec": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/common-timers": "2.60.4",
+        "@webex/http-core": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/storage-adapter-spec": "2.60.4",
         "ampersand-collection": "^2.0.2",
         "ampersand-events": "^2.0.2",
         "ampersand-state": "^5.0.3",
@@ -13219,9 +13219,9 @@
       }
     },
     "node_modules/@webex/webex-core/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",
@@ -13237,15 +13237,15 @@
       }
     },
     "node_modules/@webex/webex-core/node_modules/@webex/http-core": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.2.tgz",
-      "integrity": "sha512-tS1lt4EVJpfBhnANFcQADnTwpTxGsWG8G1k3AivikHgK2ZyW2mm8ZjLWvrXeyvQigzfs16dV5X4fGwseqSA6gg==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/http-core/-/http-core-2.60.4.tgz",
+      "integrity": "sha512-THiETyXNDIotKY3rJ2Bo+xU2FkYqwT+qAWGFe0wBQcHjSmg+BlBSLDEEEYzTZlN6Z9cSgt99O2xZwkC4nD1Uew==",
       "license": "MIT",
       "dependencies": {
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/test-helper-test-users": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/test-helper-test-users": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "file-type": "^16.0.1",
         "global": "^4.4.0",
         "is-function": "^1.0.1",
@@ -14666,9 +14666,9 @@
       }
     },
     "node_modules/babel-plugin-react-compiler": {
-      "version": "0.0.0-experimental-734b737-20241003",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-734b737-20241003.tgz",
-      "integrity": "sha512-jdcHsQwYAPuB2u/wpyCXCMI2B9n4weLAx8csvjNwYBw9drXYv4GmoxMyboigR9NJqDdcpIgjCBvt9qnIZM7AhA==",
+      "version": "0.0.0-experimental-592953e-20240517",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-0.0.0-experimental-592953e-20240517.tgz",
+      "integrity": "sha512-OjG1SVaeQZaJrqkMFJatg8W/MTow8Ak5rx2SI0ETQBO1XvOk/XZGMbltNCPdFJLKghBYoBjC+Y3Ap/Xr7B01mA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -14855,9 +14855,9 @@
       }
     },
     "node_modules/babel-plugin-react-native-web": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.12.tgz",
-      "integrity": "sha512-eYZ4+P6jNcB37lObWIg0pUbi7+3PKoU1Oie2j0C8UF3cXyXoR74tO2NBjI/FORb2LJyItJZEAmjU5pSaJYEL1w==",
+      "version": "0.19.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.13.tgz",
+      "integrity": "sha512-4hHoto6xaN23LCyZgL9LJZc3olmAxd7b6jDzlZnKXAh4rRAbZRKNBJoOOdp46OBqgy+K0t0guTj5/mhA8inymQ==",
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -14937,9 +14937,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "11.0.14",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.14.tgz",
-      "integrity": "sha512-4BVYR0Sc2sSNxYTiE/OLSnPiOp+weFNy8eV+hX3aD6YAIbBnw+VubKRWqJV/sOJauzOLz0SgYAYyFciYMqizRA==",
+      "version": "11.0.15",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-11.0.15.tgz",
+      "integrity": "sha512-rgiMTYwqIPULaO7iZdqyL7aAff9QLOX6OWUtLZBlOrOTreGY1yHah/5+l8MvI6NVc/8Zj5LY4Y5uMSnJIuzTLw==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -14951,7 +14951,7 @@
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
         "@react-native/babel-preset": "0.74.87",
-        "babel-plugin-react-compiler": "^0.0.0-experimental-592953e-20240517",
+        "babel-plugin-react-compiler": "0.0.0-experimental-592953e-20240517",
         "babel-plugin-react-native-web": "~0.19.10",
         "react-refresh": "^0.14.2"
       }
@@ -20922,9 +20922,9 @@
       }
     },
     "node_modules/expo": {
-      "version": "51.0.36",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.36.tgz",
-      "integrity": "sha512-eQIC0l6fz3p4cU/hV8+QcyKSacyROhaoA1oohfCD6I3F09dxmC8b3SESpzGqHfuq8wsgcUc4q8ckX7ec25IV1g==",
+      "version": "51.0.38",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-51.0.38.tgz",
+      "integrity": "sha512-/B9npFkOPmv6WMIhdjQXEY0Z9k/67UZIVkodW8JxGIXwKUZAGHL+z1R5hTtWimpIrvVhyHUFU3f8uhfEKYhHNQ==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -20935,13 +20935,13 @@
         "@expo/config-plugins": "8.0.10",
         "@expo/metro-config": "0.18.11",
         "@expo/vector-icons": "^14.0.3",
-        "babel-preset-expo": "~11.0.14",
+        "babel-preset-expo": "~11.0.15",
         "expo-asset": "~10.0.10",
         "expo-file-system": "~17.0.1",
         "expo-font": "~12.0.10",
         "expo-keep-awake": "~13.0.2",
         "expo-modules-autolinking": "1.11.3",
-        "expo-modules-core": "1.12.25",
+        "expo-modules-core": "1.12.26",
         "fbemitter": "^3.0.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -21225,9 +21225,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "1.12.25",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.12.25.tgz",
-      "integrity": "sha512-HB2LS2LEM41Xq1bG+Jtzqm6XgPaa+mM9BAvCdX1lDGMQ9Ay9vMTL/GVEs2gpsINPofICopjBRwD+wftyCbVrzg==",
+      "version": "1.12.26",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-1.12.26.tgz",
+      "integrity": "sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -21239,6 +21239,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-14.0.1.tgz",
       "integrity": "sha512-gX2mtR9o+WelX21YizXUCD/y+a4ZL+RDthDmFkHxaYbdzjSYTn8u/igoje/l3WEO+/RYspmqUFa8w/ckNbt6Vg==",
+      "deprecated": "This package is now deprecated in favor of expo-crypto, which provides the same functionality. To migrate, replace all imports from expo-random with imports from expo-crypto.",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22408,9 +22409,9 @@
       "peer": true
     },
     "node_modules/flow-parser": {
-      "version": "0.247.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.247.1.tgz",
-      "integrity": "sha512-DHwcm06fWbn2Z6uFD3NaBZ5lMOoABIQ4asrVA80IWvYjjT5WdbghkUOL1wIcbLcagnFTdCZYOlSNnKNp/xnRZQ==",
+      "version": "0.250.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.250.0.tgz",
+      "integrity": "sha512-8mkLh/CotlvqA9vCyQMbhJoPx2upEg9oKxARAayz8zQ58wCdABnTZy6U4xhMHvHvbTUFgZQk4uH2cglOCOel5A==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -38354,9 +38355,9 @@
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-5.3.1.tgz",
-      "integrity": "sha512-7FSb9meX0btdBQLwdFOwt6bGqvRPabmVMMslv8fgoSPqXyuGpgQe36kx8gR86XPw7aV1yVouTp6fyZ0EH+NfUw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-5.3.2.tgz",
+      "integrity": "sha512-crr9HkVrDiJ0A4zot89oS0Cgv0Oa4OG1Em4jit3P3ZxZSKPMYyMjfwMqgcJna9o625g8oN87rBm8SWWrSTBZxg==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -43046,9 +43047,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -43770,16 +43772,16 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.0.tgz",
-      "integrity": "sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
+        "asn1js": "^3.0.5",
         "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/webcrypto-core/node_modules/asn1js": {
@@ -43947,32 +43949,32 @@
       }
     },
     "node_modules/webex": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/webex/-/webex-2.60.2.tgz",
-      "integrity": "sha512-F8QSteQOEwUqU2mAK8n+N6923qPrRDTTQWZDYVYeMIZxcJ0CqwtPZwH+Dw3+ES7oLwVfrCWC/UNqZxJgihWsnw==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/webex/-/webex-2.60.4.tgz",
+      "integrity": "sha512-nRcmN6A98rzYp115sfI4lKV7lX9ALcC4H7E9ADSMjnMyt3W7En9qg76KVf7XaQ3WaF8OoGlwLc+O/viVlnv2JA==",
       "license": "Cisco EULA (https://www.cisco.com/c/en/us/products/end-user-license-agreement.html)",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
         "@babel/runtime-corejs2": "^7.14.8",
-        "@webex/common": "2.60.2",
-        "@webex/internal-plugin-calendar": "2.60.2",
-        "@webex/internal-plugin-device": "2.60.2",
-        "@webex/internal-plugin-presence": "2.60.2",
-        "@webex/internal-plugin-support": "2.60.2",
-        "@webex/plugin-attachment-actions": "2.60.2",
-        "@webex/plugin-authorization": "2.60.2",
-        "@webex/plugin-device-manager": "2.60.2",
-        "@webex/plugin-logger": "2.60.2",
-        "@webex/plugin-meetings": "2.60.2",
-        "@webex/plugin-memberships": "2.60.2",
-        "@webex/plugin-messages": "2.60.2",
-        "@webex/plugin-people": "2.60.2",
-        "@webex/plugin-rooms": "2.60.2",
-        "@webex/plugin-team-memberships": "2.60.2",
-        "@webex/plugin-teams": "2.60.2",
-        "@webex/plugin-webhooks": "2.60.2",
-        "@webex/storage-adapter-local-storage": "2.60.2",
-        "@webex/webex-core": "2.60.2",
+        "@webex/common": "2.60.4",
+        "@webex/internal-plugin-calendar": "2.60.4",
+        "@webex/internal-plugin-device": "2.60.4",
+        "@webex/internal-plugin-presence": "2.60.4",
+        "@webex/internal-plugin-support": "2.60.4",
+        "@webex/plugin-attachment-actions": "2.60.4",
+        "@webex/plugin-authorization": "2.60.4",
+        "@webex/plugin-device-manager": "2.60.4",
+        "@webex/plugin-logger": "2.60.4",
+        "@webex/plugin-meetings": "2.60.4",
+        "@webex/plugin-memberships": "2.60.4",
+        "@webex/plugin-messages": "2.60.4",
+        "@webex/plugin-people": "2.60.4",
+        "@webex/plugin-rooms": "2.60.4",
+        "@webex/plugin-team-memberships": "2.60.4",
+        "@webex/plugin-teams": "2.60.4",
+        "@webex/plugin-webhooks": "2.60.4",
+        "@webex/storage-adapter-local-storage": "2.60.4",
+        "@webex/webex-core": "2.60.4",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -43980,9 +43982,9 @@
       }
     },
     "node_modules/webex/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
         "@webex/components": "1.275.2",
-        "@webex/sdk-component-adapter": "1.112.11",
+        "@webex/sdk-component-adapter": "1.112.12",
         "webex": "2.60.4"
       },
       "devDependencies": {
@@ -12920,26 +12920,26 @@
       }
     },
     "node_modules/@webex/sdk-component-adapter": {
-      "version": "1.112.11",
-      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.11.tgz",
-      "integrity": "sha512-5b8FzAoQjUYMiHcTOLkMBkn+fRUPRz09hJEyxukhyrIYjGPI9fMdTOls9OAolQ+CTqoondnYNnM1tQy6msQ/tQ==",
+      "version": "1.112.12",
+      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.12.tgz",
+      "integrity": "sha512-Bv1QPmuh1hI6jX1wFQ64dRXmk2Snv4twGT4ULMnKnXQWVI3Wo5XhpcH04qroU+ezZO2geEWtY7oO/MMfaaa/7A==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.16.0",
-        "@webex/common": "^2.60.2",
+        "@webex/common": "^2.60.4",
         "@webex/component-adapter-interfaces": "^1.28.0",
         "deasync": "^0.1.29",
         "logform": "^2.2.0"
       },
       "peerDependencies": {
         "rxjs": "^6.5.4",
-        "webex": "^2.60.2"
+        "webex": "^2.60.4"
       }
     },
     "node_modules/@webex/sdk-component-adapter/node_modules/@webex/common": {
-      "version": "2.60.2",
-      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.2.tgz",
-      "integrity": "sha512-U1gQ/j9g+8qO2t6iENrqWKl1pP3xIyElFt3i298Hj9o9/DbuQ3ELuI4SKCF4S6KwyX/84obz5tHehEo0tSaoxQ==",
+      "version": "2.60.4",
+      "resolved": "https://registry.npmjs.org/@webex/common/-/common-2.60.4.tgz",
+      "integrity": "sha512-axnUDJG2ZykkPBgwIH+IpHyiNeQQvRxhY2NyxMfIO3AaH1vJrBzMi7iUPvxay/ozHStlC8VmLwHoDf01YmMBAg==",
       "license": "MIT",
       "dependencies": {
         "backoff": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
-    "@webex/sdk-component-adapter": "1.112.11",
+    "@webex/sdk-component-adapter": "1.112.12",
     "webex": "2.60.4",
     "@webex/components": "1.275.2"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
     "@webex/sdk-component-adapter": "1.112.11",
-    "webex": "2.60.2",
+    "webex": "2.60.4",
     "@webex/components": "1.275.2"
   },
   "devDependencies": {
@@ -116,7 +116,7 @@
     "prop-types": "^15.7.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "webex": "2.60.2"
+    "webex": "2.60.4"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
# **Completes** [SPARK-552246](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-552246)
## **This pull request addresses**
Upgrading the webex to newer-version which is 2.x version and the sdk-component-adapter to the newer-version as well which is 1.112.x version

- This Upgrading `webex` to newer-version is because of the fix that was made in [SDK](https://github.com/webex/webex-js-sdk/pull/3902) that needs to be in widgets 

- So the fix is about the user trying to `joinmeeting` by entering the name according to their wish but unfortunately, the user entered name was not reflected on the remote side of the meeting rather it printed the system default name so SDK fix will give the solution in the widgets that is why the `webex` is needed to upgrade in the widgets to reflect the changes that made in SDK

- Also upgrading the `sdk-component-adapter` to new version in widgets because whatever the fix does on the SDK side that version has upgraded in the `sdk-component-adapter` so the newer-version of `sdk-component-adapter` is upgrading in the `widgets` as well
## **The following scenarios were tested**

- After upgrading the version of `webex` and `sdk-component-adapter` in widgets I tested this to see whether the fix has been successful or not and it got success please do see the screen recording for more clarity 

https://github.com/user-attachments/assets/35aaa2a6-87cf-43e8-a613-c05fa2593cd6

