### PR TITLE
fix: set a valid default device type on initial login

### DIFF
--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -101,7 +101,7 @@ class Store implements IStore {
         this.agentId = response.agentId;
         this.wrapupCodes = response.wrapupCodes;
         this.isAgentLoggedIn = response.isAgentLoggedIn;
-        this.deviceType = response.deviceType ?? 'AGENT_DN';
+        this.deviceType = response.deviceType ?? this.loginOptions[0];
         this.dialNumber = response.dn;
         this.teamId = response.currentTeamId ?? '';
         this.currentState = response.lastStateAuxCodeId;

--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -17,6 +17,7 @@ import {
 import {ITask} from '@webex/plugin-cc';
 
 import {getFeatureFlags} from './util';
+import {LoginOptions} from '../../cc-components/src/components/StationLogin/constants';
 
 class Store implements IStore {
   private static instance: Store;
@@ -97,6 +98,7 @@ class Store implements IStore {
         this.loginOptions = response.webRtcEnabled
           ? response.loginVoiceOptions
           : response.loginVoiceOptions.filter((option) => option !== 'BROWSER');
+        this.loginOptions.sort((a, b) => Object.keys(LoginOptions).indexOf(a) - Object.keys(LoginOptions).indexOf(b));
         this.idleCodes = response.idleCodes;
         this.agentId = response.agentId;
         this.wrapupCodes = response.wrapupCodes;


### PR DESCRIPTION
## This pull request addresses

The default login option on first login is hardcoded to AGENT_DN in the store, but WebRTC only agents need not have the AGENT_DN login option. 

## by making the following changes

Setting the default option to a valid option from loginOptions when deviceType is undefined, i.e fresh login.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

https://app.vidcast.io/share/d8e67d2a-b77e-44a0-95c7-66018646ca33

- WebRTC only account. 
- All options available account and re-login scenario.
- [x] The testing is done with the amplify link

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
- [x] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document

---