### PR TITLE
fix(widgets): fixed-consult-transfer-popover-epic-bugs

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
@@ -628,7 +628,7 @@ export const filterAgentsByQuery = (agents: BuddyDetails[], query: string): Budd
 };
 
 /**
- * Returns agents to display for current category, applying search only for Agents tab.
+ * Returns agents to display for current category, applying search only for Agents tab, since other tabs support via the SDK
  */
 export const getAgentsForDisplay = (
   selectedCategory: 'Agents' | string,

--- a/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
@@ -613,6 +613,30 @@ export const filterAvailableAgents = (agents: BuddyDetails[], logger?): BuddyDet
 };
 
 /**
+ * Filters buddy agents by a free-text query across name, dn and id.
+ */
+export const filterAgentsByQuery = (agents: BuddyDetails[], query: string): BuddyDetails[] => {
+  const q = (query || '').trim().toLowerCase();
+  if (!q) return agents || [];
+  const safeAgents = agents || [];
+  return safeAgents.filter((a) => {
+    const name = a.agentName?.toLowerCase() || '';
+    const dn = (a as unknown as {dn?: string})?.dn?.toLowerCase() || '';
+    const id = a.agentId?.toLowerCase() || '';
+    return name.includes(q) || dn.includes(q) || id.includes(q);
+  });
+};
+
+/**
+ * Returns agents to display for current category, applying search only for Agents tab.
+ */
+export const getAgentsForDisplay = (
+  selectedCategory: 'Agents' | string,
+  agents: BuddyDetails[],
+  query: string
+): BuddyDetails[] => (selectedCategory === 'Agents' ? filterAgentsByQuery(agents, query) : agents || []);
+
+/**
  * Filters available queues
  */
 export const filterAvailableQueues = (queues: ContactServiceQueue[], logger?): ContactServiceQueue[] => {
@@ -654,4 +678,37 @@ export const debounce = <T extends (...args: unknown[]) => unknown>(
       func(...args);
     };
   }
+};
+
+/**
+ * Helpers for Dial Number / Entry Point manual actions
+ */
+export const buildConsultTransferQuickAction = (
+  selectedCategory: string,
+  isEntryPointTabVisible: boolean,
+  query: string,
+  entryPoints: {id: string; name: string}[],
+  onDialNumberSelect: ((dialNumber: string) => void) | undefined,
+  onEntryPointSelect: ((entryPointId: string, entryPointName: string) => void) | undefined
+): {visible: boolean; onClick?: () => void; title?: string} => {
+  const DN_REGEX = new RegExp('^[+1][0-9]{3,18}$|^[*#:][+1][0-9*#:]{3,18}$|^[0-9*#:]{3,18}$');
+
+  const isDial = selectedCategory === 'Dial Number';
+  const isEntry = selectedCategory === 'Entry Point' && isEntryPointTabVisible;
+  const valid = DN_REGEX.test(query || '');
+
+  if (isDial) {
+    return valid && onDialNumberSelect
+      ? {visible: true, onClick: () => onDialNumberSelect(query), title: query}
+      : {visible: false};
+  }
+
+  if (isEntry) {
+    const match = query ? entryPoints?.find((e) => e.name === query || e.id === query) : null;
+    return valid && match && onEntryPointSelect
+      ? {visible: true, onClick: () => onEntryPointSelect(match.id, match.name), title: match.name}
+      : {visible: false};
+  }
+
+  return {visible: false};
 };

--- a/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
@@ -683,7 +683,7 @@ export const debounce = <T extends (...args: unknown[]) => unknown>(
 /**
  * Helpers for Dial Number / Entry Point manual actions
  */
-export const buildConsultTransferQuickAction = (
+export const shouldAddConsultTransferAction = (
   selectedCategory: string,
   isEntryPointTabVisible: boolean,
   query: string,

--- a/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/call-control-custom.utils.ts
@@ -616,15 +616,13 @@ export const filterAvailableAgents = (agents: BuddyDetails[], logger?): BuddyDet
  * Filters buddy agents by a free-text query across name, dn and id.
  */
 export const filterAgentsByQuery = (agents: BuddyDetails[], query: string): BuddyDetails[] => {
-  const q = (query || '').trim().toLowerCase();
-  if (!q) return agents || [];
-  const safeAgents = agents || [];
-  return safeAgents.filter((a) => {
-    const name = a.agentName?.toLowerCase() || '';
-    const dn = (a as unknown as {dn?: string})?.dn?.toLowerCase() || '';
-    const id = a.agentId?.toLowerCase() || '';
-    return name.includes(q) || dn.includes(q) || id.includes(q);
-  });
+  const searchTerm = (query ?? '').trim().toLowerCase();
+  if (!searchTerm) return agents ?? [];
+  return (agents ?? []).filter((agent) =>
+    `${agent.agentName ?? ''}|${(agent as {dn?: string}).dn ?? ''}|${agent.agentId ?? ''}`
+      .toLowerCase()
+      .includes(searchTerm)
+  );
 };
 
 /**

--- a/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/consult-transfer-popover.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/consult-transfer-popover.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import {Text, ListNext, TextInput, Button} from '@momentum-ui/react-collaboration';
+import {Text, ListNext, TextInput, Button, ButtonCircle, TooltipNext} from '@momentum-ui/react-collaboration';
+import {Icon} from '@momentum-design/components/dist/react';
 import ConsultTransferListComponent from './consult-transfer-list-item';
 import {ConsultTransferPopoverComponentProps} from '../../task.types';
 import ConsultTransferEmptyState from './consult-transfer-empty-state';
-import {isAgentsEmpty, handleAgentSelection, handleQueueSelection} from './call-control-custom.utils';
+import {
+  handleAgentSelection,
+  handleQueueSelection,
+  buildConsultTransferQuickAction,
+  getAgentsForDisplay,
+} from './call-control-custom.utils';
 import {useConsultTransferPopover} from './consult-transfer-popover-hooks';
 import {
   SEARCH_PLACEHOLDER,
@@ -31,6 +37,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
   logger,
 }) => {
   const {showDialNumberTab = true, showEntryPointTab = true} = consultTransferOptions || {};
+  const isEntryPointTabVisible = (showEntryPointTab ?? true) && heading === 'Consult';
   const {
     selectedCategory,
     searchQuery,
@@ -51,14 +58,12 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
     handleEntryPointClick,
   } = useConsultTransferPopover({
     showDialNumberTab,
-    showEntryPointTab,
+    showEntryPointTab: isEntryPointTabVisible,
     getAddressBookEntries,
     getEntryPoints,
     getQueues,
     logger,
   });
-
-  const noAgents = isAgentsEmpty(buddyAgents, logger);
 
   const renderList = <T extends {id: string; name: string; number?: string}>(
     items: T[],
@@ -84,11 +89,18 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
     </ListNext>
   );
 
-  const noQueues = queuesData.length === 0;
+  const noQueues = !allowConsultToQueue || queuesData.length === 0;
   const noDialNumbers = !showDialNumberTab || dialNumbers.length === 0;
-  const noEntryPoints = !showEntryPointTab || entryPoints.length === 0;
+  const noEntryPoints = !isEntryPointTabVisible || entryPoints.length === 0;
 
-  const hasAnyData = !noAgents || !noQueues || !noDialNumbers || !noEntryPoints;
+  const consultTransferManualAction = buildConsultTransferQuickAction(
+    selectedCategory,
+    isEntryPointTabVisible,
+    searchQuery,
+    entryPoints,
+    onDialNumberSelect,
+    onEntryPointSelect
+  );
 
   return (
     <div className="agent-popover-content">
@@ -96,7 +108,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
         {heading}
       </Text>
 
-      <div>
+      <div className="consult-search-row">
         <TextInput
           id="consult-search"
           placeholder={SEARCH_PLACEHOLDER}
@@ -106,6 +118,30 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
           aria-labelledby="consult-search-label"
           className="consult-search-input"
         />
+        {consultTransferManualAction.visible && (
+          <TooltipNext
+            triggerComponent={
+              <ButtonCircle
+                className="consult-quick-action-button"
+                aria-label={`${heading} via search`}
+                onPress={consultTransferManualAction.onClick}
+                size={32}
+                color="join"
+                data-testid={`consult-quick-action:${heading.toLowerCase()}`}
+              >
+                <Icon name={buttonIcon} />
+              </ButtonCircle>
+            }
+            color="primary"
+            delay={[0, 0]}
+            placement="bottom-start"
+            type="description"
+            variant="small"
+            className="tooltip"
+          >
+            <p>{`${heading} via search`}</p>
+          </TooltipNext>
+        )}
       </div>
 
       <div className="consult-category-buttons">
@@ -119,17 +155,18 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
         >
           Agents
         </Button>
-        <Button
-          variant={selectedCategory === 'Queues' ? 'primary' : 'secondary'}
-          size="small"
-          onClick={handleQueuesClick}
-          disabled={!allowConsultToQueue}
-          className={`consult-category-button-standard ${
-            selectedCategory === 'Queues' ? 'consult-category-button-active' : ''
-          }`}
-        >
-          Queues
-        </Button>
+        {allowConsultToQueue && (
+          <Button
+            variant={selectedCategory === 'Queues' ? 'primary' : 'secondary'}
+            size="small"
+            onClick={handleQueuesClick}
+            className={`consult-category-button-standard ${
+              selectedCategory === 'Queues' ? 'consult-category-button-active' : ''
+            }`}
+          >
+            Queues
+          </Button>
+        )}
         {showDialNumberTab && (
           <Button
             variant={selectedCategory === 'Dial Number' ? 'primary' : 'secondary'}
@@ -142,7 +179,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
             Dial Number
           </Button>
         )}
-        {showEntryPointTab && (
+        {isEntryPointTabVisible && (
           <Button
             variant={selectedCategory === 'Entry Point' ? 'primary' : 'secondary'}
             size="small"
@@ -156,90 +193,105 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
         )}
       </div>
 
-      {!hasAnyData && <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />}
-
       {selectedCategory === 'Agents' &&
-        !noAgents &&
-        renderList(
-          buddyAgents.map((agent) => ({id: agent.agentId, name: agent.agentName})),
-          (item) => handleAgentSelection(item.id, item.name, onAgentSelect, logger)
-        )}
+        (getAgentsForDisplay(selectedCategory, buddyAgents, searchQuery).length === 0 ? (
+          <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />
+        ) : (
+          renderList(
+            getAgentsForDisplay(selectedCategory, buddyAgents, searchQuery).map((agent) => ({
+              id: agent.agentId,
+              name: agent.agentName,
+            })),
+            (item) => handleAgentSelection(item.id, item.name, onAgentSelect, logger)
+          )
+        ))}
 
-      {selectedCategory === 'Queues' && !noQueues && (
-        <div>
-          {renderList(
-            queuesData.map((q) => ({id: q.id, name: q.name})),
-            (item) => handleQueueSelection(item.id, item.name, onQueueSelect, logger)
-          )}
-          {hasMoreQueues && (
-            <div ref={loadMoreRef} className="consult-load-more">
-              {loadingQueues ? (
-                <Text tagName="small" type="body-secondary">
-                  {LOADING_MORE_QUEUES}
-                </Text>
-              ) : (
-                <Text tagName="small" type="body-secondary">
-                  {SCROLL_TO_LOAD_MORE}
-                </Text>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      {selectedCategory === 'Queues' &&
+        (noQueues ? (
+          <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />
+        ) : (
+          <div>
+            {renderList(
+              queuesData.map((q) => ({id: q.id, name: q.name})),
+              (item) => handleQueueSelection(item.id, item.name, onQueueSelect, logger)
+            )}
+            {hasMoreQueues && (
+              <div ref={loadMoreRef} className="consult-load-more">
+                {loadingQueues ? (
+                  <Text tagName="small" type="body-secondary">
+                    {LOADING_MORE_QUEUES}
+                  </Text>
+                ) : (
+                  <Text tagName="small" type="body-secondary">
+                    {SCROLL_TO_LOAD_MORE}
+                  </Text>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
 
-      {showDialNumberTab && selectedCategory === 'Dial Number' && !noDialNumbers && (
-        <div>
-          {renderList(
-            dialNumbers.map((d) => ({id: d.id, name: d.name, number: d.number})),
-            (item) => {
-              if (item.number) {
-                if (onDialNumberSelect) {
-                  onDialNumberSelect(item.number);
+      {showDialNumberTab &&
+        selectedCategory === 'Dial Number' &&
+        (noDialNumbers ? (
+          <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />
+        ) : (
+          <div>
+            {renderList(
+              dialNumbers.map((d) => ({id: d.id, name: d.name, number: d.number})),
+              (item) => {
+                if (item.number) {
+                  if (onDialNumberSelect) {
+                    onDialNumberSelect(item.number);
+                  }
                 }
               }
-            }
-          )}
-          {hasMoreDialNumbers && (
-            <div ref={loadMoreRef} className="consult-load-more">
-              {loadingDialNumbers ? (
-                <Text tagName="small" type="body-secondary">
-                  {LOADING_MORE_DIAL_NUMBERS}
-                </Text>
-              ) : (
-                <Text tagName="small" type="body-secondary">
-                  {SCROLL_TO_LOAD_MORE}
-                </Text>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+            )}
+            {hasMoreDialNumbers && (
+              <div ref={loadMoreRef} className="consult-load-more">
+                {loadingDialNumbers ? (
+                  <Text tagName="small" type="body-secondary">
+                    {LOADING_MORE_DIAL_NUMBERS}
+                  </Text>
+                ) : (
+                  <Text tagName="small" type="body-secondary">
+                    {SCROLL_TO_LOAD_MORE}
+                  </Text>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
 
-      {showEntryPointTab && selectedCategory === 'Entry Point' && !noEntryPoints && (
-        <div>
-          {renderList(
-            entryPoints.map((e) => ({id: e.id, name: e.name})),
-            (item) => {
-              if (onEntryPointSelect) {
-                onEntryPointSelect(item.id, item.name);
+      {isEntryPointTabVisible &&
+        selectedCategory === 'Entry Point' &&
+        (noEntryPoints ? (
+          <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />
+        ) : (
+          <div>
+            {renderList(
+              entryPoints.map((e) => ({id: e.id, name: e.name})),
+              (item) => {
+                if (onEntryPointSelect) {
+                  onEntryPointSelect(item.id, item.name);
+                }
               }
-            }
-          )}
-          {hasMoreEntryPoints && (
-            <div ref={loadMoreRef} className="consult-load-more">
-              {loadingEntryPoints ? (
-                <Text tagName="small" type="body-secondary">
-                  {LOADING_MORE_ENTRY_POINTS}
-                </Text>
-              ) : (
-                <Text tagName="small" type="body-secondary">
-                  {SCROLL_TO_LOAD_MORE}
-                </Text>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+            )}
+            {hasMoreEntryPoints && (
+              <div ref={loadMoreRef} className="consult-load-more">
+                {loadingEntryPoints ? (
+                  <Text tagName="small" type="body-secondary">
+                    {LOADING_MORE_ENTRY_POINTS}
+                  </Text>
+                ) : (
+                  <Text tagName="small" type="body-secondary">
+                    {SCROLL_TO_LOAD_MORE}
+                  </Text>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
     </div>
   );
 };

--- a/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/consult-transfer-popover.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/CallControlCustom/consult-transfer-popover.tsx
@@ -7,7 +7,7 @@ import ConsultTransferEmptyState from './consult-transfer-empty-state';
 import {
   handleAgentSelection,
   handleQueueSelection,
-  buildConsultTransferQuickAction,
+  shouldAddConsultTransferAction,
   getAgentsForDisplay,
 } from './call-control-custom.utils';
 import {useConsultTransferPopover} from './consult-transfer-popover-hooks';
@@ -20,6 +20,7 @@ import {
   LOADING_MORE_ENTRY_POINTS,
   NO_DATA_AVAILABLE_CONSULT_TRANSFER,
 } from '../../constants';
+import {CATEGORY_AGENTS, CATEGORY_DIAL_NUMBER, CATEGORY_ENTRY_POINT, CATEGORY_QUEUES} from '../../task.types';
 
 const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentProps> = ({
   heading,
@@ -37,7 +38,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
   logger,
 }) => {
   const {showDialNumberTab = true, showEntryPointTab = true} = consultTransferOptions || {};
-  const isEntryPointTabVisible = (showEntryPointTab ?? true) && heading === 'Consult';
+  const isEntryPointTabVisible = showEntryPointTab && heading === 'Consult';
   const {
     selectedCategory,
     searchQuery,
@@ -93,7 +94,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
   const noDialNumbers = !showDialNumberTab || dialNumbers.length === 0;
   const noEntryPoints = !isEntryPointTabVisible || entryPoints.length === 0;
 
-  const consultTransferManualAction = buildConsultTransferQuickAction(
+  const consultTransferManualAction = shouldAddConsultTransferAction(
     selectedCategory,
     isEntryPointTabVisible,
     searchQuery,
@@ -146,49 +147,49 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
 
       <div className="consult-category-buttons">
         <Button
-          variant={selectedCategory === 'Agents' ? 'primary' : 'secondary'}
+          variant={selectedCategory === CATEGORY_AGENTS ? 'primary' : 'secondary'}
           size="small"
           onClick={handleAgentsClick}
           className={`consult-category-button-standard ${
-            selectedCategory === 'Agents' ? 'consult-category-button-active' : ''
+            selectedCategory === CATEGORY_AGENTS ? 'consult-category-button-active' : ''
           }`}
         >
-          Agents
+          {CATEGORY_AGENTS}
         </Button>
         {allowConsultToQueue && (
           <Button
-            variant={selectedCategory === 'Queues' ? 'primary' : 'secondary'}
+            variant={selectedCategory === CATEGORY_QUEUES ? 'primary' : 'secondary'}
             size="small"
             onClick={handleQueuesClick}
             className={`consult-category-button-standard ${
-              selectedCategory === 'Queues' ? 'consult-category-button-active' : ''
+              selectedCategory === CATEGORY_QUEUES ? 'consult-category-button-active' : ''
             }`}
           >
-            Queues
+            {CATEGORY_QUEUES}
           </Button>
         )}
         {showDialNumberTab && (
           <Button
-            variant={selectedCategory === 'Dial Number' ? 'primary' : 'secondary'}
+            variant={selectedCategory === CATEGORY_DIAL_NUMBER ? 'primary' : 'secondary'}
             size="small"
             onClick={handleDialNumberClick}
             className={`consult-category-button-wide ${
-              selectedCategory === 'Dial Number' ? 'consult-category-button-active' : ''
+              selectedCategory === CATEGORY_DIAL_NUMBER ? 'consult-category-button-active' : ''
             }`}
           >
-            Dial Number
+            {CATEGORY_DIAL_NUMBER}
           </Button>
         )}
         {isEntryPointTabVisible && (
           <Button
-            variant={selectedCategory === 'Entry Point' ? 'primary' : 'secondary'}
+            variant={selectedCategory === CATEGORY_ENTRY_POINT ? 'primary' : 'secondary'}
             size="small"
             onClick={handleEntryPointClick}
             className={`consult-category-button-wide ${
-              selectedCategory === 'Entry Point' ? 'consult-category-button-active' : ''
+              selectedCategory === CATEGORY_ENTRY_POINT ? 'consult-category-button-active' : ''
             }`}
           >
-            Entry Point
+            {CATEGORY_ENTRY_POINT}
           </Button>
         )}
       </div>
@@ -232,7 +233,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
         ))}
 
       {showDialNumberTab &&
-        selectedCategory === 'Dial Number' &&
+        selectedCategory === CATEGORY_DIAL_NUMBER &&
         (noDialNumbers ? (
           <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />
         ) : (
@@ -264,7 +265,7 @@ const ConsultTransferPopoverComponent: React.FC<ConsultTransferPopoverComponentP
         ))}
 
       {isEntryPointTabVisible &&
-        selectedCategory === 'Entry Point' &&
+        selectedCategory === CATEGORY_ENTRY_POINT &&
         (noEntryPoints ? (
           <ConsultTransferEmptyState message={NO_DATA_AVAILABLE_CONSULT_TRANSFER} />
         ) : (

--- a/packages/contact-center/cc-components/src/components/task/CallControl/call-control.styles.scss
+++ b/packages/contact-center/cc-components/src/components/task/CallControl/call-control.styles.scss
@@ -217,8 +217,21 @@
       pointer-events: auto;
     }
 
+    .consult-search-row {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      gap: 0.5rem;
+    }
+
     .consult-search-input {
       width: 100%;
+      flex: 1 1 auto;
+      min-width: 0;
+    }
+
+    .consult-quick-action-button {
+      flex: 0 0 2rem; /* 32px */
     }
 
     .consult-category-buttons {

--- a/packages/contact-center/cc-components/src/components/task/constants.ts
+++ b/packages/contact-center/cc-components/src/components/task/constants.ts
@@ -26,6 +26,7 @@ export const LOADING_MORE_QUEUES = 'Loading more queues...';
 export const LOADING_MORE_DIAL_NUMBERS = 'Loading more dial numbers...';
 export const LOADING_MORE_ENTRY_POINTS = 'Loading more entry points...';
 export const NO_DATA_AVAILABLE_CONSULT_TRANSFER = 'No data available for consult transfer.';
+export const VIA_SEARCH_SUFFIX = ' via search';
 // Pagination
 export const DEFAULT_PAGE_SIZE = 25;
 // CallControlCAD constants

--- a/packages/contact-center/cc-components/tests/components/task/CallControl/CallControlCustom/__snapshots__/consult-transfer-popover.snapshot.tsx.snap
+++ b/packages/contact-center/cc-components/tests/components/task/CallControl/CallControlCustom/__snapshots__/consult-transfer-popover.snapshot.tsx.snap
@@ -11,7 +11,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -42,9 +44,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-45"
+      data-md-event-key="md-button-34"
       data-md-keyboard-key="agents"
-      id="md-button-45"
+      id="md-button-34"
       tabindex="0"
       type="button"
       variant="primary"
@@ -60,9 +62,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-46"
+      data-md-event-key="md-button-35"
       data-md-keyboard-key="queues"
-      id="md-button-46"
+      id="md-button-35"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -78,9 +80,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-47"
+      data-md-event-key="md-button-36"
       data-md-keyboard-key="dial-number"
-      id="md-button-47"
+      id="md-button-36"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -90,24 +92,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-48"
-      data-md-keyboard-key="entry-point"
-      id="md-button-48"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -279,7 +263,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -310,9 +296,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-49"
+      data-md-event-key="md-button-37"
       data-md-keyboard-key="agents"
-      id="md-button-49"
+      id="md-button-37"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -328,9 +314,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-50"
+      data-md-event-key="md-button-38"
       data-md-keyboard-key="queues"
-      id="md-button-50"
+      id="md-button-38"
       tabindex="0"
       type="button"
       variant="primary"
@@ -346,9 +332,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-51"
+      data-md-event-key="md-button-39"
       data-md-keyboard-key="dial-number"
-      id="md-button-51"
+      id="md-button-39"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -358,24 +344,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-52"
-      data-md-keyboard-key="entry-point"
-      id="md-button-52"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -474,7 +442,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -505,9 +475,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-41"
+      data-md-event-key="md-button-31"
       data-md-keyboard-key="agents"
-      id="md-button-41"
+      id="md-button-31"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -523,9 +493,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-42"
+      data-md-event-key="md-button-32"
       data-md-keyboard-key="queues"
-      id="md-button-42"
+      id="md-button-32"
       tabindex="0"
       type="button"
       variant="primary"
@@ -541,9 +511,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-43"
+      data-md-event-key="md-button-33"
       data-md-keyboard-key="dial-number"
-      id="md-button-43"
+      id="md-button-33"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -553,24 +523,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Interactions should render co
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-44"
-      data-md-keyboard-key="entry-point"
-      id="md-button-44"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -667,9 +619,11 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
     tagname="h3"
     type="body-large-bold"
   >
-    Select an Agent
+    Consult
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -937,7 +891,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -968,9 +924,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-37"
+      data-md-event-key="md-button-28"
       data-md-keyboard-key="agents"
-      id="md-button-37"
+      id="md-button-28"
       tabindex="0"
       type="button"
       variant="primary"
@@ -986,9 +942,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-38"
+      data-md-event-key="md-button-29"
       data-md-keyboard-key="queues"
-      id="md-button-38"
+      id="md-button-29"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1004,9 +960,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-39"
+      data-md-event-key="md-button-30"
       data-md-keyboard-key="dial-number"
-      id="md-button-39"
+      id="md-button-30"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1016,24 +972,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-40"
-      data-md-keyboard-key="entry-point"
-      id="md-button-40"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -1280,7 +1218,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -1311,9 +1251,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-21"
+      data-md-event-key="md-button-17"
       data-md-keyboard-key="agents"
-      id="md-button-21"
+      id="md-button-17"
       tabindex="0"
       type="button"
       variant="primary"
@@ -1328,28 +1268,10 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
     <button
       alt=""
       aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-22"
-      data-md-keyboard-key="queues"
-      disabled=""
-      id="md-button-22"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Queues
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-23"
+      data-md-event-key="md-button-18"
       data-md-keyboard-key="dial-number"
-      id="md-button-23"
+      id="md-button-18"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1359,24 +1281,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-24"
-      data-md-keyboard-key="entry-point"
-      id="md-button-24"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -1548,7 +1452,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -1579,9 +1485,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-25"
+      data-md-event-key="md-button-19"
       data-md-keyboard-key="agents"
-      id="md-button-25"
+      id="md-button-19"
       tabindex="0"
       type="button"
       variant="primary"
@@ -1597,9 +1503,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-26"
+      data-md-event-key="md-button-20"
       data-md-keyboard-key="queues"
-      id="md-button-26"
+      id="md-button-20"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1615,9 +1521,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-27"
+      data-md-event-key="md-button-21"
       data-md-keyboard-key="dial-number"
-      id="md-button-27"
+      id="md-button-21"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1627,24 +1533,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-28"
-      data-md-keyboard-key="entry-point"
-      id="md-button-28"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -1674,7 +1562,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Choose Transfer Target
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -1705,9 +1595,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-9"
+      data-md-event-key="md-button-8"
       data-md-keyboard-key="agents"
-      id="md-button-9"
+      id="md-button-8"
       tabindex="0"
       type="button"
       variant="primary"
@@ -1723,9 +1613,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-10"
+      data-md-event-key="md-button-9"
       data-md-keyboard-key="queues"
-      id="md-button-10"
+      id="md-button-9"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1741,9 +1631,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-11"
+      data-md-event-key="md-button-10"
       data-md-keyboard-key="dial-number"
-      id="md-button-11"
+      id="md-button-10"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -1753,24 +1643,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-12"
-      data-md-keyboard-key="entry-point"
-      id="md-button-12"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -1942,7 +1814,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -1973,9 +1847,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-13"
+      data-md-event-key="md-button-11"
       data-md-keyboard-key="agents"
-      id="md-button-13"
+      id="md-button-11"
       tabindex="0"
       type="button"
       variant="primary"
@@ -1991,9 +1865,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-14"
+      data-md-event-key="md-button-12"
       data-md-keyboard-key="queues"
-      id="md-button-14"
+      id="md-button-12"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2009,9 +1883,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-15"
+      data-md-event-key="md-button-13"
       data-md-keyboard-key="dial-number"
-      id="md-button-15"
+      id="md-button-13"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2021,24 +1895,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-16"
-      data-md-keyboard-key="entry-point"
-      id="md-button-16"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -2068,7 +1924,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -2099,9 +1957,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-17"
+      data-md-event-key="md-button-14"
       data-md-keyboard-key="agents"
-      id="md-button-17"
+      id="md-button-14"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2117,9 +1975,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-18"
+      data-md-event-key="md-button-15"
       data-md-keyboard-key="queues"
-      id="md-button-18"
+      id="md-button-15"
       tabindex="0"
       type="button"
       variant="primary"
@@ -2135,9 +1993,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-19"
+      data-md-event-key="md-button-16"
       data-md-keyboard-key="dial-number"
-      id="md-button-19"
+      id="md-button-16"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2149,24 +2007,18 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         Dial Number
       </span>
     </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-20"
-      data-md-keyboard-key="entry-point"
-      id="md-button-20"
-      tabindex="0"
-      type="button"
-      variant="secondary"
+  </div>
+  <div
+    class="consult-empty-state"
+  >
+    <div
+      class="consult-empty-state-svg"
+    />
+    <div
+      class="consult-empty-message"
     >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
-      </span>
-    </button>
+      No data available for consult transfer.
+    </div>
   </div>
 </div>
 `;
@@ -2182,7 +2034,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -2213,9 +2067,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-29"
+      data-md-event-key="md-button-22"
       data-md-keyboard-key="agents"
-      id="md-button-29"
+      id="md-button-22"
       tabindex="0"
       type="button"
       variant="primary"
@@ -2231,9 +2085,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-30"
+      data-md-event-key="md-button-23"
       data-md-keyboard-key="queues"
-      id="md-button-30"
+      id="md-button-23"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2249,9 +2103,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-31"
+      data-md-event-key="md-button-24"
       data-md-keyboard-key="dial-number"
-      id="md-button-31"
+      id="md-button-24"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2261,24 +2115,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-32"
-      data-md-keyboard-key="entry-point"
-      id="md-button-32"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -2375,7 +2211,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -2406,9 +2244,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-33"
+      data-md-event-key="md-button-25"
       data-md-keyboard-key="agents"
-      id="md-button-33"
+      id="md-button-25"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2424,9 +2262,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-34"
+      data-md-event-key="md-button-26"
       data-md-keyboard-key="queues"
-      id="md-button-34"
+      id="md-button-26"
       tabindex="0"
       type="button"
       variant="primary"
@@ -2442,9 +2280,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-35"
+      data-md-event-key="md-button-27"
       data-md-keyboard-key="dial-number"
-      id="md-button-35"
+      id="md-button-27"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2454,24 +2292,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-36"
-      data-md-keyboard-key="entry-point"
-      id="md-button-36"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -2570,7 +2390,9 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -2649,24 +2471,6 @@ exports[`ConsultTransferPopoverComponent Snapshots Rendering - Tests for UI elem
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-8"
-      data-md-keyboard-key="entry-point"
-      id="md-button-8"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -2838,7 +2642,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -2869,9 +2675,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-57"
+      data-md-event-key="md-button-43"
       data-md-keyboard-key="agents"
-      id="md-button-57"
+      id="md-button-43"
       tabindex="0"
       type="button"
       variant="primary"
@@ -2887,9 +2693,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-58"
+      data-md-event-key="md-button-44"
       data-md-keyboard-key="queues"
-      id="md-button-58"
+      id="md-button-44"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2905,9 +2711,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-59"
+      data-md-event-key="md-button-45"
       data-md-keyboard-key="dial-number"
-      id="md-button-59"
+      id="md-button-45"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -2917,24 +2723,6 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-60"
-      data-md-keyboard-key="entry-point"
-      id="md-button-60"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -3027,7 +2815,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
   >
     New Heading
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -3058,9 +2848,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-53"
+      data-md-event-key="md-button-40"
       data-md-keyboard-key="agents"
-      id="md-button-53"
+      id="md-button-40"
       tabindex="0"
       type="button"
       variant="primary"
@@ -3076,9 +2866,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-54"
+      data-md-event-key="md-button-41"
       data-md-keyboard-key="queues"
-      id="md-button-54"
+      id="md-button-41"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -3094,9 +2884,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-55"
+      data-md-event-key="md-button-42"
       data-md-keyboard-key="dial-number"
-      id="md-button-55"
+      id="md-button-42"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -3106,24 +2896,6 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-56"
-      data-md-keyboard-key="entry-point"
-      id="md-button-56"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>
@@ -3295,7 +3067,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
   >
     Select an Agent
   </mdc-text>
-  <div>
+  <div
+    class="consult-search-row"
+  >
     <div
       class="md-text-input-wrapper consult-search-input"
       data-focus="false"
@@ -3326,9 +3100,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard "
-      data-md-event-key="md-button-61"
+      data-md-event-key="md-button-46"
       data-md-keyboard-key="agents"
-      id="md-button-61"
+      id="md-button-46"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -3344,9 +3118,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-standard consult-category-button-active"
-      data-md-event-key="md-button-62"
+      data-md-event-key="md-button-47"
       data-md-keyboard-key="queues"
-      id="md-button-62"
+      id="md-button-47"
       tabindex="0"
       type="button"
       variant="primary"
@@ -3362,9 +3136,9 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
       alt=""
       aria-labelledby=""
       class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-63"
+      data-md-event-key="md-button-48"
       data-md-keyboard-key="dial-number"
-      id="md-button-63"
+      id="md-button-48"
       tabindex="0"
       type="button"
       variant="secondary"
@@ -3374,24 +3148,6 @@ exports[`ConsultTransferPopoverComponent Snapshots State Management should updat
         style="opacity: 1;"
       >
         Dial Number
-      </span>
-    </button>
-    <button
-      alt=""
-      aria-labelledby=""
-      class="md-button md-button--36 consult-category-button-wide "
-      data-md-event-key="md-button-64"
-      data-md-keyboard-key="entry-point"
-      id="md-button-64"
-      tabindex="0"
-      type="button"
-      variant="secondary"
-    >
-      <span
-        class="md-button__children"
-        style="opacity: 1;"
-      >
-        Entry Point
       </span>
     </button>
   </div>

--- a/packages/contact-center/cc-components/tests/components/task/CallControl/CallControlCustom/consult-transfer-popover.snapshot.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/CallControl/CallControlCustom/consult-transfer-popover.snapshot.tsx
@@ -91,9 +91,9 @@ describe('ConsultTransferPopoverComponent Snapshots', () => {
     it('should render the component with heading and category buttons', async () => {
       let screen;
       await act(async () => {
-        screen = render(<ConsultTransferPopoverComponent {...defaultProps} />);
+        screen = render(<ConsultTransferPopoverComponent {...defaultProps} heading="Consult" />);
       });
-      expect(screen.getByText('Select an Agent')).toBeInTheDocument();
+      expect(screen.getByText('Consult')).toBeInTheDocument();
       const btns = Array.from(screen.container.querySelectorAll('button')).map(
         (b) => (b as HTMLButtonElement).textContent
       );
@@ -172,8 +172,7 @@ describe('ConsultTransferPopoverComponent Snapshots', () => {
         const el = btn as HTMLButtonElement;
         return el && el.textContent === 'Queues';
       }) as HTMLButtonElement | undefined;
-      expect(queuesButton).toBeDefined();
-      expect(queuesButton?.disabled).toBe(true);
+      expect(queuesButton).toBeUndefined();
       const container = screen.container.querySelector('.agent-popover-content');
       mockUIDProps(container);
       expect(container).toMatchSnapshot();

--- a/packages/contact-center/cc-components/tests/components/task/CallControl/CallControlCustom/consult-transfer-popover.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/CallControl/CallControlCustom/consult-transfer-popover.tsx
@@ -3,8 +3,6 @@ import {render, fireEvent, waitFor, act} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ConsultTransferPopoverComponent from '../../../../../src/components/task/CallControl/CallControlCustom/consult-transfer-popover';
 import {ContactServiceQueue} from '@webex/cc-store';
-// hooks import no longer needed in this test
-import * as utils from '../../../../../src/components/task/CallControl/CallControlCustom/call-control-custom.utils';
 import {DEFAULT_PAGE_SIZE} from '../../../../../src/components/task/constants';
 
 const loggerMock = {
@@ -68,7 +66,7 @@ describe('ConsultTransferPopoverComponent', () => {
   });
 
   it('renders heading and tabs when showTabs is true', async () => {
-    const screen = await render(<ConsultTransferPopoverComponent {...baseProps} />);
+    const screen = await render(<ConsultTransferPopoverComponent {...baseProps} heading="Consult" />);
 
     // Verify main container
     expect(screen.container.querySelector('.agent-popover-content')).toBeInTheDocument();
@@ -76,7 +74,7 @@ describe('ConsultTransferPopoverComponent', () => {
     // Verify heading - it's wrapped in mdc-text component
     const heading = screen.container.querySelector('.agent-popover-title');
     expect(heading).toBeInTheDocument();
-    expect(heading).toHaveTextContent('Select an Agent');
+    expect(heading).toHaveTextContent('Consult');
     expect(heading?.tagName.toLowerCase()).toBe('mdc-text');
     expect(heading).toHaveAttribute('tagname', 'h3');
     expect(heading).toHaveAttribute('type', 'body-large-bold');
@@ -201,7 +199,7 @@ describe('ConsultTransferPopoverComponent', () => {
       buddyAgents: [],
     };
 
-    const screen = await render(<ConsultTransferPopoverComponent {...emptyAgentsProps} />);
+    const screen = await render(<ConsultTransferPopoverComponent {...emptyAgentsProps} heading="Consult" />);
     const buttons = Array.from(screen.container.querySelectorAll('button')).map(
       (b) => (b as HTMLButtonElement).textContent
     );
@@ -222,35 +220,27 @@ describe('ConsultTransferPopoverComponent', () => {
     expect(screen.container.querySelectorAll('.call-control-list-item').length).toBe(0);
   });
 
-  it('disables queue selection when allowConsultToQueue is false', async () => {
+  it('hides queue tab when allowConsultToQueue is false', async () => {
     const propsWithoutQueue = {
       ...baseProps,
       allowConsultToQueue: false,
     };
 
     const screen = await render(<ConsultTransferPopoverComponent {...propsWithoutQueue} />);
-    const queuesButton = screen.getByRole('button', {name: 'Queues'}) as HTMLButtonElement;
-    expect(queuesButton.disabled).toBe(true);
+    const maybeQueuesButton = screen.queryByRole('button', {name: 'Queues'}) as HTMLButtonElement | null;
+    expect(maybeQueuesButton).toBeNull();
   });
 
   it('covers edge case for empty items in renderList (line 50)', async () => {
-    // Mock isAgentsEmpty to return false even with empty array to force renderList call
-    const mockIsAgentsEmpty = jest.spyOn(utils, 'isAgentsEmpty').mockReturnValue(false);
+    const propsWithEmptyAgents = {
+      ...baseProps,
+      buddyAgents: [],
+    };
 
-    try {
-      const propsWithEmptyAgents = {
-        ...baseProps,
-        buddyAgents: [], // Empty array but mocked to return false for isEmpty
-      };
+    const screen = await render(<ConsultTransferPopoverComponent {...propsWithEmptyAgents} />);
 
-      const screen = await render(<ConsultTransferPopoverComponent {...propsWithEmptyAgents} />);
-
-      // Should render the "No agents found" text via empty list state
-      expect(screen.getByText('No agents found')).toBeInTheDocument();
-    } finally {
-      // Restore original functions
-      mockIsAgentsEmpty.mockRestore();
-    }
+    // With zero agents, the per-tab empty state should render
+    expect(screen.getByText('No data available for consult transfer.')).toBeInTheDocument();
   });
 
   describe('Search behavior', () => {

--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -48,6 +48,7 @@ class Store implements IStore {
   consultOfferReceived: boolean = false;
   featureFlags: {[key: string]: boolean} = {};
   isEndConsultEnabled: boolean = false;
+  isAddressBookEnabled: boolean = false;
   allowConsultToQueue: boolean = false;
   agentProfile: AgentLoginProfile = {};
   isMuted: boolean = false;
@@ -109,6 +110,7 @@ class Store implements IStore {
         this.lastStateChangeTimestamp = response.lastStateChangeTimestamp;
         this.lastIdleCodeChangeTimestamp = response.lastIdleCodeChangeTimestamp;
         this.isEndConsultEnabled = response.isEndConsultEnabled;
+        this.isAddressBookEnabled = Boolean(response.addressBookId);
         this.allowConsultToQueue = response.allowConsultToQueue;
         this.agentProfile.agentName = response.agentName;
       })

--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -110,6 +110,7 @@ class Store implements IStore {
         this.lastStateChangeTimestamp = response.lastStateChangeTimestamp;
         this.lastIdleCodeChangeTimestamp = response.lastIdleCodeChangeTimestamp;
         this.isEndConsultEnabled = response.isEndConsultEnabled;
+        // TODO: Remove this once SDK performs the validation
         this.isAddressBookEnabled = Boolean(response.addressBookId);
         this.allowConsultToQueue = response.allowConsultToQueue;
         this.agentProfile.agentName = response.agentName;

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -127,6 +127,7 @@ interface IStore {
   allowConsultToQueue: boolean;
   agentProfile: AgentLoginProfile;
   isMuted: boolean;
+  isAddressBookEnabled: boolean;
   init(params: InitParams, callback: (ccSDK: IContactCenter) => void): Promise<void>;
   registerCC(webex?: WithWebex['webex']): Promise<void>;
 }

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -167,6 +167,10 @@ class StoreWrapper implements IStoreWrapper {
     return this.store.isMuted;
   }
 
+  get isAddressBookEnabled() {
+    return this.store.isAddressBookEnabled;
+  }
+
   setIsMuted = (value: boolean): void => {
     runInAction(() => {
       this.store.isMuted = value;
@@ -718,6 +722,9 @@ class StoreWrapper implements IStoreWrapper {
 
   getAddressBookEntries = async (params?: AddressBookEntrySearchParams): Promise<AddressBookEntriesResponse> => {
     try {
+      if (!this.store.isAddressBookEnabled) {
+        return {data: [], meta: {page: 0, totalPages: 0}};
+      }
       const response: AddressBookEntriesResponse = await this.store.cc.addressBook.getEntries(params ?? {});
       return response;
     } catch (error) {

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -871,6 +871,7 @@ describe('storeEventsWrapper', () => {
     });
 
     it('should fetch address book entries successfully', async () => {
+      storeWrapper['store'].isAddressBookEnabled = true;
       jest.spyOn(storeWrapper['store'].cc.addressBook, 'getEntries').mockResolvedValue(mockAddressBookEntriesResponse);
 
       const result = await storeWrapper.getAddressBookEntries({page: 0, pageSize: 25});
@@ -879,8 +880,17 @@ describe('storeEventsWrapper', () => {
     });
 
     it('should handle error while fetching address book entries', async () => {
+      storeWrapper['store'].isAddressBookEnabled = true;
       jest.spyOn(storeWrapper['store'].cc.addressBook, 'getEntries').mockRejectedValue(new Error('ab error'));
       await expect(storeWrapper.getAddressBookEntries({page: 0, pageSize: 25})).rejects.toThrow('ab error');
+    });
+
+    it('should return empty list and not call API when address book is disabled', async () => {
+      storeWrapper['store'].isAddressBookEnabled = false;
+      const getEntriesSpy = jest.spyOn(storeWrapper['store'].cc.addressBook, 'getEntries');
+      const result = await storeWrapper.getAddressBookEntries({page: 0, pageSize: 25});
+      expect(result).toEqual({data: [], meta: {page: 0, totalPages: 0}});
+      expect(getEntriesSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #< [CAI-7305](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7305) & [CAI-7313](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7313) & [CAI-7317](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7317) & [CAI-7318](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7318) & [CAI-7316](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7316) >

## This pull request addresses

* EPIC reported few bugs in the consult-transfer popover
* Search was not working in the agents tab
* The widget was showing different tabs from the agent desktop as widgets was not adhering to flags
* For agents where `consultToQueue` was disabled, the button was coming as disabled rather than the tab being hidden
* Manual consult-transfer to dial number and entrypoint was not working
* Addressbook api was failing for users who did not have the id and hence error was seen.

## by making the following changes

* Code was added so the tabs adhere to all flags strictly.
* Consistency with agent desktop was noted.
* For address book, only if the id existed were we calling the SDK api.
* Manual dialling validation was performed only for queue and for dial number and code was taken from agent desktop for validation.
* Some CSS changes to fix glitches

Vidcast 1 (Showing agent without addressbook and queues) - https://app.vidcast.io/share/aac9473d-2c76-4445-9371-80e78ee15413

Vidcast 2 (Showing agent with all settings) - https://app.vidcast.io/share/f8346a94-a4a1-4248-8bcc-8b3015932723

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] The testing is done with the amplify link

* Tested all consult-transfer cases for 2 types of sandboxes.
* Tested with e2e tests.

## The GAI Coding Policy And Copyright Annotation Best Practices ##
 
<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->
 
- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Cursor
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the testing document

---