### PR TITLE
fix(store): minor-fixes-after-storeEventsWrapper

### DIFF
--- a/packages/contact-center/station-login/src/helper.ts
+++ b/packages/contact-center/station-login/src/helper.ts
@@ -8,17 +8,12 @@ export const useStationLogin = (props: UseStationLoginProps) => {
   const loginCb = props.onLogin;
   const logoutCb = props.onLogout;
   const logger = props.logger;
-  const [isAgentLoggedIn, setIsAgentLoggedIn] = useState(props.isAgentLoggedIn);
   const [dialNumber, setDialNumber] = useState('');
   const [deviceType, setDeviceType] = useState(props.deviceType || '');
   const [team, setTeam] = useState('');
   const [loginSuccess, setLoginSuccess] = useState<StationLoginSuccess>();
   const [loginFailure, setLoginFailure] = useState<Error>();
   const [logoutSuccess, setLogoutSuccess] = useState<StationLogoutSuccess>();
-
-  useEffect(() => {
-    setIsAgentLoggedIn(props.isAgentLoggedIn);
-  }, [props.isAgentLoggedIn]);
 
   const handleContinue = async () => {
     try {
@@ -47,7 +42,6 @@ export const useStationLogin = (props: UseStationLoginProps) => {
     cc.stationLogin({teamId: team, loginOption: deviceType, dialNumber: dialNumber})
       .then((res: StationLoginSuccess) => {
         setLoginSuccess(res);
-        setIsAgentLoggedIn(true);
         store.setDeviceType(deviceType);
         store.setIsAgentLoggedIn(true);
         if (res.data.auxCodeId) {
@@ -73,7 +67,6 @@ export const useStationLogin = (props: UseStationLoginProps) => {
     cc.stationLogout({logoutReason: 'User requested logout'})
       .then((res: StationLogoutSuccess) => {
         setLogoutSuccess(res);
-        setIsAgentLoggedIn(false);
         store.setIsAgentLoggedIn(false);
         store.setDeviceType('');
         if (logoutCb) {
@@ -106,7 +99,6 @@ export const useStationLogin = (props: UseStationLoginProps) => {
     loginSuccess,
     loginFailure,
     logoutSuccess,
-    isAgentLoggedIn,
     handleContinue,
   };
 };

--- a/packages/contact-center/station-login/src/station-login/index.tsx
+++ b/packages/contact-center/station-login/src/station-login/index.tsx
@@ -13,7 +13,6 @@ const StationLoginComponent: React.FunctionComponent<StationLoginProps> = ({onLo
     onLogin,
     onLogout,
     logger,
-    isAgentLoggedIn,
     deviceType,
   });
 
@@ -22,8 +21,10 @@ const StationLoginComponent: React.FunctionComponent<StationLoginProps> = ({onLo
     teams,
     loginOptions,
     deviceType,
+    isAgentLoggedIn,
+    showMultipleLoginAlert,
   };
-  return <StationLoginPresentational {...props} showMultipleLoginAlert={showMultipleLoginAlert} />;
+  return <StationLoginPresentational {...props} />;
 };
 
 const StationLogin = observer(StationLoginComponent);

--- a/packages/contact-center/station-login/src/station-login/station-login.types.ts
+++ b/packages/contact-center/station-login/src/station-login/station-login.types.ts
@@ -126,9 +126,6 @@ export type StationLoginPresentationalProps = Pick<
   showMultipleLoginAlert: boolean;
 };
 
-export type UseStationLoginProps = Pick<
-  IStationLoginProps,
-  'cc' | 'onLogin' | 'onLogout' | 'logger' | 'isAgentLoggedIn' | 'deviceType'
->;
+export type UseStationLoginProps = Pick<IStationLoginProps, 'cc' | 'onLogin' | 'onLogout' | 'logger' | 'deviceType'>;
 
 export type StationLoginProps = Pick<IStationLoginProps, 'onLogin' | 'onLogout'>;

--- a/packages/contact-center/station-login/tests/helper.ts
+++ b/packages/contact-center/station-login/tests/helper.ts
@@ -40,7 +40,6 @@ const logger = {
   log: jest.fn(),
   error: jest.fn(),
 };
-const isAgentLoggedIn = false;
 
 describe('useStationLogin Hook', () => {
   afterEach(() => {
@@ -87,7 +86,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'BROWSER',
       })
     );
@@ -112,7 +110,6 @@ describe('useStationLogin Hook', () => {
 
       expect(result.current).toEqual({
         name: 'StationLogin',
-        isAgentLoggedIn: true,
         setDeviceType: expect.any(Function),
         setDialNumber: expect.any(Function),
         setTeam: expect.any(Function),
@@ -152,7 +149,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: '',
       })
     );
@@ -190,7 +186,6 @@ describe('useStationLogin Hook', () => {
         cc: ccMock,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -222,7 +217,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -247,7 +241,6 @@ describe('useStationLogin Hook', () => {
 
       expect(result.current).toEqual({
         name: 'StationLogin',
-        isAgentLoggedIn: false,
         setDeviceType: expect.any(Function),
         setDialNumber: expect.any(Function),
         setTeam: expect.any(Function),
@@ -272,7 +265,6 @@ describe('useStationLogin Hook', () => {
         cc: ccMock,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -297,7 +289,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -323,7 +314,6 @@ describe('useStationLogin Hook', () => {
 
       expect(result.current).toEqual({
         name: 'StationLogin',
-        isAgentLoggedIn: true,
         setDeviceType: expect.any(Function),
         setDialNumber: expect.any(Function),
         setTeam: expect.any(Function),
@@ -362,7 +352,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'BROWSER',
       })
     );
@@ -377,7 +366,6 @@ describe('useStationLogin Hook', () => {
 
       expect(result.current).toEqual({
         name: 'StationLogin',
-        isAgentLoggedIn: false,
         setDeviceType: expect.any(Function),
         setDialNumber: expect.any(Function),
         setTeam: expect.any(Function),
@@ -401,7 +389,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -426,7 +413,6 @@ describe('useStationLogin Hook', () => {
         cc: ccMock,
         onLogin: loginCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -449,7 +435,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -472,7 +457,6 @@ describe('useStationLogin Hook', () => {
         cc: ccMock,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -498,7 +482,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -528,7 +511,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );
@@ -559,7 +541,6 @@ describe('useStationLogin Hook', () => {
         onLogin: loginCb,
         onLogout: logoutCb,
         logger,
-        isAgentLoggedIn,
         deviceType: 'EXTENSION',
       })
     );

--- a/packages/contact-center/station-login/tests/station-login/index.tsx
+++ b/packages/contact-center/station-login/tests/station-login/index.tsx
@@ -2,26 +2,28 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import {StationLogin} from '../../src';
 import * as helper from '../../src/helper';
+import * as presentational from '../../src/station-login/station-login.presentational';
 import '@testing-library/jest-dom';
 
-const teams = ['team123', 'team456'];
-
-const loginOptions = ['EXTENSION', 'AGENT_DN', 'BROWSER'];
-const deviceType = 'BROWSER';
-const logger = {};
+const teamsMock = ['team123', 'team456'];
+const ccMock = {
+  on: () => {},
+  off: () => {},
+};
+const loginOptionsMock = ['EXTENSION', 'AGENT_DN', 'BROWSER'];
+const deviceTypeMock = 'BROWSER';
+const loggerMock = {};
+const isAgentLoggedInMock = false;
 
 // Mock the store import
 jest.mock('@webex/cc-store', () => {
   return {
-    cc: {
-      on: jest.fn(),
-      off: jest.fn(),
-    },
-    teams,
-    loginOptions,
-    deviceType,
-    logger,
-    isAgentLoggedIn: false,
+    cc: ccMock,
+    teams: teamsMock,
+    loginOptions: loginOptionsMock,
+    deviceType: deviceTypeMock,
+    logger: loggerMock,
+    isAgentLoggedIn: isAgentLoggedInMock,
   };
 });
 
@@ -31,21 +33,18 @@ const logoutCb = jest.fn();
 describe('StationLogin Component', () => {
   it('renders StationLoginPresentational with correct props', () => {
     const useStationLoginSpy = jest.spyOn(helper, 'useStationLogin');
+    const StationLoginPresentationalSpy = jest
+      .spyOn(presentational, 'default')
+      .mockReturnValue(<div>StationLoginPresentational</div>);
 
     render(<StationLogin onLogin={loginCb} onLogout={logoutCb} />);
 
     expect(useStationLoginSpy).toHaveBeenCalledWith({
-      cc: {
-        on: expect.any(Function),
-        off: expect.any(Function),
-      },
+      cc: ccMock,
       onLogin: loginCb,
       onLogout: logoutCb,
-      logger,
-      isAgentLoggedIn: false,
-      deviceType: 'BROWSER',
+      logger: loggerMock,
+      deviceType: deviceTypeMock,
     });
-    const heading = screen.getByTestId('station-login-heading');
-    expect(heading).toHaveTextContent('StationLogin');
   });
 });

--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -37,11 +37,6 @@ class Store implements IStore {
   constructor() {
     makeAutoObservable(this, {
       cc: observable.ref,
-      currentTask: observable, // Make currentTask observable
-      incomingTask: observable,
-      taskList: observable,
-      wrapupRequired: observable,
-      currentState: observable,
     });
   }
 

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -97,6 +97,7 @@ enum CC_EVENTS{
 
 export type {
     IContactCenter,
+    ITask,
     Profile,
     Team,
     AgentLogin,
@@ -106,7 +107,7 @@ export type {
     IStore,
     ILogger,
     IWrapupCode,
-    IStoreWrapper
+    IStoreWrapper,
 }
 
 export {

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -1,5 +1,14 @@
-import {IStoreWrapper, IStore, InitParams, TASK_EVENTS, CC_EVENTS, IWrapupCode, WithWebex} from './store.types';
-import {ITask} from '@webex/plugin-cc';
+import {
+  IStoreWrapper,
+  IStore,
+  InitParams,
+  TASK_EVENTS,
+  CC_EVENTS,
+  IWrapupCode,
+  WithWebex,
+  IContactCenter,
+  ITask,
+} from './store.types';
 import Store from './store';
 import {runInAction} from 'mobx';
 
@@ -235,7 +244,7 @@ class StoreWrapper implements IStoreWrapper {
     }
   };
 
-  setupIncomingTaskHandler = (ccSDK: any) => {
+  setupIncomingTaskHandler = (ccSDK: IContactCenter) => {
     ccSDK.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
 
     ccSDK.on(CC_EVENTS.AGENT_STATE_CHANGE, this.handleStateChange);
@@ -243,6 +252,7 @@ class StoreWrapper implements IStoreWrapper {
     ccSDK.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
 
     return () => {
+      // TODO: https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-617635, remove event listeners after logout
       ccSDK.off(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
       ccSDK.off(CC_EVENTS.AGENT_STATE_CHANGE, this.handleStateChange);
       ccSDK.off(CC_EVENTS.AGENT_MULTI_LOGIN, this.handleMultiLoginCloseSession);

--- a/packages/contact-center/store/tests/store.ts
+++ b/packages/contact-center/store/tests/store.ts
@@ -55,11 +55,6 @@ describe('Store', () => {
 
     expect(makeAutoObservable).toHaveBeenCalledWith(storeInstance, {
       cc: expect.any(Function),
-      currentState: expect.any(Object),
-      currentTask: expect.any(Object),
-      incomingTask: expect.any(Object),
-      taskList: expect.any(Object),
-      wrapupRequired: expect.any(Object),
     });
   });
 

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -124,10 +124,6 @@ describe('storeEventsWrapper', () => {
       expect(storeWrapper['store'].currentState).toBe('newState');
     });
 
-    // registerCC = (webex?: WithWebex['webex']) => {
-    //   return this.store.registerCC(webex);
-    // };
-
     it('should call registerCC', () => {
       const mockRegisterCC = jest.fn();
       storeWrapper['store'].registerCC = mockRegisterCC;

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -2,6 +2,7 @@ import {act, waitFor} from '@testing-library/react';
 import {CC_EVENTS, TASK_EVENTS} from '../src/store.types';
 import storeWrapper from '../src/storeEventsWrapper';
 import {ITask} from '@webex/plugin-cc';
+import {register} from 'module';
 
 jest.mock('../src/store', () => ({
   getInstance: jest.fn().mockReturnValue({
@@ -36,6 +37,7 @@ jest.mock('../src/store', () => ({
     setWrapupRequired: jest.fn(),
     setCurrentTheme: jest.fn(),
     setIsAgentLoggedIn: jest.fn(),
+    registerCC: jest.fn(),
   }),
 }));
 
@@ -122,6 +124,25 @@ describe('storeEventsWrapper', () => {
       expect(storeWrapper['store'].currentState).toBe('newState');
     });
 
+    // registerCC = (webex?: WithWebex['webex']) => {
+    //   return this.store.registerCC(webex);
+    // };
+
+    it('should call registerCC', () => {
+      const mockRegisterCC = jest.fn();
+      storeWrapper['store'].registerCC = mockRegisterCC;
+
+      storeWrapper.registerCC();
+      expect(mockRegisterCC).toHaveBeenCalled();
+
+      const mockLogger = {log: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn(), trace: jest.fn()};
+      storeWrapper.registerCC({
+        cc: {},
+        logger: mockLogger,
+      });
+      expect(mockRegisterCC).toHaveBeenCalledWith({cc: {}, logger: mockLogger});
+    });
+
     it('should setLastStateChangeTimestamp', () => {
       expect(storeWrapper.setLastStateChangeTimestamp).toBeInstanceOf(Function);
 
@@ -156,7 +177,7 @@ describe('storeEventsWrapper', () => {
     });
 
     it('should setWrapupCodes', () => {
-      const mockCodes = [{code1: 'code1'}, {code2: 'code2'}];
+      const mockCodes = [{id: 'code1', name: 'code1'}];
       expect(storeWrapper.setWrapupCodes).toBeInstanceOf(Function);
 
       storeWrapper.setWrapupCodes(mockCodes);

--- a/packages/contact-center/task/package.json
+++ b/packages/contact-center/task/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "@webex/cc-store": "workspace:*",
-    "mobx-react-lite": "^4.1.0",
-    "webex": "3.7.0-wxcc.15"
+    "mobx-react-lite": "^4.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",

--- a/packages/contact-center/task/src/CallControl/index.tsx
+++ b/packages/contact-center/task/src/CallControl/index.tsx
@@ -7,10 +7,14 @@ import {CallControlProps} from '../task.types';
 import CallControlPresentational from './call-control.presentational';
 
 const CallControlComponent: React.FunctionComponent<CallControlProps> = ({onHoldResume, onEnd, onWrapUp}) => {
-  const {logger, currentTask, wrapupCodes, wrapupRequired} = store;
-  const result = useCallControl({currentTask, onHoldResume, onEnd, onWrapUp, logger});
+  const {logger, currentTask, deviceType, wrapupCodes, wrapupRequired} = store;
+  const result = {
+    ...useCallControl({currentTask, deviceType, onHoldResume, onEnd, onWrapUp, logger}),
+    wrapupRequired,
+    wrapupCodes,
+  };
 
-  return <CallControlPresentational {...result} wrapupRequired={wrapupRequired} wrapupCodes={wrapupCodes} />;
+  return <CallControlPresentational {...result} />;
 };
 
 const CallControl = observer(CallControlComponent);

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -94,8 +94,9 @@ export const useIncomingTask = (props: UseTaskProps) => {
 };
 
 export const useCallControl = (props: useCallControlProps) => {
-  const {currentTask, onHoldResume, onEnd, onWrapUp, logger} = props;
+  const {currentTask, onHoldResume, onEnd, onWrapUp, logger, deviceType} = props;
   const audioRef = useRef<HTMLAudioElement | null>(null); // Ref for the audio element
+  const isBrowser = deviceType === 'BROWSER';
 
   const logError = (message: string, method: string) => {
     logger.error(message, {
@@ -114,7 +115,7 @@ export const useCallControl = (props: useCallControlProps) => {
   );
 
   useEffect(() => {
-    if (!currentTask) return;
+    if (!currentTask || !isBrowser) return;
     // Call control only event for WebRTC calls
     currentTask.on(TASK_EVENTS.TASK_MEDIA, handleTaskMedia);
 

--- a/packages/contact-center/task/src/task.types.ts
+++ b/packages/contact-center/task/src/task.types.ts
@@ -1,5 +1,4 @@
-import {ITask, IContactCenter} from '@webex/plugin-cc';
-import {ILogger, WrapupCodes} from '@webex/cc-store';
+import {ILogger, ITask, IContactCenter, WrapupCodes} from '@webex/cc-store';
 
 /**
  * Interface representing the TaskProps of a user.
@@ -189,6 +188,11 @@ export interface ControlProps {
    * @param wrapupId - The ID associated with the wrap-up reason.
    */
   wrapupCall: (wrapupReason: string, wrapupId: string) => void;
+
+  /**
+   * Selected login option
+   */
+  deviceType: string;
 }
 
 export type CallControlProps = Pick<ControlProps, 'onHoldResume' | 'onEnd' | 'onWrapUp'>;
@@ -205,4 +209,7 @@ export type CallControlPresentationalProps = Pick<
   | 'wrapupCall'
 >;
 
-export type useCallControlProps = Pick<ControlProps, 'currentTask' | 'onHoldResume' | 'onEnd' | 'onWrapUp' | 'logger'>;
+export type useCallControlProps = Pick<
+  ControlProps,
+  'currentTask' | 'onHoldResume' | 'onEnd' | 'onWrapUp' | 'logger' | 'deviceType'
+>;

--- a/packages/contact-center/task/tests/CallControl/index.tsx
+++ b/packages/contact-center/task/tests/CallControl/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {render, screen} from '@testing-library/react';
 import * as helper from '../../src/helper';
 import {CallControl} from '../../src';
-import store from '@webex/cc-store';
 import '@testing-library/jest-dom';
 
 // Mock the store
@@ -30,17 +29,16 @@ describe('CallControl Component', () => {
   it('renders CallControlPresentational with correct props', () => {
     const useCallControlSpy = jest.spyOn(helper, 'useCallControl');
 
-    const mockCurentTask = store.currentTask;
-
     render(<CallControl onHoldResume={onHoldResumeCb} onEnd={onEndCb} onWrapUp={onWrapUpCb} />);
 
     // Assert that the useIncomingTask hook is called with the correct arguments
     expect(useCallControlSpy).toHaveBeenCalledWith({
-      currentTask: mockCurentTask,
+      currentTask: expect.any(Object),
       onHoldResume: onHoldResumeCb,
       onEnd: onEndCb,
       onWrapUp: onWrapUpCb,
       logger: {},
+      deviceType: 'BROWSER',
     });
   });
 });

--- a/packages/contact-center/task/tests/IncomingTask/index.tsx
+++ b/packages/contact-center/task/tests/IncomingTask/index.tsx
@@ -20,11 +20,7 @@ describe('IncomingTask Component', () => {
 
     // Mock the return value of the useIncomingTask hook
     useIncomingTaskSpy.mockReturnValue({
-      currentTask: null,
-      setCurrentTask: jest.fn(),
-      answered: false,
-      ended: false,
-      missed: false,
+      incomingTask: null,
       accept: jest.fn(),
       decline: jest.fn(),
       isBrowser: true,

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -123,8 +123,6 @@ describe('useIncomingTask Hook', () => {
       useIncomingTask({
         cc: ccMock,
         incomingTask: taskMock,
-        onAccepted: null,
-        onDeclined: null,
         deviceType: 'BROWSER',
         logger,
       })
@@ -147,8 +145,6 @@ describe('useIncomingTask Hook', () => {
       useIncomingTask({
         cc: ccMock,
         incomingTask: taskMock,
-        onAccepted: null,
-        onDeclined: null,
         deviceType: 'BROWSER',
         logger,
       })
@@ -352,10 +348,8 @@ describe('useTaskList Hook', () => {
     const {result} = renderHook(() =>
       useTaskList({
         cc: ccMock,
-        onTaskAccepted: null,
-        onTaskDeclined: null,
         logger,
-        deviceType: '',
+        deviceType: 'BROWSER',
         taskList: mockTaskList,
       })
     );
@@ -376,8 +370,6 @@ describe('useTaskList Hook', () => {
     const {result} = renderHook(() =>
       useTaskList({
         cc: ccMock,
-        onTaskAccepted: null,
-        onTaskDeclined: null,
         logger,
         deviceType: '',
         taskList: mockTaskList,
@@ -444,6 +436,7 @@ describe('useCallControl', () => {
 
     const {result} = renderHook(() =>
       useCallControl({
+        deviceType: 'BROWSER',
         currentTask: mockCurrentTask,
         logger: mockLogger,
       })
@@ -478,6 +471,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -497,6 +491,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -518,6 +513,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -538,6 +534,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -556,6 +553,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -576,6 +574,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -596,6 +595,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -617,11 +617,12 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
     await act(async () => {
-      await result.current.wrapupCall('Wrap reason', 123);
+      await result.current.wrapupCall('Wrap reason', '123');
     });
 
     expect(mockLogger.error).toHaveBeenCalledWith('Error wrapping up call: Error: Wrapup error', expect.any(Object));
@@ -635,6 +636,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -654,6 +656,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -672,6 +675,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -691,6 +695,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -719,6 +724,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -746,6 +752,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -774,6 +781,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -812,6 +820,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
     result.current.audioRef.current = null;
@@ -850,13 +859,14 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
     // Ensure no event handler is set
     expect(taskMock.on).not.toHaveBeenCalled();
   });
 
-  it('should test undefined audioRef.current branch', async () => {
+  it('should test undefined audioRef.current', async () => {
     // This test is to improve the coverage
     const {result} = renderHook(() =>
       useCallControl({
@@ -865,6 +875,7 @@ describe('useCallControl', () => {
         onEnd: mockOnEnd,
         onWrapUp: mockOnWrapUp,
         logger: mockLogger,
+        deviceType: 'BROWSER',
       })
     );
 
@@ -880,5 +891,23 @@ describe('useCallControl', () => {
         taskAssignedCallback(mockTrack);
       }
     });
+  });
+
+  it('should not add media listeners if device type is not BROWSER', async () => {
+    const mockAudioElement = {current: {srcObject: null}};
+    jest.spyOn(React, 'useRef').mockReturnValue(mockAudioElement);
+
+    renderHook(() =>
+      useCallControl({
+        currentTask: mockCurrentTask,
+        onHoldResume: mockOnHoldResume,
+        onEnd: mockOnEnd,
+        onWrapUp: mockOnWrapUp,
+        logger: mockLogger,
+        deviceType: 'EXTENSION',
+      })
+    );
+    // Ensure no event handler is set
+    expect(taskMock.on).not.toHaveBeenCalled();
   });
 });

--- a/packages/contact-center/user-state/src/helper.ts
+++ b/packages/contact-center/user-state/src/helper.ts
@@ -10,7 +10,6 @@ export const useUserState = ({idleCodes, agentId, cc, currentState, lastStateCha
   // Initialize the Web Worker using a Blob
   const workerScript = `
     let intervalId;
-
     const startTimer = (startTime) => {
       if (intervalId) clearInterval(intervalId);
       intervalId = setInterval(() => {
@@ -18,7 +17,6 @@ export const useUserState = ({idleCodes, agentId, cc, currentState, lastStateCha
         self.postMessage(elapsedTime);
       }, 1000);
     };
-
     self.onmessage = (event) => {
       if (event.data.type === 'start' || event.data.type === 'reset') {
         const startTime = event.data.startTime;
@@ -38,28 +36,13 @@ export const useUserState = ({idleCodes, agentId, cc, currentState, lastStateCha
   }, []);
 
   useEffect(() => {
-    if (workerRef.current) {
-      workerRef.current.terminate();
-      const blob = new Blob([workerScript], {type: 'application/javascript'});
-      const workerUrl = URL.createObjectURL(blob);
-      workerRef.current = new Worker(workerUrl);
-      workerRef.current.onmessage = (event) => {
-        setElapsedTime(event.data);
-      };
-      if (lastStateChangeTimestamp) {
-        const timeNow = new Date();
-        const elapsed = Math.floor(Math.abs(timeNow.getTime() - lastStateChangeTimestamp.getTime()) / 1000);
-        setElapsedTime(elapsed);
-        workerRef.current.postMessage({type: 'reset', startTime: lastStateChangeTimestamp.getTime()});
-      } else {
-        workerRef.current.postMessage({type: 'start', startTime: Date.now()});
-      }
+    if (workerRef.current && lastStateChangeTimestamp) {
+      const timeNow = new Date();
+      const elapsed = Math.floor(Math.abs(timeNow.getTime() - lastStateChangeTimestamp.getTime()) / 1000);
+      setElapsedTime(elapsed);
+      workerRef.current.postMessage({type: 'reset', startTime: lastStateChangeTimestamp.getTime()});
     }
-
-    return () => {
-      workerRef.current?.terminate();
-    };
-  }, [currentState]);
+  }, [lastStateChangeTimestamp]);
 
   const setAgentStatus = (selectedCode) => {
     const {auxCodeId, state} = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5807,7 +5807,6 @@ __metadata:
     mobx-react-lite: "npm:^4.1.0"
     ts-loader: "npm:9.5.1"
     typescript: "npm:5.6.3"
-    webex: "npm:3.7.0-wxcc.15"
     webpack: "npm:5.94.0"
     webpack-cli: "npm:5.1.4"
     webpack-merge: "npm:6.0.1"


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[SPARK-610353](https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-610353)

## This pull request addresses
The final round of review for the PR -https://github.com/webex/widgets/pull/369
Since we were on a clock these non-blocking comments were left.

## by making the following changes
- Removed the isAgentLoggedIn local state in station-login
- Reverted worker thread logic for user-state timmer
- Removed webex as dependency in cc-task, exporting the types from cc-store

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
- [x] The testing is done with the amplify link

https://github.com/user-attachments/assets/4f59576a-09fe-48b4-bfd1-114cd4992233

- Changes state from available to any other state and made sure timmer is refreshed
- Refresh with state as available- timmer should start from 0
- Refresh with state as meeting- timmer held the last state change time

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the testing document
- [x] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.