### PR TITLE
fix(release): update-pipeline-to-new-branch-name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,4 +148,4 @@ workflows:
             - unit_tests
           filters:
             branches:
-              only: feat/cc-widgets
+              only: wxcc

--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,7 @@
   "branches": [
     "master",
     {
-      "name": "feat/cc-widgets",
+      "name": "wxcc",
       "prerelease": "wxcc"
     }
   ],


### PR DESCRIPTION
# This PR completes Adhoc

## Why this PR?
For publishing, we have our own custom logic, while publishing we consider the branch name as the tag . See below 
<img width="818" alt="Screenshot 2024-11-21 at 12 55 38 PM" src="https://github.com/user-attachments/assets/2e5f47a7-a13b-49e0-aaa1-a64542d368bd">

Since the branch name is feat/cc-widgets, we published it onto feat/cc-widgets tag. 

## By making this change
We will update the circle ci and releaserc to run on new branch name i.e wxcc. And the name branch name i.e. wxcc will be taken as the tag on npmjs