### PR TITLE
fix(cc-digital-channels): upgrade cc-digital-interactions to 3.0.8 and add peer deps for React 19

### DIFF
--- a/packages/contact-center/cc-digital-channels/package.json
+++ b/packages/contact-center/cc-digital-channels/package.json
@@ -65,7 +65,7 @@
     "webpack-merge": "6.0.1"
   },
   "peerDependencies": {
-    "@momentum-ui/web-components": "^2.23.35",
+    "@momentum-ui/web-components": "^2.26.20",
     "react": ">=18.3.1",
     "react-dom": ">=18.3.1"
   }

--- a/packages/contact-center/cc-digital-channels/package.json
+++ b/packages/contact-center/cc-digital-channels/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@webex/cc-store": "workspace:*",
-    "cc-digital-interactions": "3.0.6-beta.1",
+    "cc-digital-interactions": "3.0.8",
     "mobx-react-lite": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/contact-center/cc-widgets/package.json
+++ b/packages/contact-center/cc-widgets/package.json
@@ -84,7 +84,10 @@
     "webpack-merge": "6.0.1"
   },
   "peerDependencies": {
-    "@momentum-ui/react-collaboration": ">=26.197.0"
+    "@momentum-ui/react-collaboration": ">=26.197.0",
+    "@momentum-ui/web-components": "^2.23.35",
+    "react": ">=18.3.1",
+    "react-dom": ">=18.3.1"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/packages/contact-center/cc-widgets/package.json
+++ b/packages/contact-center/cc-widgets/package.json
@@ -85,7 +85,7 @@
   },
   "peerDependencies": {
     "@momentum-ui/react-collaboration": ">=26.197.0",
-    "@momentum-ui/web-components": "^2.23.35",
+    "@momentum-ui/web-components": "^2.26.20",
     "react": ">=18.3.1",
     "react-dom": ">=18.3.1"
   },

--- a/widgets-samples/cc/samples-cc-react-app/package.json
+++ b/widgets-samples/cc/samples-cc-react-app/package.json
@@ -21,7 +21,7 @@
     "@momentum-ui/react-collaboration": "26.197.0",
     "@momentum-ui/tokens": "1.7.1",
     "@momentum-ui/utils": "6.2.15",
-    "@momentum-ui/web-components": "^2.23.35",
+    "@momentum-ui/web-components": "^2.26.20",
     "@webex/cc-widgets": "workspace:*",
     "babel-loader": "^9.2.1",
     "file-loader": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,7 +3902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@momentum-ui/web-components@npm:^2.23.35":
+"@momentum-ui/web-components@npm:^2.26.20":
   version: 2.26.27
   resolution: "@momentum-ui/web-components@npm:2.26.27"
   dependencies:
@@ -9476,7 +9476,7 @@ __metadata:
     webpack-cli: "npm:5.1.4"
     webpack-merge: "npm:6.0.1"
   peerDependencies:
-    "@momentum-ui/web-components": ^2.23.35
+    "@momentum-ui/web-components": ^2.26.20
     react: ">=18.3.1"
     react-dom: ">=18.3.1"
   languageName: unknown
@@ -9739,7 +9739,7 @@ __metadata:
     webpack-merge: "npm:6.0.1"
   peerDependencies:
     "@momentum-ui/react-collaboration": ">=26.197.0"
-    "@momentum-ui/web-components": ^2.23.35
+    "@momentum-ui/web-components": ^2.26.20
     react: ">=18.3.1"
     react-dom: ">=18.3.1"
   languageName: unknown
@@ -31308,7 +31308,7 @@ __metadata:
     "@momentum-ui/react-collaboration": "npm:26.197.0"
     "@momentum-ui/tokens": "npm:1.7.1"
     "@momentum-ui/utils": "npm:6.2.15"
-    "@momentum-ui/web-components": "npm:^2.23.35"
+    "@momentum-ui/web-components": "npm:^2.26.20"
     "@webex/cc-widgets": "workspace:*"
     babel-loader: "npm:^9.2.1"
     eslint: "npm:^9.20.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9450,7 +9450,7 @@ __metadata:
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
-    cc-digital-interactions: "npm:3.0.6-beta.1"
+    cc-digital-interactions: "npm:3.0.8"
     css-loader: "npm:7.1.2"
     eslint: "npm:^9.20.1"
     eslint-config-prettier: "npm:^10.0.1"
@@ -9739,6 +9739,9 @@ __metadata:
     webpack-merge: "npm:6.0.1"
   peerDependencies:
     "@momentum-ui/react-collaboration": ">=26.197.0"
+    "@momentum-ui/web-components": ^2.23.35
+    react: ">=18.3.1"
+    react-dom: ">=18.3.1"
   languageName: unknown
   linkType: soft
 
@@ -15260,9 +15263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cc-digital-interactions@npm:3.0.6-beta.1":
-  version: 3.0.6-beta.1
-  resolution: "cc-digital-interactions@npm:3.0.6-beta.1"
+"cc-digital-interactions@npm:3.0.8":
+  version: 3.0.8
+  resolution: "cc-digital-interactions@npm:3.0.8"
   dependencies:
     "@microsoft/signalr": "npm:^8.0.7"
     "@wxcc-desktop/sdk": "npm:^2.0.11"
@@ -15277,9 +15280,9 @@ __metadata:
     showdown: "npm:2.1.0"
   peerDependencies:
     "@momentum-ui/web-components": ^2.26.20
-    react: ^18.3.1
-    react-dom: ^18.3.1
-  checksum: 10c0/071e508afe3e0aa184a69a40d9dd61558e0708943fa094f6195402e78d80284df18404abc646d1c035c8c81c390fb63ccaa92257600a4ae4d089c66e28dda99e
+    react: ">=18.3.1"
+    react-dom: ">=18.3.1"
+  checksum: 10c0/306326e32c37ce05ab2c0d170f72bd987a648f8819b09bcea82f2dc61adaaf8bf46d24020fe691b08d5b467a6d72956312ef207451e756eec21710024383f95e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!--
Hey there,\
Thank you for taking the time to improve our code! 🙂\
Please let us know why this change is necessary and what testing you have performed. \
This ensures our reviewers understand the impact of your change. \

**IMPORTANT**
FAILING TO FILL OUT THIS TEMPLATE WILL RESULT IN REJECTION OF YOUR PULL REQUEST
This is for compliance purposes with FedRAMP program.
-->

# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7679

## This pull request addresses

**React 19 compatibility for consumers of @webex/cc-widgets when using Digital Channels.**

After Digital Channels was added, Epic (and any app on React 19) hit:

- ERESOLVE on install because cc-digital-interactions@3.0.6-beta.1 required react@^18.3.1 (excludes React 19).
- Missing peer dependency signals — cc-widgets did not declare react, react-dom, or @momentum-ui/web-components, so consumers did not know to install them and could see missing-module or peer warnings.

**Engage Team** has fixed this by releasing cc-digital-interactions@3.0.8 with react: ">=18.3.1" (React 19 allowed).

## by making the following changes

1. packages/contact-center/cc-digital-channels/package.json

- Bumped cc-digital-interactions from 3.0.6-beta.1 to 3.0.8 so the dependency tree is React 19–compatible.

2. packages/contact-center/cc-widgets/package.json

- Declared missing peerDependencies: react and react-dom (>=18.3.1) and @momentum-ui/web-components (^2.23.35).
- Ensures consumers are told to install these (they are externals in the bundle) and avoids “missing module” / peer dependency warnings when using Digital Channels.

With these updates, React 19 apps can install and use @webex/cc-widgets (including Digital Channels) without the previous dependency conflict.

<!-- You may include screenshots -->

### Change Type

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
< ENUMERATE TESTS PERFORMED, WHETHER MANUAL OR AUTOMATED >

## The GAI Coding Policy And Copyright Annotation Best Practices ##

<!-- **MANDATORY** If Yes, Mention the GAI Coding Policy Copyright Annotation Best Practices followed separated by a comma below the yes checkbox -->

- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.
