### PR TITLE
fix(release): add-publish-step-in-tooling

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -16,6 +16,12 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "node ./tooling/src/publish.js ${nextRelease.channel} ${nextRelease.version} "
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": [


### PR DESCRIPTION
# This PR completed Adhoc


## Why this PR?
During testing, we unintentionally published npm versions 1.28.0-wxcc.1 and 1.28.0-wxcc.2. Since npm does not allow overwriting existing versions, we need to continue publishing from 1.28.0-wxcc.3.

**We have published release 1.28.0-wxcc.2 https://github.com/webex/widgets/pull/333. Now we need to start publishing our changes onto npm, so we are adding back the publishing step**

Semantic Release relies on GitHub releases to determine the next version. To ensure the versioning aligns correctly, this PR is necessary to create a GitHub release for version 1.28.0-wxcc.2. This step helps maintain consistency between npm and GitHub versioning.