### PR TITLE
fix(cc-task): TaskList onTaskSelected callback

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/task.types.ts
+++ b/packages/contact-center/cc-components/src/components/task/task.types.ts
@@ -50,6 +50,11 @@ export interface TaskProps {
   onTaskDeclined?: (task: ITask) => void;
 
   /**
+   * Handler for task selected in TaskList
+   */
+  onTaskSelected?: (task: ITask) => void;
+
+  /**
    * accept incoming task action
    */
   accept: (task: ITask) => void;

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -26,6 +26,7 @@ class StoreWrapper implements IStoreWrapper {
   onIncomingTask: ({task}: {task: ITask}) => void;
   onTaskRejected?: (task: ITask, reason: string) => void;
   onTaskAssigned?: (task: ITask) => void;
+  onTaskSelected?: (task: ITask) => void;
 
   constructor() {
     this.store = Store.getInstance();
@@ -214,6 +215,12 @@ class StoreWrapper implements IStoreWrapper {
         });
       }
 
+      // Determine if the new task is the same as the current task
+      let isSameTask = false;
+      if (task && this.currentTask) {
+        isSameTask = task.data.interactionId === this.currentTask.data.interactionId;
+      }
+
       // Update the current task
       this.store.currentTask = task ? Object.assign(Object.create(Object.getPrototypeOf(task)), task) : null;
 
@@ -237,6 +244,10 @@ class StoreWrapper implements IStoreWrapper {
         this.setCurrentConsultQueueId(currentConsultQueueId);
         this.setConsultStartTimeStamp(consultStartTimeStamp);
         this.setConsultOfferReceived(consultOfferReceived);
+      }
+
+      if (this.onTaskSelected && !isSameTask) {
+        this.onTaskSelected(task);
       }
     });
   };
@@ -320,6 +331,13 @@ class StoreWrapper implements IStoreWrapper {
 
   setTaskAssigned = (callback: ((task: ITask) => void) | undefined): void => {
     this.onTaskAssigned = callback;
+  };
+
+  setTaskSelected = (callback: ((task: ITask) => void) | undefined): void => {
+    if (callback && this.currentTask) {
+      callback(this.currentTask);
+    }
+    this.onTaskSelected = callback;
   };
 
   setCCCallback = (event: CC_EVENTS | TASK_EVENTS, callback) => {

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -1616,4 +1616,99 @@ describe('storeEventsWrapper', () => {
     expect(setConsultStartTimeStampSpy).toHaveBeenCalledWith(1234567890);
     jest.clearAllMocks();
   });
+
+  describe('setCurrentTask', () => {
+    let mockTaskA: ITask;
+    let mockTaskB: ITask;
+
+    beforeEach(() => {
+      mockTaskA = {
+        data: {interactionId: 'taskA'},
+      } as unknown as ITask;
+      mockTaskB = {
+        data: {interactionId: 'taskB'},
+      } as unknown as ITask;
+      storeWrapper['store'].taskMetaData = {};
+      storeWrapper['store'].consultCompleted = true;
+      storeWrapper['store'].consultInitiated = true;
+      storeWrapper['store'].consultAccepted = true;
+      storeWrapper['store'].isQueueConsultInProgress = true;
+      storeWrapper['store'].currentConsultQueueId = 'queue1';
+      storeWrapper['store'].consultStartTimeStamp = 123;
+      storeWrapper['store'].consultOfferReceived = true;
+      storeWrapper['store'].currentTask = null;
+      storeWrapper.onTaskSelected = undefined;
+    });
+
+    it('should set currentTask and save previous task metadata', () => {
+      // Set an initial task
+      storeWrapper.setCurrentTask(mockTaskA);
+      expect(storeWrapper.currentTask).toEqual(mockTaskA);
+
+      // Change to a new task, should save metadata for previous
+      storeWrapper.setCurrentTask(mockTaskB);
+      expect(storeWrapper.currentTask).toEqual(mockTaskB);
+      expect(storeWrapper['store'].taskMetaData['taskA']).toEqual({
+        consultCompleted: true,
+        consultInitiated: true,
+        consultAccepted: true,
+        isQueueConsultInProgress: true,
+        currentConsultQueueId: 'queue1',
+        consultStartTimeStamp: 123,
+        consultOfferReceived: true,
+      });
+    });
+
+    it('should restore metadata for new task if present', () => {
+      storeWrapper['store'].taskMetaData['taskB'] = {
+        consultCompleted: false,
+        consultInitiated: false,
+        consultAccepted: true,
+        isQueueConsultInProgress: false,
+        currentConsultQueueId: 'queueX',
+        consultStartTimeStamp: 456,
+        consultOfferReceived: false,
+      };
+      const setConsultAcceptedSpy = jest.spyOn(storeWrapper, 'setConsultAccepted');
+      const setConsultInitiatedSpy = jest.spyOn(storeWrapper, 'setConsultInitiated');
+      const setConsultCompletedSpy = jest.spyOn(storeWrapper, 'setConsultCompleted');
+      const setIsQueueConsultInProgressSpy = jest.spyOn(storeWrapper, 'setIsQueueConsultInProgress');
+      const setCurrentConsultQueueIdSpy = jest.spyOn(storeWrapper, 'setCurrentConsultQueueId');
+      const setConsultStartTimeStampSpy = jest.spyOn(storeWrapper, 'setConsultStartTimeStamp');
+      const setConsultOfferReceivedSpy = jest.spyOn(storeWrapper, 'setConsultOfferReceived');
+
+      storeWrapper.setCurrentTask(mockTaskB);
+
+      expect(setConsultAcceptedSpy).toHaveBeenCalledWith(true);
+      expect(setConsultInitiatedSpy).toHaveBeenCalledWith(false);
+      expect(setConsultCompletedSpy).toHaveBeenCalledWith(false);
+      expect(setIsQueueConsultInProgressSpy).toHaveBeenCalledWith(false);
+      expect(setCurrentConsultQueueIdSpy).toHaveBeenCalledWith('queueX');
+      expect(setConsultStartTimeStampSpy).toHaveBeenCalledWith(456);
+      expect(setConsultOfferReceivedSpy).toHaveBeenCalledWith(false);
+    });
+
+    it('should call onTaskSelected if task changes', () => {
+      const onTaskSelected = jest.fn();
+      storeWrapper.onTaskSelected = onTaskSelected;
+      storeWrapper.setCurrentTask(mockTaskA);
+      expect(onTaskSelected).toHaveBeenCalledWith(mockTaskA);
+
+      // Should not call again if same task is set
+      onTaskSelected.mockClear();
+      storeWrapper.setCurrentTask(mockTaskA);
+      expect(onTaskSelected).not.toHaveBeenCalled();
+
+      // Should call if task changes
+      storeWrapper.setCurrentTask(mockTaskB);
+      expect(onTaskSelected).toHaveBeenCalledWith(mockTaskB);
+    });
+
+    it('should set currentTask to null if passed null', () => {
+      storeWrapper.setCurrentTask(mockTaskA);
+      expect(storeWrapper.currentTask).toEqual(mockTaskA);
+      storeWrapper.setCurrentTask(null);
+      expect(storeWrapper.currentTask).toBeNull();
+    });
+  });
 });

--- a/packages/contact-center/task/src/TaskList/index.tsx
+++ b/packages/contact-center/task/src/TaskList/index.tsx
@@ -6,16 +6,18 @@ import {TaskListComponent} from '@webex/cc-components';
 import {useTaskList} from '../helper';
 import {TaskListProps} from '../task.types';
 
-const TaskList: React.FunctionComponent<TaskListProps> = observer(({onTaskAccepted, onTaskDeclined}) => {
-  const {cc, taskList, currentTask, deviceType, logger} = store;
+const TaskList: React.FunctionComponent<TaskListProps> = observer(
+  ({onTaskAccepted, onTaskDeclined, onTaskSelected}) => {
+    const {cc, taskList, currentTask, deviceType, logger} = store;
 
-  const result = useTaskList({cc, deviceType, logger, taskList, onTaskAccepted, onTaskDeclined});
-  const props = {
-    ...result,
-    currentTask,
-  };
+    const result = useTaskList({cc, deviceType, logger, taskList, onTaskAccepted, onTaskDeclined, onTaskSelected});
+    const props = {
+      ...result,
+      currentTask,
+    };
 
-  return <TaskListComponent {...props} />;
-});
+    return <TaskListComponent {...props} />;
+  }
+);
 
 export {TaskList};

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -10,7 +10,7 @@ const ENGAGED_USERNAME = 'Engaged';
 
 // Hook for managing the task list
 export const useTaskList = (props: UseTaskListProps) => {
-  const {deviceType, onTaskAccepted, onTaskDeclined, logger, taskList} = props;
+  const {deviceType, onTaskAccepted, onTaskDeclined, onTaskSelected, logger, taskList} = props;
   const isBrowser = deviceType === 'BROWSER';
 
   const logError = (message: string, method: string) => {
@@ -21,14 +21,23 @@ export const useTaskList = (props: UseTaskListProps) => {
   };
 
   useEffect(() => {
-    store.setTaskAssigned(function (task) {
-      if (onTaskAccepted) onTaskAccepted(task);
-    });
+    if (onTaskAccepted) {
+      store.setTaskAssigned(function (task) {
+        onTaskAccepted(task);
+      });
+    }
 
-    store.setTaskRejected(function (task, reason) {
-      console.log('Task rejected:', task, reason);
-      if (onTaskDeclined) onTaskDeclined(task);
-    });
+    if (onTaskDeclined) {
+      store.setTaskRejected(function (task, reason) {
+        onTaskDeclined(task, reason);
+      });
+    }
+
+    if (onTaskSelected) {
+      store.setTaskSelected(function (task) {
+        onTaskSelected(task);
+      });
+    }
   }, []);
 
   const acceptTask = (task: ITask) => {

--- a/packages/contact-center/task/src/task.types.ts
+++ b/packages/contact-center/task/src/task.types.ts
@@ -3,10 +3,10 @@ import {TaskProps, ControlProps, OutdialCallProps} from '@webex/cc-components';
 export type UseTaskProps = Pick<TaskProps, 'incomingTask' | 'onAccepted' | 'onRejected' | 'deviceType' | 'logger'>;
 export type UseTaskListProps = Pick<
   TaskProps,
-  'cc' | 'taskList' | 'deviceType' | 'onTaskAccepted' | 'onTaskDeclined' | 'logger'
+  'cc' | 'taskList' | 'deviceType' | 'onTaskAccepted' | 'onTaskDeclined' | 'onTaskSelected' | 'logger'
 >;
 export type IncomingTaskProps = Pick<TaskProps, 'incomingTask' | 'onAccepted' | 'onRejected'>;
-export type TaskListProps = Pick<TaskProps, 'onTaskAccepted' | 'onTaskDeclined'>;
+export type TaskListProps = Pick<TaskProps, 'onTaskAccepted' | 'onTaskDeclined' | 'onTaskSelected'>;
 
 export type CallControlProps = Pick<
   ControlProps,

--- a/packages/contact-center/task/tests/TaskList/index.tsx
+++ b/packages/contact-center/task/tests/TaskList/index.tsx
@@ -20,6 +20,7 @@ jest.mock('@webex/cc-store', () => ({
   taskList: taskListMock,
   setTaskAssigned: jest.fn(),
   setTaskRejected: jest.fn(),
+  setTaskSelected: jest.fn(),
 }));
 
 describe('TaskList Component', () => {
@@ -28,7 +29,7 @@ describe('TaskList Component', () => {
   afterEach(cleanup);
 
   it('renders TaskListPresentational with the correct props', () => {
-    render(<TaskList onTaskAccepted={jest.fn()} onTaskDeclined={jest.fn()} />);
+    render(<TaskList onTaskAccepted={jest.fn()} onTaskDeclined={jest.fn()} onTaskSelected={jest.fn()} />);
 
     // Assert that `TaskListPresentational` is rendered.
     const taskListPresentational = screen.getByTestId('task-list');
@@ -54,6 +55,7 @@ describe('TaskList Component', () => {
       logger: undefined,
       onTaskAccepted: expect.any(Function),
       onTaskDeclined: expect.any(Function),
+      onTaskSelected: expect.any(Function),
       taskList: taskListMock,
     });
   });

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -24,6 +24,7 @@ const onAccepted = jest.fn();
 const onDeclined = jest.fn();
 const onTaskAccepted = jest.fn().mockImplementation(() => {});
 const onTaskDeclined = jest.fn();
+const onTaskSelected = jest.fn().mockImplementation(() => {});
 
 const logger = {
   error: jest.fn(),
@@ -330,14 +331,14 @@ describe('useTaskList Hook', () => {
     // Mock the callback registration
     store.setTaskAssigned = jest.fn((callback) => {
       // Store the callback
-      store.taskAssignedCallback = callback;
+      store.onTaskAssigned = callback;
     });
 
     renderHook(() => useTaskList({cc: ccMock, deviceType: '', onTaskAccepted, logger, taskList: mockTaskList}));
 
     // Manually trigger the stored callback with the task
     act(() => {
-      store.taskAssignedCallback(taskMock);
+      store.onTaskAssigned(taskMock);
     });
 
     expect(onTaskAccepted).toHaveBeenCalledWith(taskMock);
@@ -383,17 +384,40 @@ describe('useTaskList Hook', () => {
     // Mock the callback registration
     store.setTaskRejected = jest.fn((callback) => {
       // Store the callback
-      store.taskRejectedCallback = callback;
+      store.onTaskRejected = callback;
     });
 
     renderHook(() => useTaskList({cc: ccMock, deviceType: '', onTaskDeclined, logger, taskList: mockTaskList}));
 
     // Manually trigger the stored callback with the task
     act(() => {
-      store.taskRejectedCallback(taskMock, 'test-reason');
+      store.onTaskRejected(taskMock, 'test-reason');
     });
 
-    expect(onTaskDeclined).toHaveBeenCalledWith(taskMock);
+    expect(onTaskDeclined).toHaveBeenCalledWith(taskMock, 'test-reason');
+
+    // Ensure no errors are logged
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('should call onTaskSelected callback when provided', async () => {
+    // Reset the mock first
+    onTaskSelected.mockClear();
+
+    // Mock the callback registration
+    store.setTaskSelected = jest.fn((callback) => {
+      // Store the callback
+      store.onTaskSelected = callback;
+    });
+
+    renderHook(() => useTaskList({cc: ccMock, deviceType: '', onTaskSelected, logger, taskList: mockTaskList}));
+
+    // Manually trigger the stored callback with the task
+    act(() => {
+      store.onTaskSelected(taskMock);
+    });
+
+    expect(onTaskSelected).toHaveBeenCalledWith(taskMock);
 
     // Ensure no errors are logged
     expect(logger.error).not.toHaveBeenCalled();

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -139,6 +139,10 @@ function App() {
     console.log('onTaskDeclined invoked for task:', task);
   };
 
+  const onTaskSelected = (task) => {
+    console.log('onTaskSelected invoked for task:', task);
+  };
+
   const onHoldResume = () => {
     console.log('onHoldResume invoked');
   };
@@ -668,7 +672,7 @@ function App() {
                         <section className="section-box">
                           <fieldset className="fieldset">
                             <legend className="legend-box">Task List</legend>
-                            <TaskList onTaskAccepted={onTaskAccepted} onTaskDeclined={onTaskDeclined} />
+                            <TaskList onTaskAccepted={onTaskAccepted} onTaskDeclined={onTaskDeclined} onTaskSelected={onTaskSelected} />
                           </fieldset>
                         </section>
                       </div>


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# PARTIALLY COMPLETES [CAI-6283](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6283)

## This pull request addresses

TaskList component today does not let the developers know when a change in selection happens. This PR is raised to address this gap

## by making the following changes

* Add onTaskSelected Prop to TaskList component
* Update the store to set a new task selected call back
* Make call to this call back every time the currentTask is set to an actual task object. It won't be called if task or currentTask is null or if the set task is same as the current task

### Vidcast Demo

https://app.vidcast.io/share/917186b3-61f1-403e-9a4b-804b91887183

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] The testing is done with the amplify link
* Changing tasks when there are multiple tasks accepted
* Station Relogin with an existing task in place
* Accepting an incoming task
* Wrapping up one task when there are multiple tasks

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [x] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document

---