### PR TITLE
fix(agent-invite-failed-events): show-agent-invite-failed-reasons

### DIFF
--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -22,7 +22,7 @@
     "test:styles": "eslint"
   },
   "dependencies": {
-    "@webex/plugin-cc": "3.8.1-next.28",
+    "@webex/plugin-cc": "3.8.1-next.29",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9498,7 +9498,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/plugin-cc": "npm:3.8.1-next.28"
+    "@webex/plugin-cc": "npm:3.8.1-next.29"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
@@ -11249,9 +11249,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-cc@npm:3.8.1-next.28":
-  version: 3.8.1-next.28
-  resolution: "@webex/plugin-cc@npm:3.8.1-next.28"
+"@webex/plugin-cc@npm:3.8.1-next.29":
+  version: 3.8.1-next.29
+  resolution: "@webex/plugin-cc@npm:3.8.1-next.29"
   dependencies:
     "@types/platform": "npm:1.3.4"
     "@webex/calling": "npm:3.8.1-next.20"
@@ -11263,7 +11263,7 @@ __metadata:
     "@webex/webex-core": "npm:3.8.1-next.10"
     jest-html-reporters: "npm:3.0.11"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/e3b99d259da4ced9a956716d20609b1be9be82afef4b5cd1ed288262ac40609607bf901e7d6b027b66ca56c68465b0710a1da012d97a9a69556f1547733440d6
+  checksum: 10c0/09027eb4d1b8b3fe63e0c2aace07978c27972b495558649952b39ae1d41952b76063da80bbc7b6eead62cc16f3685957cd115d537348a0301353a35dc619a1e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6910

## This pull request addresses


Displaying the appropriate reason via a modal popup when the agent is unavailable or uses an invalid number in extension mode. This behavior is now consistent with the handling of RONA time expiration and agent-declined scenarios.

## by making the following changes

Updated package.json and yarn.lock to use @webex/plugin-cc version 3.8.1-next.29.

<!-- You may include screenshots -->
<img width="1166" height="652" alt="Screenshot 2025-08-12 at 3 25 20 PM" src="https://github.com/user-attachments/assets/168dce65-f6c3-46ba-ac92-3e33f434adc0" />

<img width="1166" height="652" alt="Screenshot 2025-08-12 at 3 23 47 PM" src="https://github.com/user-attachments/assets/5be38851-a918-4d5c-94f4-dbbd20c55a5e" />


### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [x] Internal code refactor

## The following scenarios were tested

- [x] The testing is done with the amplify link
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document

---