### PR TITLE
feat(user-state): load and change state, client timer

### DIFF
--- a/docs/react-samples/src/App.tsx
+++ b/docs/react-samples/src/App.tsx
@@ -6,6 +6,7 @@ import {UserState} from '@webex/cc-user-state';
 function App() {
   const [isSdkReady, setIsSdkReady] = useState(false);
   const [accessToken, setAccessToken] = useState("");
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const webexConfig = {
       fedramp: false,
@@ -16,10 +17,12 @@ function App() {
 
   const onLogin = () => {
     console.log('Agent login has been succesful');
+    setIsLoggedIn(true);
   }
 
   const onLogout = () => {
     console.log('Agent logout has been succesful');
+    setIsLoggedIn(false);
   }
 
   return (
@@ -39,12 +42,13 @@ function App() {
           });
         }}
       >Init Widgets</button>
-      {/* write code to check if sdk is ready and load components */}
       {
         isSdkReady && (
           <>
             <StationLogin  onLogin={onLogin} onLogout={onLogout} />
-            <UserState />
+            {
+              isLoggedIn && <UserState />
+            }
           </>
         )
       }

--- a/docs/web-component-samples/app.js
+++ b/docs/web-component-samples/app.js
@@ -1,6 +1,6 @@
-const widgetsContainer = document.getElementById('widgets-container');
 const accessTokenElem = document.getElementById('access_token_elem');
 const ccStationLogin = document.getElementById('cc-station-login');
+const ccUserState = document.getElementById('cc-user-state');
 
 function switchButtonState(){
     const buttonElem = document.querySelector('button');
@@ -20,7 +20,7 @@ function initWidgets(){
     }).then(() => {
         ccStationLogin.onLogin = loginSuccess;
         ccStationLogin.onLogout = logoutSuccess;
-        widgetsContainer.classList.remove('disabled');
+        ccStationLogin.classList.remove('disabled');
     }).catch((error) => {
         console.error('Failed to initialize widgets:', error);
     });
@@ -28,8 +28,10 @@ function initWidgets(){
 
 function loginSuccess(){
     console.log('Agent login has been succesful');
+    ccUserState.classList.remove('disabled');
 }
 
 function logoutSuccess(){
     console.log('Agent logout has been succesful');
+    ccUserState.classList.add('disabled');
 }

--- a/docs/web-component-samples/app.js
+++ b/docs/web-component-samples/app.js
@@ -1,6 +1,7 @@
 const accessTokenElem = document.getElementById('access_token_elem');
+const widgetsContainer = document.getElementById('widgets-container');
 const ccStationLogin = document.getElementById('cc-station-login');
-const ccUserState = document.getElementById('cc-user-state');
+const ccUserState = document.createElement('widget-cc-user-state');
 
 if (!ccStationLogin && !ccUserState) {
     console.error('Failed to find the required elements');
@@ -33,6 +34,7 @@ function initWidgets(){
 function loginSuccess(){
     console.log('Agent login has been succesful');
     ccUserState.classList.remove('disabled');
+    widgetsContainer.appendChild(ccUserState);
 }
 
 function logoutSuccess(){

--- a/docs/web-component-samples/app.js
+++ b/docs/web-component-samples/app.js
@@ -2,6 +2,10 @@ const accessTokenElem = document.getElementById('access_token_elem');
 const ccStationLogin = document.getElementById('cc-station-login');
 const ccUserState = document.getElementById('cc-user-state');
 
+if (!ccStationLogin && !ccUserState) {
+    console.error('Failed to find the required elements');
+}
+
 function switchButtonState(){
     const buttonElem = document.querySelector('button');
     buttonElem.disabled = accessTokenElem.value.trim() === '';

--- a/docs/web-component-samples/index.html
+++ b/docs/web-component-samples/index.html
@@ -24,7 +24,6 @@
     <button onclick="initWidgets()" disabled>Init Widgets</button>
     <div id="widgets-container">
       <widget-cc-station-login class="disabled" id="cc-station-login"></widget-cc-station-login>
-      <widget-cc-user-state class="disabled" id="cc-user-state"></widget-cc-user-state>
     </div>
     <script src="dist/bundle.js"></script>
     <script src="app.js"></script>

--- a/docs/web-component-samples/index.html
+++ b/docs/web-component-samples/index.html
@@ -22,9 +22,9 @@
       autocapitalize="off"
     />
     <button onclick="initWidgets()" disabled>Init Widgets</button>
-    <div id="widgets-container" class="disabled">
-      <widget-cc-station-login id="cc-station-login"></widget-cc-station-login>
-      <widget-cc-user-state></widget-cc-user-state>
+    <div id="widgets-container">
+      <widget-cc-station-login class="disabled" id="cc-station-login"></widget-cc-station-login>
+      <widget-cc-user-state class="disabled" id="cc-user-state"></widget-cc-user-state>
     </div>
     <script src="dist/bundle.js"></script>
     <script src="app.js"></script>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.1",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react-hooks": "^8.0.1",
     "crypto-browserify": "^3.12.1",
     "html-webpack-plugin": "^5.6.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.1",
-    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react-hooks": "^8.0.1",
     "crypto-browserify": "^3.12.1",
     "html-webpack-plugin": "^5.6.3",

--- a/packages/contact-center/station-login/src/helper.ts
+++ b/packages/contact-center/station-login/src/helper.ts
@@ -17,7 +17,9 @@ export const useStationLogin = (props: UseStationLoginProps) => {
     cc.stationLogin({teamId: team, loginOption: deviceType, dialNumber: dialNumber})
       .then((res: StationLoginSuccess) => {
         setLoginSuccess(res);
-        loginCb();
+        if(loginCb){
+          loginCb();
+        }
       }).catch((error: Error) => {
         console.error(error);
         setLoginFailure(error);
@@ -28,7 +30,9 @@ export const useStationLogin = (props: UseStationLoginProps) => {
     cc.stationLogout({logoutReason: 'User requested logout'})
       .then((res: StationLogoutSuccess) => {
         setLogoutSuccess(res);
-        logoutCb();
+        if(logoutCb){
+          logoutCb();
+        }
       }).catch((error: any) => {
         console.error(error);
       });

--- a/packages/contact-center/station-login/src/helper.ts
+++ b/packages/contact-center/station-login/src/helper.ts
@@ -33,7 +33,7 @@ export const useStationLogin = (props: UseStationLoginProps) => {
         if(logoutCb){
           logoutCb();
         }
-      }).catch((error: any) => {
+      }).catch((error: Error) => {
         console.error(error);
       });
   };

--- a/packages/contact-center/station-login/src/station-login/station-login.types.ts
+++ b/packages/contact-center/station-login/src/station-login/station-login.types.ts
@@ -51,12 +51,12 @@ export interface IStationLoginProps {
   /**
    * Callback function to be invoked once the agent login is successful
    */
-  onLogin: () => void;
+  onLogin?: () => void;
 
   /**
    * Callback function to be invoked once the agent login is successful
    */
-  onLogout: () => void;
+  onLogout?: () => void;
 
   /**
    * Handler to set device type

--- a/packages/contact-center/station-login/tests/helper.ts
+++ b/packages/contact-center/station-login/tests/helper.ts
@@ -18,6 +18,10 @@ const loginCb = jest.fn();
 const logoutCb = jest.fn();
 
 describe('useStationLogin Hook', () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   
   it('should set loginSuccess on successful login', async () => {
     const successResponse = {
@@ -77,6 +81,24 @@ describe('useStationLogin Hook', () => {
       loginFailure: undefined,
       logoutSuccess: undefined
     });
+  });
+
+  it('should not call login callback if not present', async () => {
+
+    ccMock.stationLogin.mockResolvedValue({});
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      //@ts-ignore
+      useStationLogin({cc: ccMock, onLogin: undefined, onLogout: logoutCb})
+    );
+
+    act(() => {
+      result.current.login();
+    });
+
+    await waitForNextUpdate();
+
+    expect(loginCb).not.toHaveBeenCalled();
   });
 
   it('should set loginFailure on failed login', async () => {
@@ -162,5 +184,22 @@ describe('useStationLogin Hook', () => {
       loginFailure: undefined,
       logoutSuccess: successResponse
     });
+  });
+
+  it('should not call logout callback if not present', async () => {
+    ccMock.stationLogout.mockResolvedValue({});
+
+    const {result, waitForNextUpdate} = renderHook(() =>
+      //@ts-ignore
+      useStationLogin({cc: ccMock, onLogin: loginCb})
+    );
+
+    act(() => {
+      result.current.logout();
+    });
+
+    await waitForNextUpdate();
+
+    expect(logoutCb).not.toHaveBeenCalled();
   });
 })

--- a/packages/contact-center/station-login/tests/helper.ts
+++ b/packages/contact-center/station-login/tests/helper.ts
@@ -1,4 +1,4 @@
-import {renderHook, act} from '@testing-library/react-hooks';
+import {renderHook, act, waitFor} from '@testing-library/react';
 import {useStationLogin} from '../src/helper';
 
 // Mock webex instance
@@ -49,7 +49,7 @@ describe('useStationLogin Hook', () => {
 
     ccMock.stationLogin.mockResolvedValue(successResponse);
 
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useStationLogin({cc: ccMock, onLogin: loginCb, onLogout: logoutCb})
     );
 
@@ -61,25 +61,25 @@ describe('useStationLogin Hook', () => {
       result.current.login();
     });
 
-    await waitForNextUpdate();
-    
-    expect(ccMock.stationLogin).toHaveBeenCalledWith({
-      teamId: loginParams.teamId,
-      loginOption: loginParams.loginOption,
-      dialNumber: loginParams.dialNumber,
-    });
-    expect(loginCb).toHaveBeenCalledWith();
-
-    expect(result.current).toEqual({
-      name: 'StationLogin',
-      setDeviceType: expect.any(Function),
-      setDialNumber: expect.any(Function),
-      setTeam: expect.any(Function),
-      login: expect.any(Function),
-      logout: expect.any(Function),
-      loginSuccess: successResponse,
-      loginFailure: undefined,
-      logoutSuccess: undefined
+    waitFor(() => {
+      expect(ccMock.stationLogin).toHaveBeenCalledWith({
+        teamId: loginParams.teamId,
+        loginOption: loginParams.loginOption,
+        dialNumber: loginParams.dialNumber,
+      });
+      expect(loginCb).toHaveBeenCalledWith();
+  
+      expect(result.current).toEqual({
+        name: 'StationLogin',
+        setDeviceType: expect.any(Function),
+        setDialNumber: expect.any(Function),
+        setTeam: expect.any(Function),
+        login: expect.any(Function),
+        logout: expect.any(Function),
+        loginSuccess: successResponse,
+        loginFailure: undefined,
+        logoutSuccess: undefined
+      });
     });
   });
 
@@ -87,18 +87,17 @@ describe('useStationLogin Hook', () => {
 
     ccMock.stationLogin.mockResolvedValue({});
 
-    const { result, waitForNextUpdate } = renderHook(() =>
-      //@ts-ignore
-      useStationLogin({cc: ccMock, onLogin: undefined, onLogout: logoutCb})
+    const { result } = renderHook(() =>
+      useStationLogin({cc: ccMock, onLogout: logoutCb})
     );
 
     act(() => {
       result.current.login();
     });
 
-    await waitForNextUpdate();
-
-    expect(loginCb).not.toHaveBeenCalled();
+    waitFor(() => {
+      expect(loginCb).not.toHaveBeenCalled();
+    });
   });
 
   it('should set loginFailure on failed login', async () => {
@@ -106,7 +105,7 @@ describe('useStationLogin Hook', () => {
     ccMock.stationLogin.mockRejectedValue(errorResponse);
 
     loginCb.mockClear();
-    const { result, waitForNextUpdate } = renderHook(() =>
+    const { result } = renderHook(() =>
       useStationLogin({cc: ccMock, onLogin: loginCb, onLogout: logoutCb})
     );
 
@@ -118,26 +117,26 @@ describe('useStationLogin Hook', () => {
       result.current.login();
     });
 
-    await waitForNextUpdate();
-
-    expect(ccMock.stationLogin).toHaveBeenCalledWith({
-      teamId: loginParams.teamId,
-      loginOption: loginParams.loginOption,
-      dialNumber: loginParams.dialNumber,
-    });
-    
-    expect(loginCb).not.toHaveBeenCalledWith();
-
-    expect(result.current).toEqual({
-      name: 'StationLogin',
-      setDeviceType: expect.any(Function),
-      setDialNumber: expect.any(Function),
-      setTeam: expect.any(Function),
-      login: expect.any(Function),
-      logout: expect.any(Function),
-      loginSuccess: undefined,
-      loginFailure: errorResponse,
-      logoutSuccess: undefined
+    waitFor(() => {
+      expect(ccMock.stationLogin).toHaveBeenCalledWith({
+        teamId: loginParams.teamId,
+        loginOption: loginParams.loginOption,
+        dialNumber: loginParams.dialNumber,
+      });
+      
+      expect(loginCb).not.toHaveBeenCalledWith();
+  
+      expect(result.current).toEqual({
+        name: 'StationLogin',
+        setDeviceType: expect.any(Function),
+        setDialNumber: expect.any(Function),
+        setTeam: expect.any(Function),
+        login: expect.any(Function),
+        logout: expect.any(Function),
+        loginSuccess: undefined,
+        loginFailure: errorResponse,
+        logoutSuccess: undefined
+      });
     });
   });
 
@@ -159,7 +158,7 @@ describe('useStationLogin Hook', () => {
 
     ccMock.stationLogout.mockResolvedValue(successResponse);
 
-    const {result, waitForNextUpdate} = renderHook(() =>
+    const {result} = renderHook(() =>
       useStationLogin({cc: ccMock, onLogin: loginCb, onLogout: logoutCb})
     );
 
@@ -167,30 +166,29 @@ describe('useStationLogin Hook', () => {
       result.current.logout();
     });
 
-    await waitForNextUpdate();
+    waitFor(() => {
+      expect(ccMock.stationLogout).toHaveBeenCalledWith({logoutReason: 'User requested logout'});
+      expect(logoutCb).toHaveBeenCalledWith();
 
-    expect(ccMock.stationLogout).toHaveBeenCalledWith({logoutReason: 'User requested logout'});
-    expect(logoutCb).toHaveBeenCalledWith();
 
-
-    expect(result.current).toEqual({
-      name: 'StationLogin',
-      setDeviceType: expect.any(Function),
-      setDialNumber: expect.any(Function),
-      setTeam: expect.any(Function),
-      login: expect.any(Function),
-      logout: expect.any(Function),
-      loginSuccess: undefined,
-      loginFailure: undefined,
-      logoutSuccess: successResponse
+      expect(result.current).toEqual({
+        name: 'StationLogin',
+        setDeviceType: expect.any(Function),
+        setDialNumber: expect.any(Function),
+        setTeam: expect.any(Function),
+        login: expect.any(Function),
+        logout: expect.any(Function),
+        loginSuccess: undefined,
+        loginFailure: undefined,
+        logoutSuccess: successResponse
+      });
     });
   });
 
   it('should not call logout callback if not present', async () => {
     ccMock.stationLogout.mockResolvedValue({});
 
-    const {result, waitForNextUpdate} = renderHook(() =>
-      //@ts-ignore
+    const {result} = renderHook(() =>
       useStationLogin({cc: ccMock, onLogin: loginCb})
     );
 
@@ -198,8 +196,8 @@ describe('useStationLogin Hook', () => {
       result.current.logout();
     });
 
-    await waitForNextUpdate();
-
-    expect(logoutCb).not.toHaveBeenCalled();
+    waitFor(() => {
+      expect(logoutCb).not.toHaveBeenCalled();
+    });
   });
 })

--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -46,8 +46,6 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "//": "We can remove this when we have tests",
-    "passWithNoTests": true,
     "testMatch": [
       "**/tests/**/*.ts",
       "**/tests/**/*.tsx"

--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -1,11 +1,11 @@
 import {makeAutoObservable, observable} from 'mobx';
 import Webex from 'webex';
 import {
-  AgentLogin,
   IContactCenter,
   Profile,
   Team,
   WithWebex,
+  IdleCode,
   InitParams,
   IStore
 } from './store.types';
@@ -14,6 +14,8 @@ class Store implements IStore {
   teams: Team[] = [];
   loginOptions: string[] = [];
   cc: IContactCenter;
+  idleCodes: IdleCode[] = [];
+  agentId: string = '';
 
   constructor() {
     makeAutoObservable(this, {cc: observable.ref});
@@ -24,6 +26,8 @@ class Store implements IStore {
     return this.cc.register().then((response: Profile) => {
       this.teams = response.teams;
       this.loginOptions = response.loginVoiceOptions;
+      this.idleCodes = response.idleCodes;
+      this.agentId = response.agentId;
     }).catch((error) => {
       console.error('Error registering contact center', error);
       return Promise.reject(error);

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -11,10 +11,18 @@ interface WithWebexConfig {
   
 type InitParams = WithWebex | WithWebexConfig;
 
+type IdleCode = {
+    name: string;
+    id: string;
+    isSystem: boolean;
+    isDefault: boolean;
+}
+
 interface IStore {
     teams: Team[];
     loginOptions: string[];
     cc: IContactCenter;
+    idleCodes: IdleCode[];
   
     registerCC(webex: WithWebex['webex']): Promise<Profile>;
     init(params: InitParams): Promise<void>;
@@ -26,6 +34,7 @@ export type {
     Team,
     AgentLogin,
     WithWebex,
+    IdleCode,
     InitParams,
     IStore
 }

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -23,6 +23,7 @@ interface IStore {
     loginOptions: string[];
     cc: IContactCenter;
     idleCodes: IdleCode[];
+    agentId: string;
   
     registerCC(webex: WithWebex['webex']): Promise<Profile>;
     init(params: InitParams): Promise<void>;

--- a/packages/contact-center/store/tests/store.ts
+++ b/packages/contact-center/store/tests/store.ts
@@ -47,7 +47,9 @@ describe('Store', () => {
     it('should set teams and loginOptions on successful register', async () => {
       const mockResponse = {
         teams: [{ id: 'team1', name: 'Team 1' }],
-        loginVoiceOptions: ['option1', 'option2']
+        loginVoiceOptions: ['option1', 'option2'],
+        idleCodes: [{ id: 'code1', name: 'Code 1', isSystem: false, isDefault: false }],
+        agentId: 'agent1'
       };
       mockWebex.cc.register.mockResolvedValue(mockResponse);
 
@@ -55,6 +57,8 @@ describe('Store', () => {
 
       expect(store.teams).toEqual(mockResponse.teams);
       expect(store.loginOptions).toEqual(mockResponse.loginVoiceOptions);
+      expect(store.idleCodes).toEqual(mockResponse.idleCodes);
+      expect(store.agentId).toEqual(mockResponse.agentId);
     });
 
     it('should log an error on failed register', async () => {

--- a/packages/contact-center/store/tests/store.ts
+++ b/packages/contact-center/store/tests/store.ts
@@ -44,7 +44,7 @@ describe('Store', () => {
   });
 
   describe('registerCC', () => {
-    it('should set teams and loginOptions on successful register', async () => {
+    it('should initialise store values on successful register', async () => {
       const mockResponse = {
         teams: [{ id: 'team1', name: 'Team 1' }],
         loginVoiceOptions: ['option1', 'option2'],

--- a/packages/contact-center/user-state/package.json
+++ b/packages/contact-center/user-state/package.json
@@ -49,7 +49,8 @@
     "testMatch": [
       "**/tests/**/*.ts",
       "**/tests/**/*.tsx"
-    ]
+    ],
+    "verbose": true
   },
   "stableVersion": "1.28.0-ccwidgets.1"
 }

--- a/packages/contact-center/user-state/package.json
+++ b/packages/contact-center/user-state/package.json
@@ -46,8 +46,10 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "//": "We can remove this when we have tests",
-    "passWithNoTests": true
+    "testMatch": [
+      "**/tests/**/*.ts",
+      "**/tests/**/*.tsx"
+    ]
   },
   "stableVersion": "1.28.0-ccwidgets.1"
 }

--- a/packages/contact-center/user-state/src/helper.ts
+++ b/packages/contact-center/user-state/src/helper.ts
@@ -6,6 +6,7 @@ export const useUserState = ({idleCodes, agentId, cc}) => {
   const [errorMessage, setErrorMessage] = useState('');
 
   const [elapsedTime, setElapsedTime] = useState(0);
+  const [currentState, setCurrentState] = useState({});
 
   useEffect(() => {
     // Reset the timer whenever the component mounts or the state changes
@@ -18,17 +19,26 @@ export const useUserState = ({idleCodes, agentId, cc}) => {
     return () => clearInterval(timer);
   }, []);
 
-  const setAgentStatus = ({
-    auxCodeId,
-    state
-  }) => {
+  const setAgentStatus = (selectedCode) => {
+    const {
+      auxCodeId,
+      state
+    } = {
+      auxCodeId: selectedCode.id,
+      state: selectedCode.name
+    }
     setIsSettingAgentStatus(true);
+    let oldState = {
+      ...currentState
+    };
+    setCurrentState(selectedCode);
     const chosenState = state === 'Available' ? 'Available' : 'Idle';
     cc.setAgentState({state: chosenState, auxCodeId, agentId, lastStateChangeReason: state}).then((response) => {
       setIsSettingAgentStatus(false);
       setErrorMessage('');
       setElapsedTime(0);
     }).catch(error => {
+      setCurrentState(oldState);
       setErrorMessage(error.toString());
       setIsSettingAgentStatus(false);
     });
@@ -39,6 +49,8 @@ export const useUserState = ({idleCodes, agentId, cc}) => {
     setAgentStatus,
     isSettingAgentStatus,
     errorMessage,
-    elapsedTime
+    elapsedTime,
+    currentState,
+    setCurrentState
   }
 };

--- a/packages/contact-center/user-state/src/helper.ts
+++ b/packages/contact-center/user-state/src/helper.ts
@@ -34,12 +34,12 @@ export const useUserState = ({idleCodes, agentId, cc}) => {
     setCurrentState(selectedCode);
     const chosenState = state === 'Available' ? 'Available' : 'Idle';
     cc.setAgentState({state: chosenState, auxCodeId, agentId, lastStateChangeReason: state}).then((response) => {
-      setIsSettingAgentStatus(false);
       setErrorMessage('');
       setElapsedTime(0);
     }).catch(error => {
       setCurrentState(oldState);
       setErrorMessage(error.toString());
+    }).finally(() => {
       setIsSettingAgentStatus(false);
     });
   };

--- a/packages/contact-center/user-state/src/helper.ts
+++ b/packages/contact-center/user-state/src/helper.ts
@@ -1,11 +1,44 @@
-export const useUserState = () => {
+import {useState, useEffect} from "react";
 
+export const useUserState = ({idleCodes, agentId, cc}) => {
 
-  const handleAgentStatus = (event: { target: { value: string; }; }) => {
+  const [isSettingAgentStatus, setIsSettingAgentStatus] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const [elapsedTime, setElapsedTime] = useState(0);
+
+  useEffect(() => {
+    // Reset the timer whenever the component mounts or the state changes
+    setElapsedTime(0);
+    const timer = setInterval(() => {
+      setElapsedTime(prevTime => prevTime + 1);
+    }, 1000);
+
+    // Cleanup the timer on component unmount
+    return () => clearInterval(timer);
+  }, []);
+
+  const setAgentStatus = ({
+    auxCodeId,
+    state
+  }) => {
+    setIsSettingAgentStatus(true);
+    const chosenState = state === 'Available' ? 'Available' : 'Idle';
+    cc.setAgentState({state: chosenState, auxCodeId, agentId, lastStateChangeReason: state}).then((response) => {
+      setIsSettingAgentStatus(false);
+      setErrorMessage('');
+      setElapsedTime(0);
+    }).catch(error => {
+      setErrorMessage(error.toString());
+      setIsSettingAgentStatus(false);
+    });
   };
 
-  const setAgentStatus = () => {
-  };
-
-  return {name: 'UserState', handleAgentStatus, setAgentStatus};
+  return {
+    idleCodes,
+    setAgentStatus,
+    isSettingAgentStatus,
+    errorMessage,
+    elapsedTime
+  }
 };

--- a/packages/contact-center/user-state/src/user-state/index.tsx
+++ b/packages/contact-center/user-state/src/user-state/index.tsx
@@ -5,13 +5,15 @@ import r2wc from '@r2wc/react-to-web-component';
 
 import {useUserState} from '../helper';
 import UserStatePresentational from './user-state.presentational';
+import {IUserState} from './use-state.types';
 
 const UserState: React.FunctionComponent = observer(() => {
-  const {} = store;
-  const result = useUserState();
-  const props = {
-    ...result,
-  };
+  const {cc, idleCodes, agentId} = store;
+  const props: IUserState = useUserState({
+    idleCodes,
+    agentId,
+    cc
+  });
 
   return <UserStatePresentational {...props} />;
 });

--- a/packages/contact-center/user-state/src/user-state/use-state.types.ts
+++ b/packages/contact-center/user-state/src/user-state/use-state.types.ts
@@ -1,19 +1,19 @@
+import { IdleCode } from '@webex/cc-store';
+
 /**
  * Interface representing the state of a user.
  */
 export interface IUserState {
   /**
-   * The name of the user.
+   * The list of idle codes.
    */
-  name: string;
+  idleCodes: IdleCode[];
 
-  /**
-   * Handler for agent state changes
-   */
-  handleAgentStatus: (event) => void;
+  setAgentStatus: (status: { auxCodeId: string; state: string }) => void;
 
-  /**
-   * Setter for agent state
-   */
-  setAgentStatus: () => void
+  isSettingAgentStatus: boolean;
+
+  errorMessage: string;
+
+  elapsedTime: number;
 }

--- a/packages/contact-center/user-state/src/user-state/use-state.types.ts
+++ b/packages/contact-center/user-state/src/user-state/use-state.types.ts
@@ -9,11 +9,41 @@ export interface IUserState {
    */
   idleCodes: IdleCode[];
 
+  /**
+   * Function to set the agent
+   * status.
+   * @param status The status to set.
+   * @param status.auxCodeId The aux code id.
+   * @param status.state The state to set.
+   * @returns void
+   */
   setAgentStatus: (status: { auxCodeId: string; state: string }) => void;
 
+  /**
+   * Boolean indicating if the agent status is being set.
+   */
   isSettingAgentStatus: boolean;
 
+  /**
+   * The error message to display
+   */
   errorMessage: string;
 
+  /**
+   * The duration of the current user state
+   */
   elapsedTime: number;
+
+  /**
+   * The idle code of the current user state
+   */
+  currentState: IdleCode;
+
+  /**
+   * Function to set the current state
+   * of the user.
+   * @param state The state to set.
+   * @returns void
+   */
+  setCurrentState: (state: IdleCode) => void;
 }

--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -1,14 +1,127 @@
-import React from 'react';
+import React, {CSSProperties, useEffect} from 'react';
 
 import {IUserState} from './use-state.types';
 
 const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => {
-  const {handleAgentStatus, setAgentStatus} = props;
+  const {idleCodes,setAgentStatus,isSettingAgentStatus, errorMessage, elapsedTime} = props;
+
+  const styles = {
+    box: {
+      backgroundColor: '#ffffff',
+      borderRadius: '8px',
+      boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+      padding: '20px',
+      maxWidth: '800px',
+      margin: '0 auto'
+    },
+
+    sectionBox: {
+      padding: '10px',
+      border: '1px solid #ddd',
+      borderRadius: '8px'
+    },
+
+    fieldset:  {
+      border: '1px solid #ccc',
+      borderRadius: '5px',
+      padding: '10px',
+      marginBottom: '20px',
+      position: 'relative'
+    } as CSSProperties,
+
+    legendBox: {
+      fontWeight: 'bold',
+      color: '#0052bf'
+    },
+
+    btn: {
+      padding: '10px 20px',
+      backgroundColor: '#0052bf',
+      color: 'white',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: 'pointer',
+      transition: 'background-color 0.3s',
+      marginRight: '8px'
+    },
+
+    select: {
+      width: '100%',
+      padding: '8px',
+      marginTop: '8px',
+      marginBottom: '12px',
+      border: '1px solid #ccc',
+      borderRadius: '4px'
+    },
+
+    input: {
+      width: '97%',
+      padding: '8px',
+      marginTop: '8px',
+      marginBottom: '12px',
+      border: '1px solid #ccc',
+      borderRadius: '4px'
+    },
+
+    elapsedTime: {
+      position: 'absolute',
+      right: '30px',
+      top: '25px',
+      color: isSettingAgentStatus ? 'grey' : 'black'
+    } as CSSProperties
+  };
+
+  const formatTime = (time) => {
+    const hours = Math.floor(time / 3600);
+    const minutes = Math.floor((time % 3600) / 60);
+    const seconds = time % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  };
 
   return (
     <>
-      <h1 data-testid="user-state-heading">{props.name}</h1>
-      <h4>User State: {}</h4>
+      <div style={styles.box}>
+        <section style={styles.sectionBox}>
+          <fieldset style={styles.fieldset}>
+            <legend style={styles.legendBox}>Agent State</legend>
+            <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}></div>
+            <select
+              id="idleCodes"
+              style={styles.select}
+              onChange={
+                (event) => {
+                  const select = event.target;
+                  const auxCodeId = select.value;
+                  const state = select.options[select.selectedIndex].text;
+                  setAgentStatus({
+                    auxCodeId,
+                    state
+                  });
+                }
+              }
+              disabled={isSettingAgentStatus}
+            >
+              {idleCodes && idleCodes.map((code) => {
+                return !code.isSystem ? (
+                  <option
+                    key={code.id}
+                    value={code.id}
+                    selected={code.isDefault}
+                  >
+                      {code.name}
+                  </option>
+                ): (
+                  <></>
+                );
+              })}
+            </select>
+            <div style={styles.elapsedTime}>{formatTime(elapsedTime)}</div>
+            {
+              errorMessage && <div style={{color: 'red'}}>{errorMessage}</div>
+            }
+          </fieldset>
+        </section>
+      </div>
     </>
   );
 };

--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -1,4 +1,4 @@
-import React, {CSSProperties, useEffect} from 'react';
+import React, {CSSProperties} from 'react';
 
 import {IUserState} from './use-state.types';
 
@@ -101,12 +101,11 @@ const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => 
               }
               disabled={isSettingAgentStatus}
             >
-              {idleCodes && idleCodes.map((code) => {
+              {idleCodes && idleCodes.map((code, index) => {
                 return !code.isSystem ? (
                   <option
-                    key={code.id}
+                    key={index}
                     value={code.id}
-                    selected={code.isDefault}
                   >
                       {code.name}
                   </option>

--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -1,4 +1,4 @@
-import React, {CSSProperties, useMemo} from 'react';
+import React, {CSSProperties, useMemo, useRef} from 'react';
 
 import {IUserState} from './use-state.types';
 
@@ -69,9 +69,10 @@ const getStyles = (isSettingAgentStatus: boolean): Record<string, CSSProperties>
 });
 
 const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => {
-  const {idleCodes,setAgentStatus,isSettingAgentStatus, errorMessage, elapsedTime} = props;
+  const {idleCodes,setAgentStatus,isSettingAgentStatus, errorMessage, elapsedTime, currentState} = props;
 
   const styles = useMemo(() => getStyles(isSettingAgentStatus), [isSettingAgentStatus]);
+  const selectRef = useRef<HTMLSelectElement>(null);
 
   const formatTime = (time: number): string => {
     const hours = Math.floor(time / 3600);
@@ -89,28 +90,26 @@ const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => 
             <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}></div>
             <select
               id="idleCodes"
+              value={currentState.id}
               style={styles.select}
               onChange={
                 (event) => {
-                  const select = event.target;
-                  const auxCodeId = select.value;
-                  const state = select.options[select.selectedIndex].text;
-                  setAgentStatus({
-                    auxCodeId,
-                    state
-                  });
+                  const code = idleCodes?.filter(code => code.id === event.target.value)[0];
+                  setAgentStatus(code);
                 }
               }
               disabled={isSettingAgentStatus}
             >
-              {idleCodes?.filter(code => !code.isSystem).map((code) => (
-                <option
-                  key={code.id}
-                  value={code.id}
-                >
-                    {code.name}
-                </option>
-              ))}
+              {idleCodes?.filter(code => !code.isSystem).map((code) => {
+                return (
+                  <option
+                    key={code.id}
+                    value={code.id}
+                  >
+                      {code.name}
+                  </option>
+                );
+            })}
             </select>
             <div style={styles.elapsedTime}>{formatTime(elapsedTime)}</div>
             {

--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -83,7 +83,7 @@ const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => 
       <div style={styles.box}>
         <section style={styles.sectionBox}>
           <fieldset style={styles.fieldset}>
-            <legend style={styles.legendBox}>Agent State</legend>
+            <legend data-testid='user-state-title' style={styles.legendBox}>Agent State</legend>
             <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}></div>
             <select
               id="idleCodes"

--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -1,77 +1,79 @@
-import React, {CSSProperties} from 'react';
+import React, {CSSProperties, useMemo} from 'react';
 
 import {IUserState} from './use-state.types';
+
+const getStyles = (isSettingAgentStatus: boolean): Record<string, CSSProperties> => ({
+  box: {
+    backgroundColor: '#ffffff',
+    borderRadius: '8px',
+    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+    padding: '20px',
+    maxWidth: '800px',
+    margin: '0 auto'
+  },
+
+  sectionBox: {
+    padding: '10px',
+    border: '1px solid #ddd',
+    borderRadius: '8px'
+  },
+
+  fieldset:  {
+    border: '1px solid #ccc',
+    borderRadius: '5px',
+    padding: '10px',
+    marginBottom: '20px',
+    position: 'relative'
+  } as CSSProperties,
+
+  legendBox: {
+    fontWeight: 'bold',
+    color: '#0052bf'
+  },
+
+  btn: {
+    padding: '10px 20px',
+    backgroundColor: '#0052bf',
+    color: 'white',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    transition: 'background-color 0.3s',
+    marginRight: '8px'
+  },
+
+  select: {
+    width: '100%',
+    padding: '8px',
+    marginTop: '8px',
+    marginBottom: '12px',
+    border: '1px solid #ccc',
+    borderRadius: '4px'
+  },
+
+  input: {
+    width: '97%',
+    padding: '8px',
+    marginTop: '8px',
+    marginBottom: '12px',
+    border: '1px solid #ccc',
+    borderRadius: '4px'
+  },
+
+  elapsedTime: {
+    position: 'absolute',
+    right: '30px',
+    top: '25px',
+    color: isSettingAgentStatus ? 'grey' : 'black'
+  } as CSSProperties
+});
 
 const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => {
   const {idleCodes,setAgentStatus,isSettingAgentStatus, errorMessage, elapsedTime} = props;
 
-  const styles = {
-    box: {
-      backgroundColor: '#ffffff',
-      borderRadius: '8px',
-      boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-      padding: '20px',
-      maxWidth: '800px',
-      margin: '0 auto'
-    },
+  const styles = useMemo(() => getStyles(isSettingAgentStatus), [isSettingAgentStatus]);
 
-    sectionBox: {
-      padding: '10px',
-      border: '1px solid #ddd',
-      borderRadius: '8px'
-    },
-
-    fieldset:  {
-      border: '1px solid #ccc',
-      borderRadius: '5px',
-      padding: '10px',
-      marginBottom: '20px',
-      position: 'relative'
-    } as CSSProperties,
-
-    legendBox: {
-      fontWeight: 'bold',
-      color: '#0052bf'
-    },
-
-    btn: {
-      padding: '10px 20px',
-      backgroundColor: '#0052bf',
-      color: 'white',
-      border: 'none',
-      borderRadius: '4px',
-      cursor: 'pointer',
-      transition: 'background-color 0.3s',
-      marginRight: '8px'
-    },
-
-    select: {
-      width: '100%',
-      padding: '8px',
-      marginTop: '8px',
-      marginBottom: '12px',
-      border: '1px solid #ccc',
-      borderRadius: '4px'
-    },
-
-    input: {
-      width: '97%',
-      padding: '8px',
-      marginTop: '8px',
-      marginBottom: '12px',
-      border: '1px solid #ccc',
-      borderRadius: '4px'
-    },
-
-    elapsedTime: {
-      position: 'absolute',
-      right: '30px',
-      top: '25px',
-      color: isSettingAgentStatus ? 'grey' : 'black'
-    } as CSSProperties
-  };
-
-  const formatTime = (time) => {
+  const formatTime = (time: number): string => {
     const hours = Math.floor(time / 3600);
     const minutes = Math.floor((time % 3600) / 60);
     const seconds = time % 60;
@@ -101,18 +103,14 @@ const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => 
               }
               disabled={isSettingAgentStatus}
             >
-              {idleCodes && idleCodes.map((code, index) => {
-                return !code.isSystem ? (
-                  <option
-                    key={index}
-                    value={code.id}
-                  >
-                      {code.name}
-                  </option>
-                ): (
-                  <></>
-                );
-              })}
+              {idleCodes?.filter(code => !code.isSystem).map((code) => (
+                <option
+                  key={code.id}
+                  value={code.id}
+                >
+                    {code.name}
+                </option>
+              ))}
             </select>
             <div style={styles.elapsedTime}>{formatTime(elapsedTime)}</div>
             {

--- a/packages/contact-center/user-state/tests/helper.ts
+++ b/packages/contact-center/user-state/tests/helper.ts
@@ -25,10 +25,12 @@ describe('useUserState Hook', () => {
   it('should initialize with default values', () => {
     const { result } = renderHook(() => useUserState({ idleCodes, agentId, cc: mockCC }));
 
-    expect(result.current.isSettingAgentStatus).toBe(false);
-    expect(result.current.errorMessage).toBe('');
-    expect(result.current.elapsedTime).toBe(0);
-    expect(result.current.currentState).toEqual({});
+    expect(result.current).toMatchObject({
+      isSettingAgentStatus: false,
+      errorMessage: '',
+      elapsedTime: 0,
+      currentState: {}
+    });
   });
 
   it('should increment elapsedTime every second', () => {
@@ -47,11 +49,11 @@ describe('useUserState Hook', () => {
 
     act(() => {
       result.current.setAgentStatus(idleCodes[1]);
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(3000);
     });
 
-    waitFor(() => {
-      expect(result.current.elapsedTime).toBe(0);
+    await waitFor(() => {
+      expect(result.current.elapsedTime).toBe(3);
     });
   });
 
@@ -65,10 +67,12 @@ describe('useUserState Hook', () => {
 
     expect(result.current.isSettingAgentStatus).toBe(true);
 
-    waitFor(() => {
-      expect(result.current.isSettingAgentStatus).toBe(false);
-      expect(result.current.errorMessage).toBe('');
-      expect(result.current.currentState).toEqual(idleCodes[1]);
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        isSettingAgentStatus: false,
+        errorMessage: '',
+        currentState: idleCodes[1]
+      });
     });
   });
 
@@ -81,10 +85,12 @@ describe('useUserState Hook', () => {
       result.current.setAgentStatus(idleCodes[1]);
     });
 
-    waitFor(() => {
-      expect(result.current.isSettingAgentStatus).toBe(false);
-      expect(result.current.errorMessage).toBe(`Error: ${errorMsg}`);
-      expect(result.current.currentState).toEqual({});
+    await waitFor(() => {
+      expect(result.current).toMatchObject({
+        isSettingAgentStatus: false,
+        errorMessage: `Error: ${errorMsg}`,
+        currentState: {}
+      });
     });
   });
 });

--- a/packages/contact-center/user-state/tests/helper.ts
+++ b/packages/contact-center/user-state/tests/helper.ts
@@ -1,4 +1,5 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react'; // Import act from react
 import { useUserState } from '../src/helper'; // adjust the path accordingly
 
 jest.useFakeTimers();
@@ -12,7 +13,7 @@ describe('useUserState', () => {
     };
   });
 
-  test('should initialize with correct default values', () => {
+  it('should initialize with correct default values', () => {
     const { result } = renderHook(() => useUserState({ idleCodes: [], agentId: '123', cc: ccMock }));
     
     expect(result.current.isSettingAgentStatus).toBe(false);
@@ -20,7 +21,7 @@ describe('useUserState', () => {
     expect(result.current.elapsedTime).toBe(0);
   });
 
-  test('should update elapsedTime every second', () => {
+  it('should update elapsedTime every second', () => {
     const { result } = renderHook(() => useUserState({ idleCodes: [], agentId: '123', cc: ccMock }));
     
     act(() => {
@@ -30,7 +31,7 @@ describe('useUserState', () => {
     expect(result.current.elapsedTime).toBe(3);
   });
 
-  test('setAgentStatus should handle success', async () => {
+  it('setAgentStatus should handle success', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useUserState({ idleCodes: [], agentId: '123', cc: ccMock }));
     
     act(() => {
@@ -51,7 +52,7 @@ describe('useUserState', () => {
     expect(result.current.elapsedTime).toBe(0);
   });
 
-  test('setAgentStatus should handle error', async () => {
+  it('setAgentStatus should handle error', async () => {
     ccMock.setAgentState.mockRejectedValueOnce(new Error('Network error'));
     const { result, waitForNextUpdate } = renderHook(() => useUserState({ idleCodes: [], agentId: '123', cc: ccMock }));
 

--- a/packages/contact-center/user-state/tests/user-state/index.tsx
+++ b/packages/contact-center/user-state/tests/user-state/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {UserState} from '../../src';
+import * as helper from '../../src/helper';
+import '@testing-library/jest-dom';
+
+// Mock the store import
+jest.mock('@webex/cc-store', () => {return {
+  cc: {}
+}});
+
+describe('UserState Component', () => {
+  it('renders UserStatePresentational with correct props', () => {
+    const useUserStateSpy = jest.spyOn(helper, 'useUserState');
+    
+    render(<UserState/>);
+
+    expect(useUserStateSpy).toHaveBeenCalledWith({cc: {}});
+    const heading = screen.getByTestId('user-state-title');
+    expect(heading).toHaveTextContent('Agent State');
+  });
+});

--- a/packages/contact-center/user-state/tests/user-state/index.tsx
+++ b/packages/contact-center/user-state/tests/user-state/index.tsx
@@ -6,7 +6,9 @@ import '@testing-library/jest-dom';
 
 // Mock the store import
 jest.mock('@webex/cc-store', () => {return {
-  cc: {}
+  cc: {},
+  idleCodes: [],
+  agentId: 'testAgentId'
 }});
 
 describe('UserState Component', () => {
@@ -15,7 +17,7 @@ describe('UserState Component', () => {
     
     render(<UserState/>);
 
-    expect(useUserStateSpy).toHaveBeenCalledWith({cc: {}});
+    expect(useUserStateSpy).toHaveBeenCalledWith({cc: {}, idleCodes: [], agentId: 'testAgentId'});
     const heading = screen.getByTestId('user-state-title');
     expect(heading).toHaveTextContent('Agent State');
   });

--- a/packages/contact-center/user-state/tests/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/tests/user-state/user-state.presentational.tsx
@@ -5,36 +5,58 @@ import UserStatePresentational from '../../src/user-state/user-state.presentatio
 
 describe('UserStatePresentational Component', () => {
   const mockSetAgentStatus = jest.fn();
-  const mockIdleCodes = [
-    { id: '1', name: 'Available', isSystem: false, isDefault: true },
-    { id: '2', name: 'On Break', isSystem: false, isDefault: false },
-  ];
+  const mockSetCurrentState = jest.fn();
+  const defaultProps = {
+    idleCodes: [
+      { id: '1', name: 'Idle Code 1', isSystem: false },
+      { id: '2', name: 'Idle Code 2', isSystem: true },
+      { id: '3', name: 'Idle Code 3', isSystem: false }
+    ],
+    setAgentStatus: mockSetAgentStatus,
+    isSettingAgentStatus: false,
+    errorMessage: '',
+    elapsedTime: 3661, // 1 hour, 1 minute, 1 second
+    currentState: { id: '1' },
+    setCurrentState: mockSetCurrentState
+  };
 
-  it('renders without crashing', () => {
-    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3600} />);
-    expect(screen.getByText('Agent State')).toBeInTheDocument();
-  });
-
-  it('displays the correct default option', () => {
-    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3600} />);
-    const selectElement = screen.getByRole('combobox');
-    expect(selectElement.value).toBe('1');
-  });
-
-  it('calls setAgentStatus with the correct parameters', () => {
-    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3600} />);
-    const selectElement = screen.getByRole('combobox');
-    fireEvent.change(selectElement, { target: { value: '2' } });
-    expect(mockSetAgentStatus).toHaveBeenCalledWith({ auxCodeId: '2', state: 'On Break' });
-  });
-
-  it('displays an error message when provided', () => {
-    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="Error occurred" elapsedTime={3600} />);
-    expect(screen.getByText('Error occurred')).toBeInTheDocument();
-  });
-
-  it('formats elapsed time correctly', () => {
-    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3661} />);
+  it('should render the component with correct elements', () => {
+    render(<UserStatePresentational {...defaultProps} />);
+    expect(screen.getByTestId('user-state-title')).toHaveTextContent('Agent State');
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getByText('01:01:01')).toBeInTheDocument();
+  });
+
+  it('should render only non-system idle codes in the dropdown', () => {
+    render(<UserStatePresentational {...defaultProps} />);
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('Idle Code 1');
+    expect(options[1]).toHaveTextContent('Idle Code 3');
+  });
+
+  it('should call setAgentStatus with correct code when an idle code is selected', () => {
+    render(<UserStatePresentational {...defaultProps} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '3' } });
+    expect(mockSetAgentStatus).toHaveBeenCalledWith({ id: '3', name: 'Idle Code 3', isSystem: false });
+  });
+
+  it('should display an error message if provided', () => {
+    render(<UserStatePresentational {...defaultProps} errorMessage="Error message" />);
+    expect(screen.getByText('Error message')).toBeInTheDocument();
+    expect(screen.getByText('Error message')).toHaveStyle('color: red');
+  });
+
+  it('should disable the select box when isSettingAgentStatus is true', () => {
+    render(<UserStatePresentational {...{ ...defaultProps, isSettingAgentStatus: true }} />);
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('should render elapsed time in correct color based on isSettingAgentStatus', () => {
+    const { rerender } = render(<UserStatePresentational {...defaultProps} />);
+    expect(screen.getByText('01:01:01')).toHaveStyle('color: black');
+
+    rerender(<UserStatePresentational {...{ ...defaultProps, isSettingAgentStatus: true }} />);
+    expect(screen.getByText('01:01:01')).toHaveStyle('color: grey');
   });
 });

--- a/packages/contact-center/user-state/tests/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/tests/user-state/user-state.presentational.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import UserStatePresentational from '../../src/user-state/user-state.presentational';
+
+describe('UserStatePresentational Component', () => {
+  const mockSetAgentStatus = jest.fn();
+  const mockIdleCodes = [
+    { id: '1', name: 'Available', isSystem: false, isDefault: true },
+    { id: '2', name: 'On Break', isSystem: false, isDefault: false },
+  ];
+
+  it('renders without crashing', () => {
+    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3600} />);
+    expect(screen.getByText('Agent State')).toBeInTheDocument();
+  });
+
+  it('displays the correct default option', () => {
+    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3600} />);
+    const selectElement = screen.getByRole('combobox');
+    expect(selectElement.value).toBe('1');
+  });
+
+  it('calls setAgentStatus with the correct parameters', () => {
+    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3600} />);
+    const selectElement = screen.getByRole('combobox');
+    fireEvent.change(selectElement, { target: { value: '2' } });
+    expect(mockSetAgentStatus).toHaveBeenCalledWith({ auxCodeId: '2', state: 'On Break' });
+  });
+
+  it('displays an error message when provided', () => {
+    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="Error occurred" elapsedTime={3600} />);
+    expect(screen.getByText('Error occurred')).toBeInTheDocument();
+  });
+
+  it('formats elapsed time correctly', () => {
+    render(<UserStatePresentational idleCodes={mockIdleCodes} setAgentStatus={mockSetAgentStatus} isSettingAgentStatus={false} errorMessage="" elapsedTime={3661} />);
+    expect(screen.getByText('01:01:01')).toBeInTheDocument();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,21 +3977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:^6.6.3":
-  version: 6.6.3
-  resolution: "@testing-library/jest-dom@npm:6.6.3"
-  dependencies:
-    "@adobe/css-tools": "npm:^4.4.0"
-    aria-query: "npm:^5.0.0"
-    chalk: "npm:^3.0.0"
-    css.escape: "npm:^1.5.1"
-    dom-accessibility-api: "npm:^0.6.3"
-    lodash: "npm:^4.17.21"
-    redent: "npm:^3.0.0"
-  checksum: 10c0/5566b6c0b7b0709bc244aec3aa3dc9e5f4663e8fb2b99d8cd456fc07279e59db6076cbf798f9d3099a98fca7ef4cd50e4e1f4c4dec5a60a8fad8d24a638a5bf6
-  languageName: node
-  linkType: hard
-
 "@testing-library/react-hooks@npm:^8.0.1":
   version: 8.0.1
   resolution: "@testing-library/react-hooks@npm:8.0.1"
@@ -25838,7 +25823,6 @@ __metadata:
     "@semantic-release/exec": "npm:^6.0.3"
     "@semantic-release/git": "npm:^10.0.1"
     "@semantic-release/github": "npm:^11.0.1"
-    "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react-hooks": "npm:^8.0.1"
     crypto-browserify: "npm:^3.12.1"
     html-webpack-plugin: "npm:^5.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,6 +3977,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/jest-dom@npm:^6.6.3":
+  version: 6.6.3
+  resolution: "@testing-library/jest-dom@npm:6.6.3"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    chalk: "npm:^3.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    lodash: "npm:^4.17.21"
+    redent: "npm:^3.0.0"
+  checksum: 10c0/5566b6c0b7b0709bc244aec3aa3dc9e5f4663e8fb2b99d8cd456fc07279e59db6076cbf798f9d3099a98fca7ef4cd50e4e1f4c4dec5a60a8fad8d24a638a5bf6
+  languageName: node
+  linkType: hard
+
 "@testing-library/react-hooks@npm:^8.0.1":
   version: 8.0.1
   resolution: "@testing-library/react-hooks@npm:8.0.1"
@@ -25823,6 +25838,7 @@ __metadata:
     "@semantic-release/exec": "npm:^6.0.3"
     "@semantic-release/git": "npm:^10.0.1"
     "@semantic-release/github": "npm:^11.0.1"
+    "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react-hooks": "npm:^8.0.1"
     crypto-browserify: "npm:^3.12.1"
     html-webpack-plugin: "npm:^5.6.3"


### PR DESCRIPTION
# Closes [SPARK-584812](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-584812)

# This PR addresses

- User State KS UI
- User State change functionality
- Show User State Widget in the Sample app using the `onLogin` callback of Station Login Widget
- Elapsed time of currently set state.
- Respective Unit Tests

# Pending Items

- KeepAlive for Timer (Working on understanding WxCC Code Changes)

# Manual Tests Done

- Changing the Agent State
- Adding a custom agent state on the admin portal, listing it and changing to that state from the Widget
- Changing the Agent State via the Widget and Seeing it reflected in the WxCC Desktop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced user login state management, allowing conditional rendering of user-related components.
	- Enhanced `UserState` component to utilize specific properties for better data handling.
	- Added new properties for agent status management, including elapsed time and error messages.

- **Bug Fixes**
	- Improved error handling in the login/logout processes to prevent runtime issues.

- **Tests**
	- Expanded test coverage for the `useUserState` hook and `UserState` component, ensuring robust functionality and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->