### PR TITLE
feat(widgets): added-agent-rona-popup

### DIFF
--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -52,7 +52,6 @@ interface IStore {
 
 interface IStoreWrapper extends IStore{
     store: IStore;
-    onTaskRejected?: (reason: string) => void;
     setCurrentTask(task: any): void;
     setWrapupRequired(value: boolean): void;
     setTaskList(taskList: ITask[]): void;

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -52,6 +52,7 @@ interface IStore {
 
 interface IStoreWrapper extends IStore{
     store: IStore;
+    onTaskRejected?: (reason: string) => void;
     setCurrentTask(task: any): void;
     setWrapupRequired(value: boolean): void;
     setTaskList(taskList: ITask[]): void;

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -5,6 +5,7 @@ import {runInAction} from 'mobx';
 
 class StoreWrapper implements IStoreWrapper {
   store: IStore;
+  onTaskRejected?: (reason: string) => void;
 
   constructor() {
     this.store = Store.getInstance();
@@ -183,7 +184,13 @@ class StoreWrapper implements IStoreWrapper {
 
     // When we receive TASK_REJECT sdk changes the agent status
     // When we receive TASK_REJECT that means the task was not accepted by the agent and we wont need wrap up
-    task.on(TASK_EVENTS.TASK_REJECT, () => this.handleTaskRemove(task.data.interactionId));
+    task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => {
+      // Call the user defined callback first if available
+      if (this.onTaskRejected) {
+        this.onTaskRejected(reason || 'No reason provided');
+      }
+      this.handleTaskRemove(task.data.interactionId);
+    });
 
     this.setTaskList([...this.store.taskList, task]);
   };
@@ -214,7 +221,13 @@ class StoreWrapper implements IStoreWrapper {
 
     // When we receive TASK_REJECT sdk changes the agent status
     // When we receive TASK_REJECT that means the task was not accepted by the agent and we wont need wrap up
-    task.on(TASK_EVENTS.TASK_REJECT, () => this.handleTaskRemove(task.data.interactionId));
+    task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => {
+      // Call the user defined callback first if available
+      if (this.onTaskRejected) {
+        this.onTaskRejected(reason || 'No reason provided');
+      }
+      this.handleTaskRemove(task.data.interactionId);
+    });
 
     if (!this.store.taskList.some((t) => t.data.interactionId === task.data.interactionId)) {
       this.setTaskList([...this.store.taskList, task]);

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -115,6 +115,10 @@ class StoreWrapper implements IStoreWrapper {
     this.store.wrapupCodes = wrapupCodes;
   };
 
+  setTaskRejected = (callback: ((reason: string) => void) | undefined): void => {
+    this.onTaskRejected = callback;
+  };
+
   init(options: InitParams): Promise<void> {
     return this.store.init(options, this.setupIncomingTaskHandler);
   }

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -184,13 +184,9 @@ class StoreWrapper implements IStoreWrapper {
 
     // When we receive TASK_REJECT sdk changes the agent status
     // When we receive TASK_REJECT that means the task was not accepted by the agent and we wont need wrap up
-    task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => {
-      // Call the user defined callback first if available
-      if (this.onTaskRejected) {
-        this.onTaskRejected(reason || 'No reason provided');
-      }
-      this.handleTaskRemove(task.data.interactionId);
-    });
+    task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => 
+      this.handleTaskReject(task, reason)
+    );
 
     this.setTaskList([...this.store.taskList, task]);
   };
@@ -221,13 +217,9 @@ class StoreWrapper implements IStoreWrapper {
 
     // When we receive TASK_REJECT sdk changes the agent status
     // When we receive TASK_REJECT that means the task was not accepted by the agent and we wont need wrap up
-    task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => {
-      // Call the user defined callback first if available
-      if (this.onTaskRejected) {
-        this.onTaskRejected(reason || 'No reason provided');
-      }
-      this.handleTaskRemove(task.data.interactionId);
-    });
+    task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => 
+      this.handleTaskReject(task, reason)
+    );
 
     if (!this.store.taskList.some((t) => t.data.interactionId === task.data.interactionId)) {
       this.setTaskList([...this.store.taskList, task]);
@@ -247,6 +239,13 @@ class StoreWrapper implements IStoreWrapper {
       return;
     }
   };
+
+  handleTaskReject = (task: ITask, reason: string) => {
+    if (this.onTaskRejected) {
+      this.onTaskRejected(reason || 'No reason provided');
+    }
+    this.handleTaskRemove(task.data.interactionId);
+  }
 
   setupIncomingTaskHandler = (ccSDK: any) => {
     ccSDK.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -189,7 +189,7 @@ class StoreWrapper implements IStoreWrapper {
     // When we receive TASK_REJECT sdk changes the agent status
     // When we receive TASK_REJECT that means the task was not accepted by the agent and we wont need wrap up
     task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => 
-      this.handleTaskReject(task, reason)
+      this.handleTaskReject(task.data.interactionId, reason)
     );
 
     this.setTaskList([...this.store.taskList, task]);
@@ -222,7 +222,7 @@ class StoreWrapper implements IStoreWrapper {
     // When we receive TASK_REJECT sdk changes the agent status
     // When we receive TASK_REJECT that means the task was not accepted by the agent and we wont need wrap up
     task.on(TASK_EVENTS.TASK_REJECT, (reason: string) => 
-      this.handleTaskReject(task, reason)
+      this.handleTaskReject(task.data.interactionId, reason)
     );
 
     if (!this.store.taskList.some((t) => t.data.interactionId === task.data.interactionId)) {
@@ -244,11 +244,11 @@ class StoreWrapper implements IStoreWrapper {
     }
   };
 
-  handleTaskReject = (task: ITask, reason: string) => {
+  handleTaskReject = (taskId: string, reason: string) => {
     if (this.onTaskRejected) {
       this.onTaskRejected(reason || 'No reason provided');
     }
-    this.handleTaskRemove(task.data.interactionId);
+    this.handleTaskRemove(taskId);
   }
 
   setupIncomingTaskHandler = (ccSDK: any) => {

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -608,5 +608,28 @@ describe('storeEventsWrapper', () => {
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(CC_EVENTS.AGENT_STATE_CHANGE, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(CC_EVENTS.AGENT_MULTI_LOGIN, expect.any(Function));
     });
+
+    it('should handle task rejection event and call onTaskRejected with the provided reason', () => {
+      const rejectTask: ITask = {
+        data: { interactionId: 'rejectTest', interaction: { state: 'connected' } },
+        on: jest.fn(),
+        off: jest.fn(),
+      } as unknown as ITask;
+      
+      storeWrapper.onTaskRejected = jest.fn();
+      const removeSpy = jest.spyOn(storeWrapper, 'handleTaskRemove');
+      storeWrapper['store'].taskList = [];
+      
+      storeWrapper.handleIncomingTask(rejectTask);
+      const taskRejectCall = rejectTask.on.mock.calls.find(call => call[0] === TASK_EVENTS.TASK_REJECT);
+      expect(taskRejectCall).toBeDefined();
+      const rejectCallback = taskRejectCall[1];
+      
+      // Simulate rejection event with a specified reason
+      rejectCallback({ reason: 'Task Rejected Reason' });
+      
+      expect(storeWrapper.onTaskRejected).toHaveBeenCalledWith('Task Rejected Reason');
+      expect(removeSpy).toHaveBeenCalledWith('rejectTest');
+    });
   });
 });

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -616,7 +616,8 @@ describe('storeEventsWrapper', () => {
         off: jest.fn(),
       } as unknown as ITask;
       
-      storeWrapper.onTaskRejected = jest.fn();
+      const onTaskRejectedMock = jest.fn();
+      storeWrapper.setTaskRejected(onTaskRejectedMock);
       const removeSpy = jest.spyOn(storeWrapper, 'handleTaskRemove');
       storeWrapper['store'].taskList = [];
       
@@ -626,9 +627,10 @@ describe('storeEventsWrapper', () => {
       const rejectCallback = taskRejectCall[1];
       
       // Simulate rejection event with a specified reason
-      rejectCallback('Task Rejected Reason');
+      const reason = 'Task Rejected Reason';
+      rejectCallback({ reason });
       
-      expect(storeWrapper.onTaskRejected).toHaveBeenCalledWith('Task Rejected Reason');
+      expect(onTaskRejectedMock).toHaveBeenCalledWith({ 'reason': reason });
       expect(removeSpy).toHaveBeenCalledWith('rejectTest');
     });
   });

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -626,7 +626,7 @@ describe('storeEventsWrapper', () => {
       const rejectCallback = taskRejectCall[1];
       
       // Simulate rejection event with a specified reason
-      rejectCallback({ reason: 'Task Rejected Reason' });
+      rejectCallback('Task Rejected Reason');
       
       expect(storeWrapper.onTaskRejected).toHaveBeenCalledWith('Task Rejected Reason');
       expect(removeSpy).toHaveBeenCalledWith('rejectTest');

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -1,7 +1,7 @@
 import {useEffect, useCallback, useRef} from 'react';
 import {ITask} from '@webex/plugin-cc';
-import store from '@webex/cc-store';
-import {TASK_EVENTS, useCallControlProps, UseTaskListProps, UseTaskProps} from './task.types';
+import {store, TASK_EVENTS} from '@webex/cc-store';
+import {useCallControlProps, UseTaskListProps, UseTaskProps} from './task.types';
 
 // Hook for managing the task list
 export const useTaskList = (props: UseTaskListProps) => {

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -1,6 +1,6 @@
 import {useEffect, useCallback, useRef} from 'react';
 import {ITask} from '@webex/plugin-cc';
-import {store, TASK_EVENTS} from '@webex/cc-store';
+import store, {TASK_EVENTS} from '@webex/cc-store';
 import {useCallControlProps, UseTaskListProps, UseTaskProps} from './task.types';
 
 // Hook for managing the task list

--- a/packages/contact-center/task/src/task.types.ts
+++ b/packages/contact-center/task/src/task.types.ts
@@ -120,6 +120,7 @@ export enum TASK_EVENTS {
   TASK_RESUME = 'task:resume',
   TASK_END = 'task:end',
   TASK_WRAPUP = 'task:wrapup',
+  TASK_REJECT = 'task:rejected',
 } // TODO: remove this once cc sdk exports this enum
 
 /**

--- a/packages/contact-center/task/src/task.types.ts
+++ b/packages/contact-center/task/src/task.types.ts
@@ -107,21 +107,6 @@ export type TaskListPresentationalProps = Pick<
   TaskProps,
   'currentTask' | 'taskList' | 'isBrowser' | 'acceptTask' | 'declineTask'
 >;
-export enum TASK_EVENTS {
-  TASK_INCOMING = 'task:incoming',
-  TASK_ASSIGNED = 'task:assigned',
-  TASK_MEDIA = 'task:media',
-  TASK_HOLD = 'task:hold',
-  TASK_UNHOLD = 'task:unhold',
-  TASK_CONSULT = 'task:consult',
-  TASK_CONSULT_END = 'task:consultEnd',
-  TASK_CONSULT_ACCEPT = 'task:consultAccepted',
-  TASK_PAUSE = 'task:pause',
-  TASK_RESUME = 'task:resume',
-  TASK_END = 'task:end',
-  TASK_WRAPUP = 'task:wrapup',
-  TASK_REJECT = 'task:rejected',
-} // TODO: remove this once cc sdk exports this enum
 
 /**
  * Interface representing the properties for control actions on a task.

--- a/packages/contact-center/task/tests/CallControl/index.tsx
+++ b/packages/contact-center/task/tests/CallControl/index.tsx
@@ -21,6 +21,9 @@ jest.mock('@webex/cc-store', () => ({
     end: jest.fn(() => Promise.resolve()),
     wrapup: jest.fn(() => Promise.resolve()),
   },
+  TASK_EVENTS: {
+    TASK_MEDIA: 'task:media',
+  },
 }));
 const onHoldResumeCb = jest.fn();
 const onEndCb = jest.fn();

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -1,6 +1,6 @@
 import {renderHook, act, waitFor} from '@testing-library/react';
 import {useIncomingTask, useTaskList, useCallControl} from '../src/helper';
-import {TASK_EVENTS} from '../src/task.types';
+import {TASK_EVENTS} from '@webex/cc-store';
 import React from 'react';
 
 // Mock webex instance and task

--- a/widgets-samples/cc/samples-cc-react-app/src/App.scss
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.scss
@@ -1,0 +1,10 @@
+.task-rejected-popup {
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  background-color: white;
+  padding: 20px;
+  border: 1px solid #ccc;
+  z-index: 1000;
+}

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -120,13 +120,13 @@ function App() {
   };
 
   useEffect(() => {
-    store.onTaskRejected = (reason: string) => {
+    store.setTaskRejected((reason: string) => {
       setRejectedReason(reason);
       setShowRejectedPopup(true);
-    };
+    });
 
     return () => {
-      store.onTaskRejected = undefined;
+      store.setTaskRejected(undefined);
     };
   }, []);
 

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useRef, useEffect} from 'react';
 import {StationLogin, UserState, IncomingTask, TaskList, CallControl, store} from '@webex/cc-widgets';
 import {ThemeProvider, IconProvider} from '@momentum-design/components/dist/react';
+import './App.scss';
 
 function App() {
   const [isSdkReady, setIsSdkReady] = useState(false);
@@ -242,19 +243,8 @@ function App() {
             </>
           )}  
 
-        {showRejectedPopup && (
-            <div
-              style={{
-                position: 'fixed',
-                top: '20%',
-                left: '50%',
-                transform: 'translate(-50%, 0)',
-                backgroundColor: 'white',
-                padding: '20px',
-                border: '1px solid #ccc',
-                zIndex: 1000,
-              }}
-            >
+          {showRejectedPopup && (
+            <div className="task-rejected-popup">
               <h2>Task Rejected</h2>
               <p>Reason: {rejectedReason}</p>
               <select value={selectedState} onChange={(e) => setSelectedState(e.target.value)}>

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -83,8 +83,6 @@ function App() {
   };
 
   const changeAgentState = (newState: string) => {
-    // If the selected state is "Available", we pass it as is; otherwise, we consider it "Idle".
-    const chosenState = newState === 'Available' ? 'Available' : 'Idle';
     // In the idle codes, we need to search for the 'Idle' state with code name 'Meeting'.
     const lookupCodeName = newState === 'Available' ? 'Available' : 'Meeting';
     
@@ -96,7 +94,7 @@ function App() {
     const agentId = store.agentId || '';
     store.cc
       .setAgentState({
-        state: chosenState,
+        state: newState,
         auxCodeId: idleCode.id,
         agentId,
         lastStateChangeReason: newState,
@@ -104,7 +102,7 @@ function App() {
       .then((response) => {
         store.setCurrentState(response.data.auxCodeId);
         store.setLastStateChangeTimestamp(new Date(response.data.lastStateChangeTimestamp));
-        console.log('Agent state updated to', chosenState);
+        console.log('Agent state updated to', newState);
       })
       .catch((error) => {
         console.error('Error updating agent state:', error);
@@ -250,8 +248,7 @@ function App() {
               <select value={selectedState} onChange={(e) => setSelectedState(e.target.value)}>
                 <option value="">Select a state</option>
                 <option value="Available">Available</option>
-                <option value="Busy">Busy</option>
-                <option value="On Break">On Break</option>
+                <option value="Idle">Idle</option>
               </select>
               <button onClick={handlePopoverSubmit}>Submit</button>
             </div>

--- a/widgets-samples/cc/samples-cc-wc-app/app.js
+++ b/widgets-samples/cc/samples-cc-wc-app/app.js
@@ -2,7 +2,8 @@
 const accessTokenElem = document.getElementById('access_token_elem');
 const themeElem = document.getElementById('theme');
 const widgetsContainer = document.getElementById('widgets-container');
-
+const popupContainer = document.getElementById('popup-container');
+const taskRejectedSubmitButton = document.getElementById('task-rejected-submit-button');
 const ccStationLogin = document.createElement('widget-cc-station-login');
 const ccUserState = document.createElement('widget-cc-user-state');
 const ccIncomingTask = document.createElement('widget-cc-incoming-task');
@@ -18,7 +19,6 @@ const taskListCheckbox = document.getElementById('taskListCheckbox');
 const callControlCheckbox = document.getElementById('callControlCheckbox');
 
 let isMultiLoginEnabled = false;
-const popupContainer = document.getElementById('popup-container');
 
 themeElem.addEventListener('change', () => {
   store.setCurrentTheme(themeElem.checked ? 'DARK' : 'LIGHT');
@@ -31,6 +31,15 @@ themeElem.addEventListener('change', () => {
 store.onTaskRejected = function(reason) {
   showTaskRejectedPopup(reason);
 };
+
+// Attach submit button event listener once.
+taskRejectedSubmitButton.addEventListener('click', function() {
+  const selectedState = document.getElementById('state-select').value;
+  if (selectedState) {
+    changeAgentState(selectedState);
+  }
+  popupContainer.style.display = 'none';
+});
 
 if (!ccStationLogin && !ccUserState) {
   console.error('Failed to find the required elements');
@@ -171,27 +180,6 @@ function changeAgentState(newState) {
 
 // Helper to show the task rejected popup.
 function showTaskRejectedPopup(reason) {
-  popupContainer.innerHTML = `
-      <div id="task-rejected-popup">
-        <h2>Task Rejected</h2>
-        <p>Reason: ${reason || 'No reason provided'}</p>
-        <select id="state-select">
-          <option value="">Select a state</option>
-          <option value="Available">Available</option>
-          <option value="Busy">Busy</option>
-          <option value="On Break">On Break</option>
-        </select>
-        <button id="submit-button">Submit</button>
-      </div>
-    `;
+  document.getElementById('task-rejected-reason').textContent = "Reason: " + (reason || 'No reason provided');
   popupContainer.style.display = 'block';
-
-  document.getElementById('submit-button').addEventListener('click', function() {
-    var selectedState = document.getElementById('state-select').value;
-    if (selectedState) {
-      changeAgentState(selectedState);
-    }
-    popupContainer.style.display = 'none';
-    popupContainer.innerHTML = '';
-  });
 }

--- a/widgets-samples/cc/samples-cc-wc-app/app.js
+++ b/widgets-samples/cc/samples-cc-wc-app/app.js
@@ -131,15 +131,15 @@ function onTaskDeclined() {
 }
 
 function onHoldResume() {
-    console.log('onHoldResume invoked');
+  console.log('onHoldResume invoked');
 }
-  
+
 function onEnd() {
-    console.log('onEnd invoked');
+  console.log('onEnd invoked');
 }
-  
+
 function onWrapup() {
-    console.log('onWrapUp invoked');
+  console.log('onWrapUp invoked');
 }
 
 // Helper to change the agent state, using "Available" as is or "Meeting" for lookup if not.

--- a/widgets-samples/cc/samples-cc-wc-app/app.js
+++ b/widgets-samples/cc/samples-cc-wc-app/app.js
@@ -28,9 +28,9 @@ themeElem.addEventListener('change', () => {
   );
 });
 
-store.onTaskRejected = function(reason) {
+store.setTaskRejected(function(reason) {
   showTaskRejectedPopup(reason);
-};
+});
 
 // Attach submit button event listener once.
 taskRejectedSubmitButton.addEventListener('click', function() {

--- a/widgets-samples/cc/samples-cc-wc-app/app.js
+++ b/widgets-samples/cc/samples-cc-wc-app/app.js
@@ -153,7 +153,6 @@ function onWrapup() {
 
 // Helper to change the agent state, using "Available" as is or "Meeting" for lookup if not.
 function changeAgentState(newState) {
-  const chosenState = newState === 'Available' ? 'Available' : 'Idle';
   const lookupCodeName = newState === 'Available' ? 'Available' : 'Meeting';
   const idleCode = store.idleCodes?.find((code) => code.name === lookupCodeName);
   if (!idleCode) {
@@ -163,7 +162,7 @@ function changeAgentState(newState) {
   const agentId = store.agentId || '';
   store.cc
     .setAgentState({
-      state: chosenState,
+      state: newState,
       auxCodeId: idleCode.id,
       agentId: agentId,
       lastStateChangeReason: newState,
@@ -171,7 +170,7 @@ function changeAgentState(newState) {
     .then(function(response) {
       store.setCurrentState(response.data.auxCodeId);
       store.setLastStateChangeTimestamp(new Date(response.data.lastStateChangeTimestamp));
-      console.log('Agent state updated to', chosenState);
+      console.log('Agent state updated to', newState);
     })
     .catch(function(error) {
       console.error('Error updating agent state:', error);

--- a/widgets-samples/cc/samples-cc-wc-app/app.js
+++ b/widgets-samples/cc/samples-cc-wc-app/app.js
@@ -146,11 +146,7 @@ function onWrapup() {
 function changeAgentState(newState) {
   const chosenState = newState === 'Available' ? 'Available' : 'Idle';
   const lookupCodeName = newState === 'Available' ? 'Available' : 'Meeting';
-  const idleCode =
-    store.idleCodes &&
-    store.idleCodes.find(function(code) {
-      return code.name === lookupCodeName;
-    });
+  const idleCode = store.idleCodes?.find((code) => code.name === lookupCodeName);
   if (!idleCode) {
     console.error('No idle code found for selected state:', newState);
     return;

--- a/widgets-samples/cc/samples-cc-wc-app/app.js
+++ b/widgets-samples/cc/samples-cc-wc-app/app.js
@@ -18,6 +18,7 @@ const taskListCheckbox = document.getElementById('taskListCheckbox');
 const callControlCheckbox = document.getElementById('callControlCheckbox');
 
 let isMultiLoginEnabled = false;
+const popupContainer = document.getElementById('popup-container');
 
 themeElem.addEventListener('change', () => {
   store.setCurrentTheme(themeElem.checked ? 'DARK' : 'LIGHT');
@@ -26,6 +27,10 @@ themeElem.addEventListener('change', () => {
     themeElem.checked ? 'mds-theme-stable-darkWebex' : 'mds-theme-stable-lightWebex'
   );
 });
+
+store.onTaskRejected = function(reason) {
+  showTaskRejectedPopup(reason);
+};
 
 if (!ccStationLogin && !ccUserState) {
   console.error('Failed to find the required elements');
@@ -126,13 +131,71 @@ function onTaskDeclined() {
 }
 
 function onHoldResume() {
-  console.log('onHoldResume invoked');
+    console.log('onHoldResume invoked');
 }
-
+  
 function onEnd() {
-  console.log('onEnd invoked');
+    console.log('onEnd invoked');
+}
+  
+function onWrapup() {
+    console.log('onWrapUp invoked');
 }
 
-function onWrapup() {
-  console.log('onWrapUp invoked');
+// Helper to change the agent state, using "Available" as is or "Meeting" for lookup if not.
+function changeAgentState(newState) {
+  const chosenState = newState === 'Available' ? 'Available' : 'Idle';
+  const lookupCodeName = newState === 'Available' ? 'Available' : 'Meeting';
+  const idleCode =
+    store.idleCodes &&
+    store.idleCodes.find(function(code) {
+      return code.name === lookupCodeName;
+    });
+  if (!idleCode) {
+    console.error('No idle code found for selected state:', newState);
+    return;
+  }
+  const agentId = store.agentId || '';
+  store.cc
+    .setAgentState({
+      state: chosenState,
+      auxCodeId: idleCode.id,
+      agentId: agentId,
+      lastStateChangeReason: newState,
+    })
+    .then(function(response) {
+      store.setCurrentState(response.data.auxCodeId);
+      store.setLastStateChangeTimestamp(new Date(response.data.lastStateChangeTimestamp));
+      console.log('Agent state updated to', chosenState);
+    })
+    .catch(function(error) {
+      console.error('Error updating agent state:', error);
+    });
+}
+
+// Helper to show the task rejected popup.
+function showTaskRejectedPopup(reason) {
+  popupContainer.innerHTML = `
+      <div id="task-rejected-popup">
+        <h2>Task Rejected</h2>
+        <p>Reason: ${reason || 'No reason provided'}</p>
+        <select id="state-select">
+          <option value="">Select a state</option>
+          <option value="Available">Available</option>
+          <option value="Busy">Busy</option>
+          <option value="On Break">On Break</option>
+        </select>
+        <button id="submit-button">Submit</button>
+      </div>
+    `;
+  popupContainer.style.display = 'block';
+
+  document.getElementById('submit-button').addEventListener('click', function() {
+    var selectedState = document.getElementById('state-select').value;
+    if (selectedState) {
+      changeAgentState(selectedState);
+    }
+    popupContainer.style.display = 'none';
+    popupContainer.innerHTML = '';
+  });
 }

--- a/widgets-samples/cc/samples-cc-wc-app/index.html
+++ b/widgets-samples/cc/samples-cc-wc-app/index.html
@@ -68,8 +68,7 @@
             <select id="state-select">
               <option value="">Select a state</option>
               <option value="Available">Available</option>
-              <option value="Busy">Busy</option>
-              <option value="On Break">On Break</option>
+              <option value="Idle">Idle</option>
             </select>
             <button id="task-rejected-submit-button">Confirm State Change</button>
           </div>

--- a/widgets-samples/cc/samples-cc-wc-app/index.html
+++ b/widgets-samples/cc/samples-cc-wc-app/index.html
@@ -8,6 +8,16 @@
       .disabled {
         display: none;
       }
+      #task-rejected-popup {
+        position: fixed;
+        top: 20%;
+        left: 50%;
+        transform: translate(-50%, 0);
+        background: white;
+        padding: 20px;
+        border: 1px solid #ccc;
+        z-index: 1000;
+      }
     </style>
   </head>
   <body>
@@ -51,6 +61,7 @@
         <br />
         <button onclick="initWidgets()" disabled>Init Widgets</button>
         <div id="widgets-container"></div>
+        <div id="popup-container" style="display: none;"></div>
       </mdc-iconprovider>
     </mdc-themeprovider>
     <script src="dist/bundle.js"></script>

--- a/widgets-samples/cc/samples-cc-wc-app/index.html
+++ b/widgets-samples/cc/samples-cc-wc-app/index.html
@@ -61,7 +61,19 @@
         <br />
         <button onclick="initWidgets()" disabled>Init Widgets</button>
         <div id="widgets-container"></div>
-        <div id="popup-container" style="display: none;"></div>
+        <div id="popup-container" style="display: none;">
+          <div id="task-rejected-popup">
+            <h2>Task Rejected</h2>
+            <p id="task-rejected-reason"></p>
+            <select id="state-select">
+              <option value="">Select a state</option>
+              <option value="Available">Available</option>
+              <option value="Busy">Busy</option>
+              <option value="On Break">On Break</option>
+            </select>
+            <button id="task-rejected-submit-button">Confirm State Change</button>
+          </div>
+        </div>
       </mdc-iconprovider>
     </mdc-themeprovider>
     <script src="dist/bundle.js"></script>


### PR DESCRIPTION
### COMPLETES [SPARK-604350](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-604350)


## ISSUE
* In widgets, we were receiving the agent rona related event but we were not handling it in the sample app.


## FIX
* Code has been added to include a `taskRejectionCallback` handler inside of the widgets store so users can specify their own custom task rejection method
* For our use case, we show a popup whihch allows users to set a state inside of our sample app (this is widgets sample app specific change)


## Vidcasts
* [Working with WebRTC in web components](https://app.vidcast.io/share/d451f694-43db-407a-9246-5218769f50c3)
* [Working with WebRTC in react components](https://app.vidcast.io/share/cd9e130e-d1fd-4689-bf1a-d733817975e3)
* [Working in EXTERNAL config](https://app.vidcast.io/share/e5a4d7d7-be0f-4018-85f7-f635d8200ce3)


### Manual Test Cases
* Tested with webRTC in both web and react components
* Tested with external type in both web and react
* Tested by keeping both web and react sample pages open and used external type (we got popup in both as expected)
* Tested that the user state is not getting messed up with this (cross verified with agent desktop)

Test Doc Link - https://confluence-eng-gpk2.cisco.com/conf/display/WSDK/CC+Widgets+Test+Plan