### PR TITLE
fix: rename agent state to user state

### DIFF
--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -85,7 +85,7 @@ const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => 
       <div style={styles.box}>
         <section style={styles.sectionBox}>
           <fieldset style={styles.fieldset}>
-            <legend data-testid='user-state-title' style={styles.legendBox}>Agent State</legend>
+            <legend data-testid='user-state-title' style={styles.legendBox}>User State</legend>
             <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}></div>
             <select
               id="idleCodes"

--- a/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
+++ b/packages/contact-center/user-state/src/user-state/user-state.presentational.tsx
@@ -82,10 +82,11 @@ const UserStatePresentational: React.FunctionComponent<IUserState> = (props) => 
 
   return (
     <>
+      {/* Adding this comment for publishing a commit */}
       <div style={styles.box}>
         <section style={styles.sectionBox}>
           <fieldset style={styles.fieldset}>
-            <legend data-testid='user-state-title' style={styles.legendBox}>User State</legend>
+            <legend data-testid='user-state-title' style={styles.legendBox}>Agent State</legend>
             <div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}></div>
             <select
               id="idleCodes"


### PR DESCRIPTION
The earlier PR was of type chore which will make semantic release not publish the widgets. Therefore merging a PR of commit type fix for that