### PR TITLE
chore(tooling): add pull request checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,55 @@ env:
   rid: ${{ github.run_id }}-${{ github.run_number }}
 
 jobs:
+  validate:
+    name: Validate Pull Request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate Labels
+        run: |
+          HEAD_REPO=${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO=${{ github.event.pull_request.base.repo.full_name }}
+          FROM_BASE=0; [ "$HEAD_REPO" == "$BASE_REPO" ] && FROM_BASE=1
+
+          HAS_VALIDATED_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'validated') }}
+          VALIDATED=0; [ "$HAS_VALIDATED_LABEL" == "true" ] && VALIDATED=1
+
+          echo from base $FROM_BASE
+          echo validated $VALIDATED
+
+          if [[ $FROM_BASE == 1 || $VALIDATED == 1 ]]
+          then
+            echo 'pull request is validated, running tests'
+            exit 0
+          else
+            echo 'pull request is not validated, exiting'
+            exit 1
+          fi
+
+      - name: Validate PR title
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          echo "PR Title is: '$TITLE'"
+
+          # Pattern explanation:
+          #   ^(fix|feat|chore)   -> Must start with one of these keywords
+          #   \(                  -> Then an opening parenthesis
+          #   [^()]+             -> Some non-empty text not containing parentheses
+          #   \)                 -> A closing parenthesis
+          #   :                  -> A colon
+          #   .+                 -> Some description text after the colon
+          #
+          regex="^(fix|feat|chore)\([^()]+\): .+"
+
+          if [[ $TITLE =~ $regex ]]; then
+            echo "PR title is valid."
+          else
+            echo "Error: PR title does NOT follow the required convention."
+            echo "Expected format: fix|feat|chore(some-text): description..."
+            exit 1
+          fi
+
   install:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,14 +28,6 @@ jobs:
           TITLE="${{ github.event.pull_request.title }}"
           echo "PR Title is: '$TITLE'"
 
-          # Pattern explanation:
-          #   ^(fix|feat|chore)   -> Must start with one of these keywords
-          #   \(                  -> Then an opening parenthesis
-          #   [^()]+             -> Some non-empty text not containing parentheses
-          #   \)                 -> A closing parenthesis
-          #   :                  -> A colon
-          #   .+                 -> Some description text after the colon
-          #
           regex="^(fix|feat|chore)\([^()]+\): .+"
 
           if [[ $TITLE =~ $regex ]]; then

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,7 @@ on:
   pull_request_target:
     branches:
       - ccwidgets
-      - add-checks-pull-request
+
     types: [opened, labeled, reopened, synchronize]
   workflow_dispatch:
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,7 @@ on:
   pull_request_target:
     branches:
       - ccwidgets
+      - add-checks-pull-request
     types: [opened, labeled, reopened, synchronize]
   workflow_dispatch:
 
@@ -19,29 +20,9 @@ jobs:
   validate:
     name: Validate Pull Request
     runs-on: ubuntu-latest
+    if: contains(toJson(github.event.pull_request.labels), 'validated')
 
     steps:
-      - name: Validate Labels
-        run: |
-          HEAD_REPO=${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO=${{ github.event.pull_request.base.repo.full_name }}
-          FROM_BASE=0; [ "$HEAD_REPO" == "$BASE_REPO" ] && FROM_BASE=1
-
-          HAS_VALIDATED_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'validated') }}
-          VALIDATED=0; [ "$HAS_VALIDATED_LABEL" == "true" ] && VALIDATED=1
-
-          echo from base $FROM_BASE
-          echo validated $VALIDATED
-
-          if [[ $FROM_BASE == 1 || $VALIDATED == 1 ]]
-          then
-            echo 'pull request is validated, running tests'
-            exit 0
-          else
-            echo 'pull request is not validated, exiting'
-            exit 1
-          fi
-
       - name: Validate PR title
         run: |
           TITLE="${{ github.event.pull_request.title }}"
@@ -67,6 +48,7 @@ jobs:
 
   install:
     runs-on: ubuntu-latest
+    needs: validate
     steps:
       - name: Checkout Project
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds validations to the Pull_Request CI job to ensure that the right label and title are set in the description. This is to ensure
1. Only those who have write access can trigger Actions on the PR
2. Titles match what semantic-release looks for to ensure we don't run into deployment issues

PR where this was tested: https://github.com/sreenara/widgets/pull/1
1. Created a PR against this branch to ensure the checks start
2. When the label is not added, no checks are run and everything is skipped
3. When the label is added, the title of the PR is checked and ensures that the author has set it correctly, else the remaining pipeline does not run