### PR TITLE
fix(release): trigger-wxcc-2-release-on-github

### DIFF
--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -1,6 +1,9 @@
 import {makeAutoObservable, observable} from 'mobx';
 
 import sdk from './sdk';
+/*
+ * Store class
+ */
 
 class Store {
   loginState = '';


### PR DESCRIPTION
# This PR completed Adhoc

## Why this PR?
During testing, we unintentionally published npm versions 1.28.0-wxcc.1 and 1.28.0-wxcc.2. Since npm does not allow overwriting existing versions, we need to continue publishing from 1.28.0-wxcc.3.

Semantic Release relies on GitHub releases to determine the next version. To ensure the versioning aligns correctly, this PR is necessary to create a GitHub release for version 1.28.0-wxcc.2. This step helps maintain consistency between npm and GitHub versioning.