### PR TITLE
chore(pipeline): persist dist for all cc folders

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - packages/contact-center/station-login/dist
-            - packages/contact-center/store/dist
-            - packages/contact-center/user-state/dist
+            - packages/contact-center/*/dist
             - packages/@webex/widgets/dist
 
   docs:


### PR DESCRIPTION
# Closes Adhoc

# This PR addresses

- The new and upcoming widgets not being published issue

# by making the following changes

- Updating the pipeline with appropriate persistence path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CircleCI configuration to use a more flexible wildcard pattern for persisting workspace artifacts in the contact center packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->