### PR TITLE
fix(WebexMeetings): update member name from join prompt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/components": "1.275.2",
-        "@webex/sdk-component-adapter": "1.112.12",
+        "@webex/components": "1.275.3",
+        "@webex/sdk-component-adapter": "1.112.13",
         "webex": "2.60.4"
       },
       "devDependencies": {
@@ -11866,9 +11866,9 @@
       }
     },
     "node_modules/@webex/components": {
-      "version": "1.275.2",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.2.tgz",
-      "integrity": "sha512-/+VzR7j53IbjPr9vHCPhWiFYwm0xP7/N5lbeDAX7M+YUryg6wg3haI/tOEWI1r8UKNwmrWTCg7/FeoAz41QK9g==",
+      "version": "1.275.3",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.3.tgz",
+      "integrity": "sha512-/deGE9KbK+ESvTrO2n96hU1kH5AiAwu8wWjbznnQamkheBCeIhxQJo5G3JiLw2DpDOpEzGflmpeEKGAsv9qaXg==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",
@@ -12920,9 +12920,9 @@
       }
     },
     "node_modules/@webex/sdk-component-adapter": {
-      "version": "1.112.12",
-      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.12.tgz",
-      "integrity": "sha512-Bv1QPmuh1hI6jX1wFQ64dRXmk2Snv4twGT4ULMnKnXQWVI3Wo5XhpcH04qroU+ezZO2geEWtY7oO/MMfaaa/7A==",
+      "version": "1.112.13",
+      "resolved": "https://registry.npmjs.org/@webex/sdk-component-adapter/-/sdk-component-adapter-1.112.13.tgz",
+      "integrity": "sha512-3ne0+JW6dXYLNCTUJkSDqYqCB4RvxI+m18iu/Gv/On8sqhYLyoNZ202Tb8BptPJw9CZ3jHTWYr/0BpdQWvWVaA==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   ],
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
-    "@webex/sdk-component-adapter": "1.112.12",
+    "@webex/sdk-component-adapter": "1.112.13",
     "webex": "2.60.4",
-    "@webex/components": "1.275.2"
+    "@webex/components": "1.275.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
## Closes [SPARK-552246](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-552246)

## This pull request addresses 
This PR enhances the getMembers function by including the `name` property in the returned member objects. By adding the `name: member.name`, each member object now contains the participant's display name in a local sample app of widgets, improving the comprehensiveness of the member data. If the user wanted to pass the `name` according to there wish that will be appear on widgets sample app (or) the system default name will be displayed

## Recording

https://github.com/user-attachments/assets/5cc7464e-bbc4-470c-a44b-f61e96e93e79

## Note: 

This is just a version update PR for the following changes:
1. SDK Component Adapter: https://github.com/webex/sdk-component-adapter/pull/344
2. Components: https://github.com/webex/components/pull/845

## Tested with this PR changes and here's a screenshot
<img width="1279" alt="Screenshot 2024-11-13 at 8 27 08 PM" src="https://github.com/user-attachments/assets/e76de613-38ca-442c-8683-5a4ef47ced6b">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency versions for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->