### PR TITLE
fix(tooling): remove-version-command-in-publish

### DIFF
--- a/tooling/src/publish.js
+++ b/tooling/src/publish.js
@@ -56,8 +56,8 @@ function versionAndPublish() {
         const packageData = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 
         console.log(`Removing stable version from package.json for ${dirent.name}`);
-        removeStableVersion(packageJsonPath, packageData); // Assuming this function is defined elsewhere
-        updateVersion(packageJsonPath, packageData, newVersion); // Assuming this function is defined elsewhere
+        removeStableVersion(packageJsonPath, packageData);
+        updateVersion(packageJsonPath, packageData, newVersion);
         return packageData.name;
       });
 

--- a/tooling/src/publish.js
+++ b/tooling/src/publish.js
@@ -17,6 +17,21 @@ function removeStableVersion(packageJsonPath, packageData) {
   }
 }
 
+// Function to update the version
+function updateVersion(packageJsonPath, packageData, newVersion) {
+  try {
+    if (packageData.hasOwnProperty('version')) {
+      packageData.version = newVersion;
+      fs.writeFileSync(packageJsonPath, JSON.stringify(packageData, null, 2), 'utf-8');
+      console.log(`Version updated to ${newVersion} successfully for ${packageData.name}.`);
+    } else {
+      console.log("'version' key does not exist in package.json.");
+    }
+  } catch (error) {
+    throw new Error(`An error occurred while updating 'version': ${error.message}`);
+  }
+}
+
 function versionAndPublish() {
   const branchName = process.argv[2];
   const newVersion = process.argv[3];
@@ -42,24 +57,15 @@ function versionAndPublish() {
 
         console.log(`Removing stable version from package.json for ${dirent.name}`);
         removeStableVersion(packageJsonPath, packageData); // Assuming this function is defined elsewhere
+        updateVersion(packageJsonPath, packageData, newVersion); // Assuming this function is defined elsewhere
         return packageData.name;
       });
 
-    // Update version in the workspace
-    const updateVersions = (workspace) => {
-      console.log(`Publishing new version for ${workspace}: ${newVersion}`);
-      execSync(`yarn workspace ${workspace} version ${newVersion}`, {stdio: 'inherit'});
-    };
-
     // Publish the package
     const publishWorkspace = (workspace) => {
-      console.log(`Updating version for ${workspace}: ${newVersion}`);
+      console.log(`Publishing new version for ${workspace}: ${newVersion}`);
       execSync(`yarn workspace ${workspace} npm publish --tag ${branchName}`, {stdio: 'inherit'});
     };
-
-    for (const workspace of workspaceData) {
-      updateVersions(workspace);
-    }
 
     for (const workspace of workspaceData) {
       publishWorkspace(workspace);


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES # Adhoc

## This pull request addresses
- When we run the `yarn version` command there is a spike in resource usage in circleCI because this command is also running yarn install for all the dependencies for each packages, and since we are running this in a loop there are a lot of yarn installs running. This seems to be failing the circleCI pipeline.

## by making the following changes
- Rather than using yarn version command to update the version, we are using a custom script to achieve that

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- Ran the publish command and ensure the custom script is updating the package.json's version
<img width="750" alt="Screenshot 2025-02-27 at 11 29 45 AM" src="https://github.com/user-attachments/assets/a919097b-96b1-4920-8894-b3450d23bb92" />

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.