### PR TITLE
fix: cleanup and using mobx-react-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:unit": "yarn run test:tooling && yarn run test:cc-widgets",
     "test:tooling": "jest --coverage",
     "test:cc-widgets": "yarn workspaces foreach --all --parallel --exclude webex-widgets --exclude @webex/web-component-samples-app --exclude @webex/react-samples-app run test:unit",
-    "build": " yarn run clean:dist && yarn workspaces foreach --all --topological --parallel --exclude webex-widgets  --exclude @webex/web-component-samples-app --exclude @webex/react-samples-app  run build:src",
+    "build": "yarn workspaces foreach --all --topological --parallel --exclude webex-widgets  --exclude @webex/web-component-samples-app --exclude @webex/react-samples-app  run build:src",
     "samples:build": "yarn workspace @webex/react-samples-app build:src && yarn workspace @webex/web-component-samples-app build:src",
     "samples:serve": "open docs/index.html && yarn workspace @webex/react-samples-app serve",
     "samples:serve-react": "yarn workspace @webex/react-samples-app serve",

--- a/packages/contact-center/cc-widgets/package.json
+++ b/packages/contact-center/cc-widgets/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist && rm -rf node_modules",
     "clean:dist": "rm -rf dist",
     "build": "yarn run -T tsc",
-    "build:src": "webpack",
+    "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
     "test:unit": "jest"
   },
@@ -45,7 +45,6 @@
     "file-loader": "6.2.0",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
-    "mobx-react": "9.1.1",
     "os-browserify": "^0.3.0",
     "process": "^0.11.10",
     "querystring-es3": "^0.2.1",
@@ -66,7 +65,10 @@
     "testMatch": [
       "**/tests/**/*.ts",
       "**/tests/**/*.tsx"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^.+\\.(css|less|scss)$": "babel-jest"
+    }
   },
   "stableVersion": "1.28.0-ccwidgets.6"
 }

--- a/packages/contact-center/station-login/package.json
+++ b/packages/contact-center/station-login/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist && rm -rf node_modules",
     "clean:dist": "rm -rf dist",
     "build": "yarn run -T tsc",
-    "build:src": "webpack",
+    "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
     "test:unit": "jest"
   },
   "dependencies": {
     "@webex/cc-store": "workspace:*",
-    "mobx-react": "9.1.1"
+    "mobx-react-lite": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",
@@ -53,7 +53,10 @@
       "**/tests/**/*.ts",
       "**/tests/**/*.tsx"
     ],
-    "verbose": true
+    "verbose": true,
+    "moduleNameMapper": {
+      "^.+\\.(css|less|scss)$": "babel-jest"
+    }
   },
   "stableVersion": "1.28.0-ccwidgets.6"
 }

--- a/packages/contact-center/station-login/src/station-login/index.tsx
+++ b/packages/contact-center/station-login/src/station-login/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import store from '@webex/cc-store';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 
 import StationLoginPresentational from './station-login.presentational';
 import {useStationLogin} from '../helper';
@@ -9,9 +9,6 @@ import {StationLoginProps} from './station-login.types';
 const StationLogin: React.FunctionComponent<StationLoginProps> = observer(({onLogin, onLogout}) => {
   const {cc, teams, loginOptions} = store;
   const result = useStationLogin({cc, onLogin, onLogout});
-
-  console.log('StationLogin: Teams >>', teams);
-  console.log('StationLogin: Login Options >>', loginOptions);
 
   const props = {
     ...result,

--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf dist && rm -rf node_modules",
     "clean:dist": "rm -rf dist",
     "build": "yarn run -T tsc",
-    "build:src": "webpack",
+    "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
     "test:unit": "jest"
   },

--- a/packages/contact-center/task/package.json
+++ b/packages/contact-center/task/package.json
@@ -11,16 +11,16 @@
     "package.json"
   ],
   "scripts": {
+    "clean": "rm -rf dist && rm -rf node_modules",
+    "clean:dist": "rm -rf dist",
     "build": "yarn run -T tsc",
-    "build:src": "webpack && yarn run build",
+    "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
     "test:unit": "jest --coverage"
   },
   "dependencies": {
     "@webex/cc-store": "workspace:*",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "typescript": "5.6.3",
+    "mobx-react-lite": "^4.1.0",
     "webex": "3.7.0-wxcc.5"
   },
   "devDependencies": {
@@ -39,16 +39,24 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "ts-loader": "9.5.1",
+    "typescript": "5.6.3",
     "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "6.0.1"
+  },
+  "peerDependencies": {
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "jest": {
     "testEnvironment": "jsdom",
     "testMatch": [
       "**/tests/**/*.ts",
       "**/tests/**/*.tsx"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^.+\\.(css|less|scss)$": "babel-jest"
+    }
   },
   "stableVersion": "1.28.0-ccwidgets.6"
 }

--- a/packages/contact-center/task/src/IncomingTask/index.tsx
+++ b/packages/contact-center/task/src/IncomingTask/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 
 import store from '@webex/cc-store';
 import {useIncomingTask} from '../helper';

--- a/packages/contact-center/task/src/TaskList/index.tsx
+++ b/packages/contact-center/task/src/TaskList/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import store from '@webex/cc-store';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 
 import TaskListPresentational from './task-list.presentational';
 import {useTaskList} from '../helper';

--- a/packages/contact-center/task/webpack.config.js
+++ b/packages/contact-center/task/webpack.config.js
@@ -9,4 +9,9 @@ module.exports = merge(baseConfig, {
     filename: 'index.js', // Set the output filename to index.js
     libraryTarget: 'commonjs2',
   },
+  externals: {
+    react: 'react',
+    'react-dom': 'react-dom',
+    '@webex/cc-store': '@webex/cc-store',
+  }
 });

--- a/packages/contact-center/user-state/package.json
+++ b/packages/contact-center/user-state/package.json
@@ -14,13 +14,13 @@
     "clean": "rm -rf dist && rm -rf node_modules",
     "clean:dist": "rm -rf dist",
     "build": "yarn run -T tsc",
-    "build:src": "webpack",
+    "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
     "test:unit": "jest"
   },
   "dependencies": {
     "@webex/cc-store": "workspace:*",
-    "mobx-react": "9.1.1",
+    "mobx-react-lite": "^4.1.0",
     "typescript": "5.6.3"
   },
   "devDependencies": {

--- a/packages/contact-center/user-state/src/user-state/index.tsx
+++ b/packages/contact-center/user-state/src/user-state/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import store from '@webex/cc-store';
-import {observer} from 'mobx-react';
+import {observer} from 'mobx-react-lite';
 
 import {useUserState} from '../helper';
 import UserStatePresentational from './user-state.presentational';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5396,7 +5396,7 @@ __metadata:
     file-loader: "npm:6.2.0"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    mobx-react: "npm:9.1.1"
+    mobx-react-lite: "npm:^4.1.0"
     ts-loader: "npm:9.5.1"
     typescript: "npm:5.6.3"
     webpack: "npm:5.94.0"
@@ -5455,14 +5455,16 @@ __metadata:
     file-loader: "npm:6.2.0"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    react: "npm:18.3.1"
-    react-dom: "npm:18.3.1"
+    mobx-react-lite: "npm:^4.1.0"
     ts-loader: "npm:9.5.1"
     typescript: "npm:5.6.3"
     webex: "npm:3.7.0-wxcc.5"
     webpack: "npm:5.94.0"
     webpack-cli: "npm:5.1.4"
     webpack-merge: "npm:6.0.1"
+  peerDependencies:
+    react: ">=18.3.1"
+    react-dom: ">=18.3.1"
   languageName: unknown
   linkType: soft
 
@@ -5485,7 +5487,7 @@ __metadata:
     file-loader: "npm:6.2.0"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    mobx-react: "npm:9.1.1"
+    mobx-react-lite: "npm:^4.1.0"
     ts-loader: "npm:9.5.1"
     typescript: "npm:5.6.3"
     webpack: "npm:5.94.0"
@@ -5521,7 +5523,6 @@ __metadata:
     file-loader: "npm:6.2.0"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
-    mobx-react: "npm:9.1.1"
     os-browserify: "npm:^0.3.0"
     process: "npm:^0.11.10"
     querystring-es3: "npm:^0.2.1"
@@ -19106,7 +19107,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mobx-react-lite@npm:^4.0.7":
+"mobx-react-lite@npm:^4.1.0":
   version: 4.1.0
   resolution: "mobx-react-lite@npm:4.1.0"
   dependencies:
@@ -19120,23 +19121,6 @@ __metadata:
     react-native:
       optional: true
   checksum: 10c0/72300665cc64d73a58d650bdf5131878376a865ae708cabc2940ee22cf6b762aeed239a83ea104ea3742a0b1563a81a19acc02f162e19f524a9b5b0f0a86668e
-  languageName: node
-  linkType: hard
-
-"mobx-react@npm:9.1.1":
-  version: 9.1.1
-  resolution: "mobx-react@npm:9.1.1"
-  dependencies:
-    mobx-react-lite: "npm:^4.0.7"
-  peerDependencies:
-    mobx: ^6.9.0
-    react: ^16.8.0 || ^17 || ^18
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 10c0/77ced87e1657c949e73ff0386ce50b90c53ef4ced36c9cca53dfad693a3e13bc5690c513b855eb486c558191d7a05ee953e73c593054e915ee016fc4516310f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
JIRA - [SPARK-601658](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-601658)

- Fixes the build and other commands in the `cc-task` package
- Fixes the dependencies in multiple packages to ensure proper dependencies
- Uses `mobx-react-lite` instead of `mobx-react` as we are only using functional components
- Fixes broken UT with jest config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
  - Replaced `mobx-react` with `mobx-react-lite` in multiple packages
  - Updated React-related peer dependencies

- **Build Process Improvements**
  - Added `clean:dist` step before webpack builds across multiple packages
  - Enhanced build scripts to ensure clean build environments

- **Testing Configuration**
  - Updated Jest configurations to handle CSS, LESS, and SCSS files

- **Webpack Configuration**
  - Added external dependencies configuration to reduce bundle size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->