### PR TITLE
fix(task): display dialed number for outdial calls in task widgets

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
@@ -56,7 +56,26 @@ export const extractIncomingTaskData = (
     const declineText = !incomingTask.data.wrapUpRequired && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // For outdial calls, use the customer participant's DN (dialed number) if available
+    // For inbound calls, use ANI (caller's number)
+    let title = isSocial ? customerName : ani;
+
+    if (isTelephony && incomingTask?.data?.interaction?.participants) {
+      // Find customer participant to get the dialed number for outdial calls
+      const customerParticipant = Object.values(incomingTask.data.interaction.participants).find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (participant: any) => participant.pType === 'Customer'
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const customerDn = (customerParticipant as any)?.dn;
+
+      // If customer has a DN, use it (this is an outdial call)
+      // Otherwise, fall back to ANI (inbound call)
+      if (customerDn) {
+        title = customerDn;
+      }
+    }
 
     // Compute disable state for accept button when auto-answering
     const isAutoAnswering = incomingTask.data.isAutoAnswering || false;

--- a/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
@@ -39,7 +39,26 @@ export const extractTaskListItemData = (
     const declineText = isTaskIncoming && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // For outdial calls, use the customer participant's DN (dialed number) if available
+    // For inbound calls, use ANI (caller's number)
+    let title = isSocial ? customerName : ani;
+
+    if (isTelephony && task?.data?.interaction?.participants) {
+      // Find customer participant to get the dialed number for outdial calls
+      const customerParticipant = Object.values(task.data.interaction.participants).find(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (participant: any) => participant.pType === 'Customer'
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const customerDn = (customerParticipant as any)?.dn;
+
+      // If customer has a DN, use it (this is an outdial call)
+      // Otherwise, fall back to ANI (inbound call)
+      if (customerDn) {
+        title = customerDn;
+      }
+    }
 
     const isAutoAnswering = task.data.isAutoAnswering || false;
 

--- a/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
@@ -105,6 +105,107 @@ describe('incoming-task.utils', () => {
       });
     });
 
+    describe('Outdial calls', () => {
+      it('should use customer DN for outdial telephony task', () => {
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+
+        // Set up an outdial scenario with customer participant having DN
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+11234567890', // Entrypoint number
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Sales Team',
+        };
+
+        mockTask.data.interaction.participants = {
+          agent1: {
+            hasJoined: true,
+            pType: 'Agent',
+            id: 'agent1',
+            name: 'Agent Smith',
+            hasLeft: false,
+          },
+          customer1: {
+            hasJoined: true,
+            pType: 'Customer',
+            id: 'customer1',
+            name: 'Customer',
+            dn: '+19876543210', // Dialed number
+            hasLeft: false,
+          },
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.isTelephony).toBe(true);
+        expect(result.ani).toBe('+11234567890');
+        expect(result.title).toBe('+19876543210'); // Should use customer DN, not ANI
+
+        // Restore original values
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+      });
+
+      it('should fall back to ANI when customer participant has no DN', () => {
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+
+        // Set up an inbound scenario without customer DN
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+15551234567',
+          customerName: 'Inbound Caller',
+          virtualTeamName: 'Support Team',
+        };
+
+        mockTask.data.interaction.participants = {
+          agent1: {
+            hasJoined: true,
+            pType: 'Agent',
+            id: 'agent1',
+            name: 'Agent Jones',
+            hasLeft: false,
+          },
+          customer1: {
+            hasJoined: true,
+            pType: 'Customer',
+            id: 'customer1',
+            name: 'Customer',
+            hasLeft: false,
+          },
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.isTelephony).toBe(true);
+        expect(result.ani).toBe('+15551234567');
+        expect(result.title).toBe('+15551234567'); // Should fall back to ANI
+
+        // Restore original values
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+      });
+
+      it('should handle missing participants gracefully', () => {
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+15559999999',
+          customerName: 'Test Customer',
+        };
+
+        mockTask.data.interaction.participants = undefined;
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+15559999999'); // Should fall back to ANI
+
+        // Restore original values
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+      });
+    });
+
     describe('Edge cases', () => {
       it('should handle missing call association details', () => {
         const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;

--- a/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
@@ -243,6 +243,118 @@ describe('task-list.utils', () => {
         mockTask.data.interaction.mediaType = originalMediaType;
       });
     });
+
+    describe('Outdial calls', () => {
+      it('should use customer DN for outdial telephony task', () => {
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        // Set up an outdial scenario with customer participant having DN
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+11234567890', // Entrypoint number
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Sales Team',
+        };
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+
+        mockTask.data.interaction.participants = {
+          agent1: {
+            hasJoined: true,
+            pType: 'Agent',
+            id: 'agent1',
+            name: 'Agent Smith',
+            hasLeft: false,
+          },
+          customer1: {
+            hasJoined: true,
+            pType: 'Customer',
+            id: 'customer1',
+            name: 'Customer',
+            dn: '+19876543210', // Dialed number
+            hasLeft: false,
+          },
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.isTelephony).toBe(true);
+        expect(result.ani).toBe('+11234567890');
+        expect(result.title).toBe('+19876543210'); // Should use customer DN, not ANI
+
+        // Restore original values
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+
+      it('should fall back to ANI when customer participant has no DN', () => {
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        // Set up an inbound scenario without customer DN
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+15551234567',
+          customerName: 'Inbound Caller',
+          virtualTeamName: 'Support Team',
+        };
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+
+        mockTask.data.interaction.participants = {
+          agent1: {
+            hasJoined: true,
+            pType: 'Agent',
+            id: 'agent1',
+            name: 'Agent Jones',
+            hasLeft: false,
+          },
+          customer1: {
+            hasJoined: true,
+            pType: 'Customer',
+            id: 'customer1',
+            name: 'Customer',
+            hasLeft: false,
+          },
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.isTelephony).toBe(true);
+        expect(result.ani).toBe('+15551234567');
+        expect(result.title).toBe('+15551234567'); // Should fall back to ANI
+
+        // Restore original values
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+
+      it('should handle missing participants gracefully', () => {
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+15559999999',
+          customerName: 'Test Customer',
+        };
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.participants = undefined;
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('+15559999999'); // Should fall back to ANI
+
+        // Restore original values
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+    });
   });
 
   describe('isTaskSelectable', () => {


### PR DESCRIPTION
<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES [CAI-7359](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7359)

## This pull request addresses

When making an outdial call via dialpad, the incoming task, task list, and active task were displaying the entrypoint number (ANI) instead of the dialed number (customer DN).

For outdial calls:
- **ANI** (Automatic Number Identification) = The number you're calling FROM (entrypoint)
- **Customer DN** (Dialed Number) = The number you're calling TO

The widgets were only using the ANI field, which works for inbound calls but shows the wrong number for outdial calls.

## by making the following changes

- Updated `extractIncomingTaskData` in `incoming-task.utils.tsx` to check for customer participant's DN field
- Updated `extractTaskListItemData` in `task-list.utils.ts` to check for customer participant's DN field
- For outdial calls: Use customer DN (dialed number) when available
- For inbound calls: Fall back to ANI (caller's number)
- Added 6 comprehensive unit tests covering outdial and inbound scenarios
- All 633 tests passing with 87% code coverage maintained

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Unit tests: All 633 tests passing (6 new tests added)
- [x] Outdial call with customer DN - verified correct number displayed
- [x] Inbound call fallback to ANI - verified correct number displayed
- [x] Missing participants handling - verified graceful fallback
- [ ] The testing is done with the amplify link

Manual testing required:
- Place an outdial call via dialpad and verify the dialed number is displayed
- Receive an inbound call and verify the ANI (caller number) is displayed
- Verify incoming task widget shows correct number
- Verify task list shows correct number
- Verify active task shows correct number

## The GAI Coding Policy And Copyright Annotation Best Practices ##

<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
