### PR TITLE
fix(release): accessibility issues fixed on components repo.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@webex/component-adapter-interfaces": "^1.30.5",
-        "@webex/components": "1.275.3",
+        "@webex/components": "1.276.2",
         "@webex/sdk-component-adapter": "1.112.13",
         "webex": "2.60.4"
       },
@@ -11866,9 +11866,9 @@
       }
     },
     "node_modules/@webex/components": {
-      "version": "1.275.3",
-      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.275.3.tgz",
-      "integrity": "sha512-/deGE9KbK+ESvTrO2n96hU1kH5AiAwu8wWjbznnQamkheBCeIhxQJo5G3JiLw2DpDOpEzGflmpeEKGAsv9qaXg==",
+      "version": "1.276.2",
+      "resolved": "https://registry.npmjs.org/@webex/components/-/components-1.276.2.tgz",
+      "integrity": "sha512-wcOOg0qQncX/vM7hDm2Q4i0mqZ+0ANNZ/kjFvbecXt5wG+02tPJHTFdW1bgoN4VUCZH2zc21jo0W9VwitDJaRw==",
       "license": "MIT",
       "dependencies": {
         "@juggle/resize-observer": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@webex/component-adapter-interfaces": "^1.30.5",
     "@webex/sdk-component-adapter": "1.112.13",
     "webex": "2.60.4",
-    "@webex/components": "1.275.3"
+    "@webex/components": "1.276.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
### Issue:

1.  [SPARK-564414](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564414)
In case of accessibility, when we were over the `Leave meeting` button, the screen reader says "undefined, button"

2. [SPARK-564415](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-564415) 
In case of accessibility, when the audio and video is disabled (permission not given by the user) the screen reader is not announcing correct status of audio and video button, it should announce No Microphone, disabled and No Camera, disabled instead of this it is announcing No microphone, No camera

### Fix

* Fixed the code to update the ariaLabel with correct status.

### **Vidcast of testing:**

https://app.vidcast.io/share/5a101376-0ffd-4881-bcd8-2d41c1e746c3
https://app.vidcast.io/share/6e99fbf8-b289-4782-b62a-30ed560feea3

### **Manual Tests Performed**
 
* Checked accessibility with voice over and ensured it aligns with applause requirements.
* Checked meeting behaviour and ensured we can join the meeting.
* Checked meeting behaviour and ensured we can leave the meeting.
* All voice over is exactly the same as before, the changes is only for "audio and video button"
* I have tested mute/unmute and video on/video off and ensured it does not break any functionality on the `Join Meeting` screen
* I have tried to disable the audio and video button by changing the permission from the browser and verified that audio and video button state is called as No Microphone, disabled and No Camera, disabled as per the JIRA ticket requirements.
* After joining the meeting, I have also tested audio, video, share screen, settings & Leave meeting functionality. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `@webex/components` package to enhance stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->