### PR TITLE
fix(task-util): disable end button during conference with active consult

### DIFF
--- a/packages/contact-center/task/src/Utils/task-util.ts
+++ b/packages/contact-center/task/src/Utils/task-util.ts
@@ -43,22 +43,35 @@ function isTelephonySupported(deviceType: string, webRtcEnabled: boolean): boole
 }
 
 /**
- * Check if consulting with an EP_DN agent (matches Agent Desktop's isEPorEPDN)
+ * Check if consulting with an EP_DN agent (Entry Point Dial Number)
+ * This function looks for EP-DN participants in the consult media
  */
 function isConsultingWithEpDnAgent(task: ITask): boolean {
-  if (!task?.data?.interaction) {
+  if (!task?.data?.interaction?.media || !task?.data?.interaction?.participants) {
     return false;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const destAgentType = (task.data.interaction as any).destAgentType;
+  // Find the consult media
+  const consultMedia = Object.values(task.data.interaction.media).find((media) => media.mType === 'consult');
 
-  return (
-    destAgentType === DestinationAgentType.EP_DN ||
-    destAgentType === DestinationAgentType.EPDN ||
-    destAgentType === DestinationAgentType.ENTRY_POINT ||
-    destAgentType === DestinationAgentType.EP
-  );
+  if (!consultMedia || !consultMedia.participants) {
+    return false;
+  }
+
+  // Check if any participant in the consult media is an EP-DN
+  const participants = task.data.interaction.participants;
+  return consultMedia.participants.some((participantId: string) => {
+    const participant = participants[participantId];
+    if (!participant) return false;
+
+    // Check for EP-DN participant types using the type field
+    return (
+      participant.type === DestinationAgentType.EP_DN ||
+      participant.type === DestinationAgentType.EPDN ||
+      participant.type === DestinationAgentType.ENTRY_POINT ||
+      participant.type === DestinationAgentType.EP
+    );
+  });
 }
 
 export function findHoldTimestamp(interaction: Interaction, mType = 'mainCall'): number | null {
@@ -114,15 +127,19 @@ export function getEndButtonVisibility(
   const isVisible = isBrowser || (isEndCallEnabled && isCall) || !isCall;
   const isEpDnConsult = task && agentId ? isConsultingWithEpDnAgent(task) : false;
 
-  // EP_DN consult: End button enabled unless main call is held
-  if (isEpDnConsult && isConsultInitiatedOrAcceptedOrBeingConsulted) {
-    const isEnabled = !isHeld || (isConferenceInProgress && !isConsultCompleted);
+  if (isConsultInitiatedOrAcceptedOrBeingConsulted) {
+    let isEnabled = false;
+    if (isEpDnConsult) {
+      // EP-DN consult: enabled when on main call OR during conference when main not held
+      isEnabled = consultCallHeld || (!isHeld && isConferenceInProgress && !isConsultCompleted);
+    } else if (isConferenceInProgress) {
+      // Regular consult during conference: disabled to prevent ending conference prematurely
+      isEnabled = false;
+    } else {
+      // Regular consult without conference: enabled when on main call (consultCallHeld = true)
+      isEnabled = consultCallHeld;
+    }
     return {isVisible, isEnabled};
-  }
-
-  // Agent-to-agent consult during conference: End button enabled when switched back to main call
-  if (isConsultInitiatedOrAcceptedOrBeingConsulted && isConferenceInProgress) {
-    return {isVisible, isEnabled: false};
   }
 
   // Default logic for other states

--- a/packages/contact-center/task/src/Utils/task-util.ts
+++ b/packages/contact-center/task/src/Utils/task-util.ts
@@ -132,12 +132,6 @@ export function getEndButtonVisibility(
     if (isEpDnConsult) {
       // EP-DN consult: enabled when on main call OR during conference when main not held
       isEnabled = consultCallHeld || (!isHeld && isConferenceInProgress && !isConsultCompleted);
-    } else if (isConferenceInProgress) {
-      // Regular consult during conference: disabled to prevent ending conference prematurely
-      isEnabled = false;
-    } else {
-      // Regular consult without conference: enabled when on main call (consultCallHeld = true)
-      isEnabled = consultCallHeld;
     }
     return {isVisible, isEnabled};
   }

--- a/packages/contact-center/task/src/Utils/task-util.ts
+++ b/packages/contact-center/task/src/Utils/task-util.ts
@@ -122,12 +122,7 @@ export function getEndButtonVisibility(
 
   // Agent-to-agent consult during conference: End button enabled when switched back to main call
   if (isConsultInitiatedOrAcceptedOrBeingConsulted && isConferenceInProgress) {
-    return {isVisible, isEnabled: consultCallHeld};
-  }
-
-  // Regular consult without conference: End button enabled only when on main call
-  if (isConsultInitiatedOrAcceptedOrBeingConsulted && !isConferenceInProgress) {
-    return {isVisible, isEnabled: consultCallHeld};
+    return {isVisible, isEnabled: false};
   }
 
   // Default logic for other states

--- a/packages/contact-center/task/tests/utils/task-util.ts
+++ b/packages/contact-center/task/tests/utils/task-util.ts
@@ -689,13 +689,12 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
     webRtcEnabled: true,
   };
 
-  it('should enable end button during EP_DN consult when main call is active (not held)', () => {
+  it('should enable end button during EP_DN consult when switched back to main call (consultCallHeld = true)', () => {
     // Mock a task with EP_DN consult - switching back to main call (consult on hold)
     const task = createMockTask({
       consultMediaResourceId: 'consult',
       interaction: createPartialInteraction({
         mediaType: 'telephony',
-        destAgentType: DestinationAgentType.EP_DN,
         state: 'consulting',
         media: {
           main: {
@@ -726,13 +725,20 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
             name: 'Customer',
             hasLeft: false,
           },
+          'epdn-agent': {
+            id: 'epdn-agent',
+            pType: 'EP-DN',
+            type: DestinationAgentType.EP_DN,
+            name: 'Entry Point Agent',
+            hasLeft: false,
+          },
         },
       }),
     });
 
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', false);
 
-    // EP_DN consult: End button should be enabled when on main call
+    // EP_DN consult: End button should be enabled when on main call (consultCallHeld = true)
     expect(result.end.isVisible).toBe(true);
     expect(result.end.isEnabled).toBe(true);
   });
@@ -743,7 +749,6 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
       consultMediaResourceId: 'consult',
       interaction: createPartialInteraction({
         mediaType: 'telephony',
-        destAgentType: DestinationAgentType.EPDN,
         state: 'consulting',
         media: {
           main: {
@@ -774,6 +779,13 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
             name: 'Customer',
             hasLeft: false,
           },
+          'epdn-agent': {
+            id: 'epdn-agent',
+            pType: 'EP-DN',
+            type: DestinationAgentType.EPDN,
+            name: 'Entry Point DN Agent',
+            hasLeft: false,
+          },
         },
       }),
     });
@@ -785,21 +797,26 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
     expect(result.end.isEnabled).toBe(false);
   });
 
-  it('should enable end button during EP_DN consult conference when main call is held but conference in progress', () => {
+  it('should enable end button during EP_DN consult conference when main call is not held', () => {
     // Mock a task with EP_DN consult in conference state
     const task = createMockTask({
       isConferenceInProgress: true,
       consultMediaResourceId: 'consult',
       interaction: createPartialInteraction({
         mediaType: 'telephony',
-        destAgentType: DestinationAgentType.ENTRY_POINT,
-        state: 'conferencing',
+        state: 'conference',
         media: {
           main: {
             mediaResourceId: 'main',
             mType: 'mainCall',
-            isHold: true, // Main call is held during conference
+            isHold: false, // Main call is not held during conference
             participants: ['agent1', 'customer1', 'epdn-agent'],
+          },
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            isHold: true, // Consult media on hold (merged into main)
+            participants: ['agent1', 'epdn-agent'],
           },
         },
         participants: {
@@ -819,8 +836,9 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
           },
           'epdn-agent': {
             id: 'epdn-agent',
-            pType: 'Agent',
-            name: 'EP DN Agent',
+            pType: 'EP-DN',
+            type: DestinationAgentType.ENTRY_POINT,
+            name: 'Entry Point Agent',
             hasLeft: false,
           },
         },
@@ -829,15 +847,15 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
 
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', true);
 
+    // EP_DN conference: End button enabled when main call not held + conference in progress
     expect(result.end.isVisible).toBe(true);
     expect(result.end.isEnabled).toBe(true);
   });
 
-  it('should recognize EP destAgentType variant', () => {
+  it('should recognize EP participant type variant', () => {
     const task = createMockTask({
       consultMediaResourceId: 'consult',
       interaction: createPartialInteraction({
-        destAgentType: DestinationAgentType.EP,
         mediaType: 'telephony',
         state: 'consulting',
         media: {
@@ -869,18 +887,25 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
             name: 'Customer',
             hasLeft: false,
           },
+          'ep-agent': {
+            id: 'ep-agent',
+            pType: 'EP',
+            type: DestinationAgentType.EP,
+            name: 'Entry Point',
+            hasLeft: false,
+          },
         },
       }),
     });
 
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', false);
 
-    // EP_DN consult: End button should be enabled when on main call
+    // EP consult: End button should be enabled when on main call (consultCallHeld = true)
     expect(result.end.isVisible).toBe(true);
     expect(result.end.isEnabled).toBe(true);
   });
 
-  it('should handle missing destAgentType as non-EP_DN consult', () => {
+  it('should disable end button for regular agent-to-agent consult (non-EP_DN)', () => {
     const task = createMockTask({
       consultMediaResourceId: 'consult',
       interaction: createPartialInteraction({
@@ -907,13 +932,25 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
             consultState: 'Initiated',
             hasLeft: false,
           },
+          agent2: {
+            id: 'agent2',
+            pType: 'Agent',
+            type: 'Agent',
+            name: 'Agent Two',
+            hasLeft: false,
+          },
+          customer1: {
+            id: 'customer1',
+            pType: 'Customer',
+            hasLeft: false,
+          },
         },
       }),
     });
 
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', false);
 
-    // Should follow regular consult logic (disabled when on consult call)
+    // Regular agent-to-agent consult: End button disabled when in consult
     expect(result.end.isVisible).toBe(true);
     expect(result.end.isEnabled).toBe(false);
   });
@@ -939,6 +976,200 @@ describe('getEndButtonVisibility - EP_DN consult scenarios', () => {
     expect(result.end).toBeDefined();
     expect(result.end.isVisible).toBeDefined();
     expect(result.end.isEnabled).toBeDefined();
+  });
+});
+
+describe('isConsultingWithEpDnAgent', () => {
+  it('should detect EP-DN participant in consult media', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            participants: ['agent1', 'epdn-agent'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+          },
+          'epdn-agent': {
+            id: 'epdn-agent',
+            pType: 'EP-DN',
+            type: DestinationAgentType.EP_DN,
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    // The function should detect EP-DN and apply special logic
+    expect(result).toBeDefined();
+  });
+
+  it('should detect EPDN variant', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            participants: ['agent1', 'epdn-agent'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+          },
+          'epdn-agent': {
+            id: 'epdn-agent',
+            type: DestinationAgentType.EPDN,
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    expect(result).toBeDefined();
+  });
+
+  it('should detect ENTRY_POINT variant', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            participants: ['agent1', 'ep-agent'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+          },
+          'ep-agent': {
+            id: 'ep-agent',
+            type: DestinationAgentType.ENTRY_POINT,
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    expect(result).toBeDefined();
+  });
+
+  it('should detect EP variant', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            participants: ['agent1', 'ep-agent'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+          },
+          'ep-agent': {
+            id: 'ep-agent',
+            type: DestinationAgentType.EP,
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    expect(result).toBeDefined();
+  });
+
+  it('should return false for regular agent-to-agent consult', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            participants: ['agent1', 'agent2'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            type: 'Agent',
+          },
+          agent2: {
+            id: 'agent2',
+            pType: 'Agent',
+            type: 'Agent',
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    expect(result).toBeDefined();
+  });
+
+  it('should handle missing consult media gracefully', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          main: {
+            mediaResourceId: 'main',
+            mType: 'mainCall',
+            participants: ['agent1', 'customer1'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    expect(result).toBeDefined();
+  });
+
+  it('should handle missing participants gracefully', () => {
+    const task = createMockTask({
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        media: {
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            participants: ['agent1', 'unknown'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility('BROWSER', {isEndCallEnabled: true}, task, 'agent1', false);
+    expect(result).toBeDefined();
   });
 });
 

--- a/packages/contact-center/task/tests/utils/task-util.ts
+++ b/packages/contact-center/task/tests/utils/task-util.ts
@@ -490,7 +490,7 @@ describe('getControlsVisibility', () => {
     expect(result.end.isVisible).toBe(true);
   });
 
-  it('should enable end button when in regular consult and switched back to main call (consultCallHeld = true)', () => {
+  it('should disable end button for regular consult even when switched back to main call (consultCallHeld = true)', () => {
     const deviceType = 'BROWSER';
     const featureFlags = {
       isEndCallEnabled: true,
@@ -546,8 +546,8 @@ describe('getControlsVisibility', () => {
 
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', false);
 
-    // End button should be enabled when switched back to main call from consult
-    expect(result.end.isEnabled).toBe(true);
+    // End button should be disabled for regular (non-EP-DN) consults regardless of consultCallHeld
+    expect(result.end.isEnabled).toBe(false);
     expect(result.end.isVisible).toBe(true);
   });
 

--- a/packages/contact-center/task/tests/utils/task-util.ts
+++ b/packages/contact-center/task/tests/utils/task-util.ts
@@ -423,7 +423,7 @@ describe('getControlsVisibility', () => {
     });
   });
 
-  it('should enable end button when in conference and switched back from consult (consultCallHeld = true)', () => {
+  it('should disable end button when in conference with active consult (consultCallHeld = true)', () => {
     const deviceType = 'BROWSER';
     const featureFlags = {
       isEndCallEnabled: true,
@@ -485,8 +485,8 @@ describe('getControlsVisibility', () => {
 
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', true);
 
-    // End button should be enabled when switched back to main call from consult
-    expect(result.end.isEnabled).toBe(true);
+    // End button should be disabled during agent-to-agent consult in conference
+    expect(result.end.isEnabled).toBe(false);
     expect(result.end.isVisible).toBe(true);
   });
 
@@ -609,6 +609,73 @@ describe('getControlsVisibility', () => {
     const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', false);
 
     // End button should be disabled when on active consult call
+    expect(result.end.isEnabled).toBe(false);
+    expect(result.end.isVisible).toBe(true);
+  });
+
+  it('should disable end button during conference when consult is active (not held)', () => {
+    const deviceType = 'BROWSER';
+    const featureFlags = {
+      isEndCallEnabled: true,
+      isEndConsultEnabled: true,
+      webRtcEnabled: true,
+    };
+
+    // Mock a task with conference in progress and agent switched to consult
+    const task = createMockTask({
+      isConferenceInProgress: true,
+      consultMediaResourceId: 'consult',
+      interaction: createPartialInteraction({
+        mediaType: 'telephony',
+        state: 'conferencing',
+        media: {
+          main: {
+            mediaResourceId: 'main',
+            mType: 'mainCall',
+            isHold: true, // Main is held - switched to consult
+            participants: ['agent1', 'agent2', 'customer1'],
+          },
+          consult: {
+            mediaResourceId: 'consult',
+            mType: 'consult',
+            isHold: false, // Consult is active
+            participants: ['agent1', 'agent3'],
+          },
+        },
+        participants: {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent One',
+            consultState: 'Conferencing',
+            isConsulted: false,
+            hasLeft: false,
+          },
+          agent2: {
+            id: 'agent2',
+            pType: 'Agent',
+            name: 'Agent Two',
+            hasLeft: false,
+          },
+          agent3: {
+            id: 'agent3',
+            pType: 'Agent',
+            name: 'Agent Three',
+            hasLeft: false,
+          },
+          customer1: {
+            id: 'customer1',
+            pType: 'Customer',
+            name: 'Customer',
+            hasLeft: false,
+          },
+        },
+      }),
+    });
+
+    const result = getControlsVisibility(deviceType, featureFlags, task, 'agent1', true);
+
+    // End button should be disabled during conference with active consult
     expect(result.end.isEnabled).toBe(false);
     expect(result.end.isVisible).toBe(true);
   });


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #[CAI-7511](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7511)

## This pull request addresses

Inconsistent end call button visibility states from CC Desktop

## by making the following changes

Modified state variables to mirror what is on the CC desktop

Vidcast: https://app.vidcast.io/share/05ed13ef-acff-4465-8854-72dc35f21583

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##

<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the testing document
- [x] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
