### PR TITLE
fix(user-state): custom status on hydration

### DIFF
--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -325,6 +325,11 @@ class StoreWrapper implements IStoreWrapper {
 
     this.setCurrentTask(task);
 
+    this.setState({
+      developerName: 'ENGAGED',
+      name: 'Engaged',
+    });
+
     const {interaction, agentId} = task.data;
     const {state, isTerminated, participants} = interaction;
 
@@ -333,6 +338,12 @@ class StoreWrapper implements IStoreWrapper {
       // wrapup
       const wrapupRequired = state === 'wrapUp' && !participants[agentId].isWrappedUp;
       this.setWrapupRequired(wrapupRequired);
+
+      if (!wrapupRequired) {
+        this.setState({
+          reset: true,
+        });
+      }
 
       return;
     }

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -803,6 +803,97 @@ describe('storeEventsWrapper', () => {
       expect(handleTaskRemoveSpy).toHaveBeenCalledWith(mockTask.data.interactionId);
     });
 
+    describe('customStates on hydration', () => {
+      it('should handle custom state correctly when wrapup required', async () => {
+        const setStateSpy = jest.spyOn(storeWrapper, 'setState');
+
+        const cc = storeWrapper['store'].cc;
+        storeWrapper['store'].init = jest.fn().mockReturnValue(storeWrapper.setupIncomingTaskHandler(cc));
+
+        const options = {someOption: 'value'};
+        await storeWrapper.init(options);
+        storeWrapper['store'].taskList = [];
+
+        const mockTask = {
+          data: {
+            interaction: {
+              isTerminated: true,
+              state: 'wrapUp',
+              participants: {
+                agent1: {
+                  isWrappedUp: false,
+                },
+              },
+            },
+            agentId: 'agent1',
+          },
+          on: jest.fn(),
+          off: jest.fn(),
+        };
+
+        act(() => {
+          storeWrapper['cc'].on.mock.calls[1][1]();
+        });
+
+        act(() => {
+          const hydrateTaskCb = storeWrapper['cc'].on.mock.calls.find(
+            (call) => call[0] === TASK_EVENTS.TASK_HYDRATE
+          )[1];
+          hydrateTaskCb(mockTask);
+        });
+
+        expect(setStateSpy).toHaveBeenCalledWith({
+          name: 'Engaged',
+          developerName: 'ENGAGED',
+        });
+      });
+
+      it('should handle custom state correctly when wrapup is not required', async () => {
+        const setStateSpy = jest.spyOn(storeWrapper, 'setState');
+
+        const cc = storeWrapper['store'].cc;
+        storeWrapper['store'].init = jest.fn().mockReturnValue(storeWrapper.setupIncomingTaskHandler(cc));
+
+        const options = {someOption: 'value'};
+        await storeWrapper.init(options);
+        storeWrapper['store'].taskList = [];
+
+        const mockTask = {
+          data: {
+            interaction: {
+              isTerminated: true,
+              state: 'wrapUp',
+              participants: {
+                agent1: {
+                  isWrappedUp: true,
+                },
+              },
+            },
+            agentId: 'agent1',
+          },
+          on: jest.fn(),
+          off: jest.fn(),
+        };
+
+        act(() => {
+          storeWrapper['cc'].on.mock.calls[1][1]();
+        });
+
+        act(() => {
+          const hydrateTaskCb = storeWrapper['cc'].on.mock.calls.find(
+            (call) => call[0] === TASK_EVENTS.TASK_HYDRATE
+          )[1];
+          hydrateTaskCb(mockTask);
+        });
+
+        expect(setStateSpy).toHaveBeenCalledTimes(2);
+
+        expect(setStateSpy).toHaveBeenCalledWith({
+          reset: true,
+        });
+      });
+    });
+
     it('should handle hydrating the store with correct data', async () => {
       const setCurrentTaskSpy = jest.spyOn(storeWrapper, 'setCurrentTask');
       const setTaskListSpy = jest.spyOn(storeWrapper, 'setTaskList');


### PR DESCRIPTION
# Completes Ad-hoc

# In this PR

- A user is already logged in and on a call and now if a new session is initiated, the custom status is not being set
- This PR fixes that by handling this in the hydrateHandler

# Known issue

- If an existing session is logged out, the status is set back to "Meeting"

# Screen recording

https://github.com/user-attachments/assets/26e134b3-f21c-432d-879c-af7ab6a93413
