### PR TITLE
fix(task): accept browser calls on login

### DIFF
--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "mobx": "6.13.5",
     "typescript": "5.6.3",
-    "webex": "3.8.0-next.40"
+    "webex": "3.8.0-next.44"
   },
   "devDependencies": {
     "@babel/core": "7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9420,7 +9420,7 @@ __metadata:
     ts-loader: "npm:9.5.1"
     typescript: "npm:5.6.3"
     typescript-eslint: "npm:^8.24.1"
-    webex: "npm:3.8.0-next.40"
+    webex: "npm:3.8.0-next.44"
     webpack: "npm:5.94.0"
     webpack-cli: "npm:5.1.4"
     webpack-merge: "npm:6.0.1"
@@ -10568,16 +10568,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-voicea@npm:3.8.0-next.30":
-  version: 3.8.0-next.30
-  resolution: "@webex/internal-plugin-voicea@npm:3.8.0-next.30"
+"@webex/internal-plugin-voicea@npm:3.8.0-next.32":
+  version: 3.8.0-next.32
+  resolution: "@webex/internal-plugin-voicea@npm:3.8.0-next.32"
   dependencies:
     "@webex/internal-plugin-llm": "npm:3.8.0-next.14"
     "@webex/internal-plugin-mercury": "npm:3.8.0-next.13"
-    "@webex/plugin-meetings": "npm:3.8.0-next.30"
+    "@webex/plugin-meetings": "npm:3.8.0-next.32"
     "@webex/webex-core": "npm:3.8.0-next.11"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/fca96ce1c14239be7b1868502234ec927fefd6aef35ce1d89ab9d541d8033ea1690f37ec2c5180e7aef696b3b3a6cd57c12508f1b16bfe051e7c7af19dbb7161
+  checksum: 10c0/4bf1dfd8249633c2aae0bb8a9616b8198fa2b6aac91be0fcccd77f23204d0510b2174a4b1b9b2737315fad31697d94d77e4e43ddfd7d5649cf1610ef3a105e61
   languageName: node
   linkType: hard
 
@@ -10785,9 +10785,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-cc@npm:3.8.0-next.23":
-  version: 3.8.0-next.23
-  resolution: "@webex/plugin-cc@npm:3.8.0-next.23"
+"@webex/plugin-cc@npm:3.8.0-next.25":
+  version: 3.8.0-next.25
+  resolution: "@webex/plugin-cc@npm:3.8.0-next.25"
   dependencies:
     "@types/platform": "npm:1.3.4"
     "@webex/calling": "npm:3.8.0-next.14"
@@ -10796,7 +10796,7 @@ __metadata:
     "@webex/webex-core": "npm:3.8.0-next.11"
     buffer: "npm:6.0.3"
     jest-html-reporters: "npm:3.0.11"
-  checksum: 10c0/af417fc8800e9888cfcc665074f6b7750029117ae7c592100ba8c43d496811f88a35d0119be86a324f2283a2ee6b1db38d6ee5bdff0da860de60290136ee45c8
+  checksum: 10c0/39b471fe9da338cfe37f86d4d9f2e4fa5ea5f19546dbed4442dfcf4fd26f516a3168694270d4b5daa03a9687b24faa7884fe22ddd8d8115e86d4c38b8dcecb00
   languageName: node
   linkType: hard
 
@@ -10950,9 +10950,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-meetings@npm:3.8.0-next.30":
-  version: 3.8.0-next.30
-  resolution: "@webex/plugin-meetings@npm:3.8.0-next.30"
+"@webex/plugin-meetings@npm:3.8.0-next.32":
+  version: 3.8.0-next.32
+  resolution: "@webex/plugin-meetings@npm:3.8.0-next.32"
   dependencies:
     "@webex/common": "npm:3.8.0-next.11"
     "@webex/event-dictionary-ts": "npm:^1.0.1688"
@@ -10964,7 +10964,7 @@ __metadata:
     "@webex/internal-plugin-metrics": "npm:3.8.0-next.11"
     "@webex/internal-plugin-support": "npm:3.8.0-next.13"
     "@webex/internal-plugin-user": "npm:3.8.0-next.11"
-    "@webex/internal-plugin-voicea": "npm:3.8.0-next.30"
+    "@webex/internal-plugin-voicea": "npm:3.8.0-next.32"
     "@webex/media-helpers": "npm:3.8.0-next.12"
     "@webex/plugin-people": "npm:3.8.0-next.13"
     "@webex/plugin-rooms": "npm:3.8.0-next.13"
@@ -10981,7 +10981,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     webrtc-adapter: "npm:^8.1.2"
-  checksum: 10c0/868d663da47614bf9871e41923a56c99aec5a62dd5955e727fae6492ffb6c496cb470f0395a32811a5ed7a67e2432165e4274a849a9456a1d6831cb137ac5e96
+  checksum: 10c0/60032198bc6fe78b92ad4dc2bd5c396a9df32ca50ec3e385a0b7450434405b83d15c5899268914898f7d0a105f9ba8dc43fcc3d9475ca2019f3ff29c8d59973b
   languageName: node
   linkType: hard
 
@@ -34558,9 +34558,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webex@npm:3.8.0-next.40":
-  version: 3.8.0-next.40
-  resolution: "webex@npm:3.8.0-next.40"
+"webex@npm:3.8.0-next.44":
+  version: 3.8.0-next.44
+  resolution: "webex@npm:3.8.0-next.44"
   dependencies:
     "@babel/polyfill": "npm:^7.12.1"
     "@babel/runtime-corejs2": "npm:^7.14.8"
@@ -34571,13 +34571,13 @@ __metadata:
     "@webex/internal-plugin-llm": "npm:3.8.0-next.14"
     "@webex/internal-plugin-presence": "npm:3.8.0-next.13"
     "@webex/internal-plugin-support": "npm:3.8.0-next.13"
-    "@webex/internal-plugin-voicea": "npm:3.8.0-next.30"
+    "@webex/internal-plugin-voicea": "npm:3.8.0-next.32"
     "@webex/plugin-attachment-actions": "npm:3.8.0-next.13"
     "@webex/plugin-authorization": "npm:3.8.0-next.12"
-    "@webex/plugin-cc": "npm:3.8.0-next.23"
+    "@webex/plugin-cc": "npm:3.8.0-next.25"
     "@webex/plugin-device-manager": "npm:3.8.0-next.14"
     "@webex/plugin-logger": "npm:3.8.0-next.11"
-    "@webex/plugin-meetings": "npm:3.8.0-next.30"
+    "@webex/plugin-meetings": "npm:3.8.0-next.32"
     "@webex/plugin-memberships": "npm:3.8.0-next.13"
     "@webex/plugin-messages": "npm:3.8.0-next.13"
     "@webex/plugin-people": "npm:3.8.0-next.13"
@@ -34588,7 +34588,7 @@ __metadata:
     "@webex/storage-adapter-local-storage": "npm:3.8.0-next.11"
     "@webex/webex-core": "npm:3.8.0-next.11"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/47b2fef2215b2c9e45fe5025c2db2275d05c0ed3f8928585a31cceea6e4c4af3420fbdd3f075e6bb707c39210b6adba8decd5192cf2dbf8a0d760756ad01f5e7
+  checksum: 10c0/7eb4e4db5ce8b8eaabf5c4dda24f5ddbbd45c6bab86c2d29f9828869e8221c18c430f0c38f5b87a07c7ec3a513f6aab96762d2fb0320798ff7e70246924b5af4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Completes Ad-hoc

# In this PR

SDK Changelog - https://webex.github.io/webex-js-sdk/changelog/?stable_version=3.8.0&commitMessage=%234213
SDK PR - https://github.com/webex/webex-js-sdk/pull/4213

Quoting description from SDK PR:

> When the WebRTC calls came in, the accept API was rejecting with errors. 
> 
> ![Screenshot 2025-04-16 at 5 15 33 PM](https://github.com/user-attachments/assets/8f1ecfd4-e825-444e-92a5-261e4b4376e5)
> 
> 
> Digging deeper, found out that the error was because an the following condition wasn't going through and `loginOption` was `undefined` if it is a login case.
> <img width="1007" alt="Screenshot 2025-04-16 at 5 43 54 PM" src="https://github.com/user-attachments/assets/62b63d15-2227-4513-a015-9b071632b8bc" />
> 
> The relogin worked alright because, on relogin we set this value today via the this.handle
> 
> <img width="1132" alt="Screenshot 2025-04-16 at 5 45 02 PM" src="https://github.com/user-attachments/assets/a564a095-97f4-4d28-b80c-036a293565f6" />
> 
> ## by making the following changes
> 
> On the login, when found that it is a WebRTC call and after registering the calling line successfully, the login option is set to BROWSER.
> 
> ## Demo
> 
> https://app.vidcast.io/share/15d09530-ce37-4624-a557-6914e3a6f263