### PR TITLE
fix(contact-center): fix bugs listed in CAI-6468

### DIFF
--- a/packages/contact-center/cc-components/src/components/UserState/constant.ts
+++ b/packages/contact-center/cc-components/src/components/UserState/constant.ts
@@ -1,0 +1,5 @@
+export const userStateLabels = {
+  availableTooltip: 'Availability State',
+  customWithAvailableTooltip: 'You are currently engaged in an interaction and in the Available state.',
+  customWithIdleStateTooltip: 'You are currently engaged in an interaction and in the idle state {{currentState}}.',
+};

--- a/packages/contact-center/cc-components/src/components/UserState/user-state.scss
+++ b/packages/contact-center/cc-components/src/components/UserState/user-state.scss
@@ -160,3 +160,7 @@
 .tooltip .md-modal-container-arrow-wrapper .md-modal-arrow-svg path {
   fill: var(--mds-color-theme-inverted-background-normal) !important;
 }
+
+.tooltip-text {
+  text-align: center;
+}

--- a/packages/contact-center/cc-components/src/components/UserState/user-state.scss
+++ b/packages/contact-center/cc-components/src/components/UserState/user-state.scss
@@ -113,34 +113,32 @@
     }
   }
 
-  .md-select-popover ul li[data-key^="hide-"] {
+  .md-select-popover ul li[data-key^='hide-'] {
     display: none;
   }
 
-.item-container.selected {
-  &.available {
-    .state-icon {
-      --mdc-icon-fill-color: var(--mds-color-theme-outline-join-normal);
+  .item-container.selected {
+    &.available {
+      .state-icon {
+        --mdc-icon-fill-color: var(--mds-color-theme-outline-join-normal);
+      }
+
+      .state-name {
+        color: var(--mds-color-theme-outline-join-normal);
+      }
     }
 
-    .state-name {
-      color: var(--mds-color-theme-outline-join-normal);
-    }
-  }
+    &.idle {
+      .state-icon {
+        --mdc-icon-fill-color: var(--mds-color-theme-text-primary-normal);
+      }
 
-  &.idle {
-    .state-icon {
-      --mdc-icon-fill-color: var(--mds-color-theme-text-primary-normal);
-    }
-
-    .state-name {
-      color: var(--mds-color-theme-text-primary-normal);
+      .state-name {
+        color: var(--mds-color-theme-text-primary-normal);
+      }
     }
   }
 }
-
-}
-
 
 .select-arrow-icon {
   position: absolute;
@@ -151,4 +149,14 @@
   align-items: center;
   pointer-events: none;
   z-index: 1;
+}
+
+.tooltip.md-modal-container-wrapper {
+  color: var(--mds-color-theme-inverted-text-primary-normal);
+  background-color: var(--mds-color-theme-inverted-background-normal) !important;
+  max-width: 19rem;
+}
+
+.tooltip .md-modal-container-arrow-wrapper .md-modal-arrow-svg path {
+  fill: var(--mds-color-theme-inverted-background-normal) !important;
 }

--- a/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
+++ b/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
@@ -78,7 +78,13 @@ const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
 
   const getTooltipText = () => {
     if (customState && customState.developerName === 'ENGAGED') {
-      return `You are currently engaged in an interaction and in the Available state.`;
+      const currentStateObj = idleCodes.find((item) => item.id === currentState);
+
+      if (currentStateObj.name === AgentUserState.Available) {
+        return `You are currently engaged in an interaction and in the Available state.`;
+      } else {
+        return `You are currently engaged in an interaction and in the idle state ${currentStateObj.name}.`;
+      }
     }
 
     return 'Availability State';
@@ -138,7 +144,9 @@ const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
           </SelectNext>
         }
       >
-        <Text tagName="small">{getTooltipText()}</Text>
+        <Text tagName="small" className="tooltip-text">
+          {getTooltipText()}
+        </Text>
       </TooltipNext>
 
       {!customState && (

--- a/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
+++ b/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
@@ -7,6 +7,7 @@ import './user-state.scss';
 import {SelectNext, Text, TooltipNext} from '@momentum-ui/react-collaboration';
 import {Item} from '@react-stately/collections';
 import {Icon} from '@momentum-design/components/dist/react';
+import {userStateLabels} from './constant';
 
 const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
   const {
@@ -81,13 +82,13 @@ const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
       const currentStateObj = idleCodes.find((item) => item.id === currentState);
 
       if (currentStateObj.name === AgentUserState.Available) {
-        return `You are currently engaged in an interaction and in the Available state.`;
+        return userStateLabels.customWithAvailableTooltip;
       } else {
-        return `You are currently engaged in an interaction and in the idle state ${currentStateObj.name}.`;
+        return userStateLabels.customWithIdleStateTooltip.replace(/{{.*?}}/g, currentStateObj.name);
       }
     }
 
-    return 'Availability State';
+    return userStateLabels.availableTooltip;
   };
 
   // Sorts the dropdown items by keeping 'Available' at the top and sorting the rest alphabetically by name

--- a/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
+++ b/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
@@ -4,7 +4,7 @@ import {IUserState, AgentUserState} from './user-state.types';
 import {formatTime} from '../../utils';
 
 import './user-state.scss';
-import {SelectNext, Text} from '@momentum-ui/react-collaboration';
+import {SelectNext, Text, TooltipNext} from '@momentum-ui/react-collaboration';
 import {Item} from '@react-stately/collections';
 import {Icon} from '@momentum-design/components/dist/react';
 
@@ -76,6 +76,14 @@ const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
     }
   };
 
+  const getTooltipText = () => {
+    if (customState && customState.developerName === 'ENGAGED') {
+      return `You are currently engaged in an interaction and in the Available state.`;
+    }
+
+    return 'Availability State';
+  };
+
   // Sorts the dropdown items by keeping 'Available' at the top and sorting the rest alphabetically by name
   const sortedItems = [
     ...items.filter((item) => item.name === AgentUserState.Available),
@@ -84,41 +92,54 @@ const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
 
   return (
     <div className="user-state-container">
-      <SelectNext
-        label=""
-        aria-label="user-state"
-        direction="bottom"
-        onSelectionChange={(key: string) => {
-          const cleanKey = key.startsWith('hide-') ? key.substring(5) : key;
-          setAgentStatus(cleanKey);
-        }}
-        showBorder
-        selectedKey={selectedKey}
-        items={sortedItems}
-        className={`state-select ${getDropdownClass()}`}
-      >
-        {(item) => {
-          const isRonaOrEngaged = [AgentUserState.RONA, AgentUserState.Engaged].includes(
-            idleCodes.find((code) => code.id === currentState)?.name || ''
-          );
-          const shouldHighlight = currentState === item.id || (isRonaOrEngaged && item.id === previousSelectableState);
+      <TooltipNext
+        type="description"
+        placement="bottom"
+        variant="small"
+        color="primary"
+        delay={[0, 0]}
+        className="tooltip"
+        triggerComponent={
+          <SelectNext
+            label=""
+            aria-label="user-state"
+            direction="bottom"
+            onSelectionChange={(key: string) => {
+              const cleanKey = key.startsWith('hide-') ? key.substring(5) : key;
+              setAgentStatus(cleanKey);
+            }}
+            showBorder
+            selectedKey={selectedKey}
+            items={sortedItems}
+            className={`state-select ${getDropdownClass()}`}
+          >
+            {(item) => {
+              const isRonaOrEngaged = [AgentUserState.RONA, AgentUserState.Engaged].includes(
+                idleCodes.find((code) => code.id === currentState)?.name || ''
+              );
+              const shouldHighlight =
+                currentState === item.id || (isRonaOrEngaged && item.id === previousSelectableState);
 
-          return (
-            <Item key={item.id} textValue={item.name}>
-              <div className={`item-container ${shouldHighlight ? `selected ${getIconStyle(item).class}` : ''}`}>
-                <Icon
-                  name={getIconStyle(item).iconName}
-                  title=""
-                  className={`state-icon ${getIconStyle(item).class}`}
-                />
-                <Text className={`state-name ${getIconStyle(item).class}`} tagName={'small'}>
-                  {item.name}
-                </Text>
-              </div>
-            </Item>
-          );
-        }}
-      </SelectNext>
+              return (
+                <Item key={item.id} textValue={item.name}>
+                  <div className={`item-container ${shouldHighlight ? `selected ${getIconStyle(item).class}` : ''}`}>
+                    <Icon
+                      name={getIconStyle(item).iconName}
+                      title=""
+                      className={`state-icon ${getIconStyle(item).class}`}
+                    />
+                    <Text className={`state-name ${getIconStyle(item).class}`} tagName={'small'}>
+                      {item.name}
+                    </Text>
+                  </div>
+                </Item>
+              );
+            }}
+          </SelectNext>
+        }
+      >
+        <Text tagName="small">{getTooltipText()}</Text>
+      </TooltipNext>
 
       {!customState && (
         <span className={`elapsedTime ${isSettingAgentStatus ? 'elapsedTime-disabled' : ''}`}>

--- a/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
+++ b/packages/contact-center/cc-components/src/components/UserState/user-state.tsx
@@ -4,9 +4,9 @@ import {IUserState, AgentUserState} from './user-state.types';
 import {formatTime} from '../../utils';
 
 import './user-state.scss';
-import {SelectNext, Text, TooltipNext} from '@momentum-ui/react-collaboration';
+import {SelectNext, Text} from '@momentum-ui/react-collaboration';
 import {Item} from '@react-stately/collections';
-import {Icon} from '@momentum-design/components/dist/react';
+import {Icon, Tooltip} from '@momentum-design/components/dist/react';
 import {userStateLabels} from './constant';
 
 const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
@@ -99,56 +99,48 @@ const UserStateComponent: React.FunctionComponent<IUserState> = (props) => {
 
   return (
     <div className="user-state-container">
-      <TooltipNext
-        type="description"
-        placement="bottom"
-        variant="small"
-        color="primary"
-        delay={[0, 0]}
-        className="tooltip"
-        triggerComponent={
-          <SelectNext
-            label=""
-            aria-label="user-state"
-            direction="bottom"
-            onSelectionChange={(key: string) => {
-              const cleanKey = key.startsWith('hide-') ? key.substring(5) : key;
-              setAgentStatus(cleanKey);
-            }}
-            showBorder
-            selectedKey={selectedKey}
-            items={sortedItems}
-            className={`state-select ${getDropdownClass()}`}
-          >
-            {(item) => {
-              const isRonaOrEngaged = [AgentUserState.RONA, AgentUserState.Engaged].includes(
-                idleCodes.find((code) => code.id === currentState)?.name || ''
-              );
-              const shouldHighlight =
-                currentState === item.id || (isRonaOrEngaged && item.id === previousSelectableState);
-
-              return (
-                <Item key={item.id} textValue={item.name}>
-                  <div className={`item-container ${shouldHighlight ? `selected ${getIconStyle(item).class}` : ''}`}>
-                    <Icon
-                      name={getIconStyle(item).iconName}
-                      title=""
-                      className={`state-icon ${getIconStyle(item).class}`}
-                    />
-                    <Text className={`state-name ${getIconStyle(item).class}`} tagName={'small'}>
-                      {item.name}
-                    </Text>
-                  </div>
-                </Item>
-              );
-            }}
-          </SelectNext>
-        }
+      <SelectNext
+        id="user-state-tooltip"
+        label=""
+        aria-label="user-state"
+        direction="bottom"
+        onSelectionChange={(key: string) => {
+          const cleanKey = key.startsWith('hide-') ? key.substring(5) : key;
+          setAgentStatus(cleanKey);
+        }}
+        showBorder
+        selectedKey={selectedKey}
+        items={sortedItems}
+        className={`state-select ${getDropdownClass()}`}
       >
+        {(item) => {
+          const isRonaOrEngaged = [AgentUserState.RONA, AgentUserState.Engaged].includes(
+            idleCodes.find((code) => code.id === currentState)?.name || ''
+          );
+          const shouldHighlight = currentState === item.id || (isRonaOrEngaged && item.id === previousSelectableState);
+
+          return (
+            <Item key={item.id} textValue={item.name}>
+              <div className={`item-container ${shouldHighlight ? `selected ${getIconStyle(item).class}` : ''}`}>
+                <Icon
+                  name={getIconStyle(item).iconName}
+                  title=""
+                  className={`state-icon ${getIconStyle(item).class}`}
+                />
+                <Text className={`state-name ${getIconStyle(item).class}`} tagName={'small'}>
+                  {item.name}
+                </Text>
+              </div>
+            </Item>
+          );
+        }}
+      </SelectNext>
+
+      <Tooltip placement="bottom" color="contrast" delay="0, 0" className="tooltip" triggerID="user-state-tooltip">
         <Text tagName="small" className="tooltip-text">
           {getTooltipText()}
         </Text>
-      </TooltipNext>
+      </Tooltip>
 
       {!customState && (
         <span className={`elapsedTime ${isSettingAgentStatus ? 'elapsedTime-disabled' : ''}`}>

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -165,7 +165,6 @@ class StoreWrapper implements IStoreWrapper {
   setCurrentState = (state: string): void => {
     runInAction(() => {
       this.store.currentState = state;
-      this.store.customState = null;
     });
   };
 
@@ -289,7 +288,6 @@ class StoreWrapper implements IStoreWrapper {
     if ('id' in state) {
       runInAction(() => {
         this.setCurrentState(state.id);
-        this.store.customState = null;
       });
     } else {
       runInAction(() => {
@@ -576,10 +574,15 @@ class StoreWrapper implements IStoreWrapper {
       this.setConsultCompleted(true);
     }
 
-    this.setState({
-      developerName: ENGAGED_LABEL,
-      name: ENGAGED_USERNAME,
-    });
+    if (
+      (['wrapUp', 'connected'].includes(task.data.interaction.state) && !task.data.isConsulted) ||
+      task.data.wrapUpRequired
+    ) {
+      this.setState({
+        developerName: ENGAGED_LABEL,
+        name: ENGAGED_USERNAME,
+      });
+    }
 
     const {interaction} = task.data;
     const {isTerminated} = interaction;

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -179,6 +179,7 @@ describe('storeEventsWrapper', () => {
 
       storeWrapper.setCurrentState('newState');
       expect(storeWrapper['store'].currentState).toBe('newState');
+      expect(storeWrapper['store'].customState).not.toBeNull();
     });
 
     it('should proxy consultCompleted', () => {

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -5,6 +5,9 @@ import {useOutdialCallProps} from '@webex/cc-components';
 import store, {TASK_EVENTS, BuddyDetails, DestinationType, ContactServiceQueue} from '@webex/cc-store';
 import {getControlsVisibility} from './Utils/task-util';
 
+const ENGAGED_LABEL = 'ENGAGED';
+const ENGAGED_USERNAME = 'Engaged';
+
 // Hook for managing the task list
 export const useTaskList = (props: UseTaskListProps) => {
   const {deviceType, onTaskAccepted, onTaskDeclined, logger, taskList} = props;
@@ -336,9 +339,21 @@ export const useCallControl = (props: useCallControlProps) => {
   };
 
   const wrapupCall = (wrapUpReason: string, auxCodeId: string) => {
-    currentTask.wrapup({wrapUpReason: wrapUpReason, auxCodeId: auxCodeId}).catch((error: Error) => {
-      logError(`Error wrapping up call: ${error}`, 'wrapupCall');
-    });
+    currentTask
+      .wrapup({wrapUpReason: wrapUpReason, auxCodeId: auxCodeId})
+      .then(() => {
+        const taskKeys = Object.keys(store.taskList);
+        if (taskKeys.length > 0) {
+          store.setCurrentTask(store.taskList[taskKeys[0]]);
+          store.setState({
+            developerName: ENGAGED_LABEL,
+            name: ENGAGED_USERNAME,
+          });
+        }
+      })
+      .catch((error: Error) => {
+        logError(`Error wrapping up call: ${error}`, 'wrapupCall');
+      });
   };
 
   const transferCall = async (transferDestination: string, destinationType: DestinationType) => {

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -762,6 +762,14 @@ describe('useCallControl', () => {
   });
 
   it('should call wrapupCall ', async () => {
+    store.setCurrentTask = jest.fn();
+    store.setState = jest.fn();
+
+    jest.spyOn(store, 'taskList', 'get').mockReturnValue({
+      anotherInteractionId: mockCurrentTask,
+      [mockCurrentTask.data.interactionId]: mockCurrentTask,
+    });
+
     const {result} = renderHook(() =>
       useCallControl({
         currentTask: mockCurrentTask,
@@ -785,6 +793,11 @@ describe('useCallControl', () => {
     expect(mockOnWrapUp).toHaveBeenCalledWith({
       task: mockCurrentTask,
       wrapUpReason: 'Wrap reason',
+    });
+    expect(store.setCurrentTask).toHaveBeenCalledWith(mockCurrentTask);
+    expect(store.setState).toHaveBeenCalledWith({
+      developerName: 'ENGAGED',
+      name: 'Engaged',
     });
   });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-6468](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6468) >

## This pull request addresses

There were various bugs which needed to be fixed for the `user-state`. List of the issues are shown below

- When in Custom State, when the agent changes the State from UI, the custom state goes away. This should not happen - **This is already working**
- RONA should have a timer but Engage shouldn't. (Test this case) - **This is already working**
- When in Custom State, if there's an event that changes the state, the custom state goes away. Testing Steps: (**Fixed**)
  - Login in to two windows
  - Jump on a call to see the states change to Engaged
  - Refresh one of two windows and see the state going to Meeting in the other window

[For all of the above, the fix is ideally to prioritize Custom State over the Agent desktop state changes and clear it on Wrapup]

- There's no tooltip today on the Widgets for Agent State. Please check Agent Desktop Behaviour and mock it. Cases to check (**Fixed**):
  - Hover on a non-custom state
  - Make a call and let it go to Engaged State and hover over it to see a tool tip
  - During an Engaged State, change the User State from Available to something else and see the tool tip behaviour
- When an agent has Multiple tasks, say Voice and Digital, if the Digital Task is wrapped up, the custom state is cleared even though there's a Voice Task. This should be handled in both Regular and Relogin cases (Please check how Agent desktop behaves as well)  - **Fixed**
- When testing responsiveness using Chrome Developer Console's Mobile emulator, the tap doesn't work on User State. The dropdown does not show up - **When we change from desktop to mobile view, it does not work but when we reload the page in the mobile view, it works**
- During an extension call, if the page is refreshed, the user state is showing Available instead of Engaged - **Fixed**

## by making the following changes

Updated the code mainly for the following files to fix the above issues
- `packages/contact-center/cc-components/src/components/UserState/user-state.tsx`
- `packages/contact-center/store/src/storeEventsWrapper.ts`
- `packages/contact-center/task/src/helper.ts`

**Vidcast** - https://app.vidcast.io/share/010ae2cc-1dc4-4b1d-b668-ac42350e9ff3?playerMode=vidcast
**RONA Timer** - https://app.vidcast.io/share/7a62d0a6-ddb2-469d-8e56-f52ab3519963
**Tooltip improvement** - https://app.vidcast.io/share/d03463a5-e6be-4995-bb9e-a67ec0695fe3

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] The testing is done with the amplify link
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

All the scenarios mentioned in the description were tested.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document

---