### PR TITLE
fix(cc-components): display dialed number instead of entrypoint for outdial calls

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
@@ -55,8 +55,30 @@ export const extractIncomingTaskData = (
 
     const declineText = !incomingTask.data.wrapUpRequired && isTelephony && isBrowser ? 'Decline' : undefined;
 
-    // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // Compute title based on media type and call direction
+    // For outdial calls (direction: "OUTBOUND"), use customer participant's DN instead of ANI
+    // ANI represents the entrypoint/DNIS for outdial, not the dialed number
+    let title = isSocial ? customerName : ani;
+
+    if (isTelephony) {
+      //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
+      const direction = incomingTask?.data?.interaction?.direction;
+
+      if (direction === 'OUTBOUND') {
+        // Find customer participant's DN for outdial calls
+        const participants = incomingTask?.data?.interaction?.participants;
+        if (participants) {
+          const customerParticipant = Object.values(participants).find(
+            //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
+            (p) => p.pType === 'Customer'
+          );
+          if (customerParticipant) {
+            //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
+            title = customerParticipant.dn || customerParticipant.id || ani;
+          }
+        }
+      }
+    }
 
     // Compute disable state for accept button when auto-answering
     const isAutoAnswering = incomingTask.data.isAutoAnswering || false;

--- a/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
@@ -38,8 +38,30 @@ export const extractTaskListItemData = (
 
     const declineText = isTaskIncoming && isTelephony && isBrowser ? 'Decline' : undefined;
 
-    // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // Compute title based on media type and call direction
+    // For outdial calls (direction: "OUTBOUND"), use customer participant's DN instead of ANI
+    // ANI represents the entrypoint/DNIS for outdial, not the dialed number
+    let title = isSocial ? customerName : ani;
+
+    if (isTelephony) {
+      //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
+      const direction = task?.data?.interaction?.direction;
+
+      if (direction === 'OUTBOUND') {
+        // Find customer participant's DN for outdial calls
+        const participants = task?.data?.interaction?.participants;
+        if (participants) {
+          const customerParticipant = Object.values(participants).find(
+            //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
+            (p) => p.pType === 'Customer'
+          );
+          if (customerParticipant) {
+            //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
+            title = customerParticipant.dn || customerParticipant.id || ani;
+          }
+        }
+      }
+    }
 
     const isAutoAnswering = task.data.isAutoAnswering || false;
 

--- a/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
@@ -105,6 +105,129 @@ describe('incoming-task.utils', () => {
       });
     });
 
+    describe('Outdial calls', () => {
+      it('should display dialed number (customer DN) for OUTBOUND telephony tasks instead of ANI', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalParticipants = mockTask.data.interaction.participants;
+
+        // Setup OUTBOUND call with customer participant
+        mockTask.data.interaction.direction = 'OUTBOUND';
+        mockTask.data.interaction.participants = {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent Name',
+            dn: '1001',
+          },
+          customer1: {
+            id: 'customer1',
+            pType: 'Customer',
+            name: 'Customer Name',
+            dn: '+15551234567', // Dialed number
+          },
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        // For outdial, title should be the customer's DN (dialed number), not ANI
+        expect(result.title).toBe('+15551234567');
+        expect(result.title).not.toBe(result.ani);
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.participants = originalParticipants;
+      });
+
+      it('should fall back to customer ID if DN is not available in OUTBOUND calls', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalParticipants = mockTask.data.interaction.participants;
+
+        // Setup OUTBOUND call with customer participant without DN
+        mockTask.data.interaction.direction = 'OUTBOUND';
+        mockTask.data.interaction.participants = {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent Name',
+            dn: '1001',
+          },
+          customer1: {
+            id: '+15559876543',
+            pType: 'Customer',
+            name: 'Customer Name',
+            // No DN field
+          },
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        // Should fall back to customer ID
+        expect(result.title).toBe('+15559876543');
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.participants = originalParticipants;
+      });
+
+      it('should fall back to ANI if customer participant is not found in OUTBOUND calls', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalParticipants = mockTask.data.interaction.participants;
+
+        // Setup OUTBOUND call without customer participant
+        mockTask.data.interaction.direction = 'OUTBOUND';
+        mockTask.data.interaction.participants = {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent Name',
+            dn: '1001',
+          },
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        // Should fall back to ANI
+        expect(result.title).toBe(result.ani);
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.participants = originalParticipants;
+      });
+
+      it('should use ANI for INBOUND telephony tasks (default behavior)', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+
+        // Explicitly set as INBOUND
+        mockTask.data.interaction.direction = 'INBOUND';
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        // For inbound, title should be ANI as before
+        expect(result.title).toBe(result.ani);
+
+        // Restore original value
+        mockTask.data.interaction.direction = originalDirection;
+      });
+
+      it('should not affect social media tasks for OUTBOUND direction', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalDirection = mockTask.data.interaction.direction;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.SOCIAL;
+        mockTask.data.interaction.direction = 'OUTBOUND';
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        // For social, title should still be customerName regardless of direction
+        expect(result.title).toBe(result.customerName);
+        expect(result.isSocial).toBe(true);
+
+        // Restore original values
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.direction = originalDirection;
+      });
+    });
+
     describe('Edge cases', () => {
       it('should handle missing call association details', () => {
         const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;

--- a/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
@@ -243,6 +243,159 @@ describe('task-list.utils', () => {
         mockTask.data.interaction.mediaType = originalMediaType;
       });
     });
+
+    describe('Outdial calls', () => {
+      it('should display dialed number (customer DN) for OUTBOUND telephony tasks instead of ANI', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalState = mockTask.data.interaction.state;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        // Setup OUTBOUND call with customer participant
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.direction = 'OUTBOUND';
+        mockTask.data.interaction.participants = {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent Name',
+            dn: '1001',
+          },
+          customer1: {
+            id: 'customer1',
+            pType: 'Customer',
+            name: 'Customer Name',
+            dn: '+15551234567', // Dialed number
+          },
+        };
+
+        const result = extractTaskListItemData(mockTask, true, 'agent1');
+
+        // For outdial, title should be the customer's DN (dialed number), not ANI
+        expect(result.title).toBe('+15551234567');
+        expect(result.title).not.toBe(result.ani);
+        expect(result.isTelephony).toBe(true);
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+
+      it('should fall back to customer ID if DN is not available in OUTBOUND calls', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalState = mockTask.data.interaction.state;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        // Setup OUTBOUND call with customer participant without DN
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.direction = 'OUTBOUND';
+        mockTask.data.interaction.participants = {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent Name',
+            dn: '1001',
+          },
+          customer1: {
+            id: '+15559876543',
+            pType: 'Customer',
+            name: 'Customer Name',
+            // No DN field
+          },
+        };
+
+        const result = extractTaskListItemData(mockTask, true, 'agent1');
+
+        // Should fall back to customer ID
+        expect(result.title).toBe('+15559876543');
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+
+      it('should fall back to ANI if customer participant is not found in OUTBOUND calls', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalParticipants = mockTask.data.interaction.participants;
+        const originalState = mockTask.data.interaction.state;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        // Setup OUTBOUND call without customer participant
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.direction = 'OUTBOUND';
+        mockTask.data.interaction.participants = {
+          agent1: {
+            id: 'agent1',
+            pType: 'Agent',
+            name: 'Agent Name',
+            dn: '1001',
+          },
+        };
+
+        const result = extractTaskListItemData(mockTask, true, 'agent1');
+
+        // Should fall back to ANI
+        expect(result.title).toBe(result.ani);
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.participants = originalParticipants;
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+
+      it('should use ANI for INBOUND telephony tasks (default behavior)', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalState = mockTask.data.interaction.state;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.direction = 'INBOUND';
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        // For inbound, title should be ANI as before
+        expect(result.title).toBe(result.ani);
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+
+      it('should not affect social media tasks for OUTBOUND direction', () => {
+        const originalDirection = mockTask.data.interaction.direction;
+        const originalState = mockTask.data.interaction.state;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalMediaChannel = mockTask.data.interaction.mediaChannel;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.SOCIAL;
+        mockTask.data.interaction.mediaChannel = 'twitter';
+        mockTask.data.interaction.direction = 'OUTBOUND';
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        // For social, title should still be customerName regardless of direction
+        expect(result.title).toBe(result.customerName);
+        expect(result.isSocial).toBe(true);
+
+        // Restore original values
+        mockTask.data.interaction.direction = originalDirection;
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.mediaChannel = originalMediaChannel;
+      });
+    });
   });
 
   describe('isTaskSelectable', () => {


### PR DESCRIPTION
# COMPLETES [CAI-7359](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7359)

## This pull request addresses

When making an outdial call via the dialpad, the IncomingTask, TaskList, and Task widgets were displaying the entrypoint/DNIS number instead of the actual dialed number. This occurred because the widgets always used the ANI field for telephony calls, which contains the entrypoint number for outbound calls rather than the number the agent dialed.

## by making the following changes

- Modified `extractIncomingTaskData` in `incoming-task.utils.tsx` to detect OUTBOUND direction calls and extract the customer participant's `dn` (dialed number) instead of using the ANI
- Applied the same fix to `extractTaskListItemData` in `task-list.utils.ts` for consistency across TaskList widget
- Added fallback chain: customer DN → customer ID → ANI (for robustness)
- Added 10 new unit tests covering outdial scenarios, fallbacks, inbound preservation, and social media non-interference

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- [x] Unit tests added/updated and passing
- [x] OUTBOUND telephony call displays customer DN (dialed number) instead of ANI
- [x] OUTBOUND call without customer DN falls back to customer ID
- [x] OUTBOUND call without customer participant falls back to ANI
- [x] INBOUND telephony calls still display ANI (no regression)
- [x] Social media tasks unaffected by direction changes

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.