### PR TITLE
fix: updated-to-latest-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/components": "1.275.3",
+        "@webex/components": "1.276.0",
         "@webex/sdk-component-adapter": "1.112.13",
         "webex": "2.60.4"
       },
@@ -11866,9 +11866,9 @@
       }
     },
     "node_modules/@webex/components": {
-      "version": "1.275.3",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.3.tgz",
-      "integrity": "sha512-/deGE9KbK+ESvTrO2n96hU1kH5AiAwu8wWjbznnQamkheBCeIhxQJo5G3JiLw2DpDOpEzGflmpeEKGAsv9qaXg==",
+      "version": "1.276.0",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.276.0.tgz",
+      "integrity": "sha512-oIYLzCFqgqlzgrwczeIi9EZui3rneUZA20nijPfMlxKgRf/QTRPAd9lfKa1wSwx45ScPi9x80mVL9TWev5Bbsg==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@webex/component-adapter-interfaces": "^1.30.5",
     "@webex/sdk-component-adapter": "1.112.13",
     "webex": "2.60.4",
-    "@webex/components": "1.275.3"
+    "@webex/components": "1.276.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
## Completes [SPARK-564413](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564413)

* The issue was arising in the meetings widget, when a user moved VO over the `Join Meeting` button and they were getting a wrong test - namely saying the state of the mute and video button. (for eg. mute, video on)
* This was causing confusion to the users

## Fix

* The reason this was not working was because the aria-label of the buttons was taking only the `hint` variable of the components and not reading from the text.
* Further, the hint was coming as null, hence code was added to just take the text as the required label.
* Tests were also done to see that older functionality was not broken.
* Components PR - https://github.com/webex/components/pull/846

Vidcast showing the solution - https://app.vidcast.io/share/3a15014f-1445-4492-8b60-248d3ff54323

## Manual Tests

* Tests were done to ensure the objective of the ticket was fulfilled.
* I have also tested other places where the same button was being used (including inside of a meeting) and have verified that the [behaviour](https://app.vidcast.io/share/3a15014f-1445-4492-8b60-248d3ff54323) is exactly as expected and no other areas were broken.
* Testing was done for personal room meeting and a scheduled meeting.