### PR TITLE
fix(cc-components): show dialed number instead of entrypoint for outdial calls

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -65,9 +65,14 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   const customerName = currentTask?.data?.interaction?.callAssociatedDetails?.customerName;
 
   //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
-  const ani = currentTask?.data?.interaction?.callAssociatedDetails?.ani;
+  const rawAni = currentTask?.data?.interaction?.callAssociatedDetails?.ani;
   //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
-  const dn = currentTask?.data?.interaction?.callAssociatedDetails?.dn;
+  const rawDn = currentTask?.data?.interaction?.callAssociatedDetails?.dn;
+
+  // For outdial calls, swap ani and dn so the dialed number is shown as the primary identifier
+  const isOutdial = !!currentTask?.data?.interaction?.outboundType;
+  const ani = isOutdial ? rawDn || rawAni : rawAni;
+  const dn = isOutdial ? rawAni || rawDn : rawDn;
 
   // Create unique IDs for tooltips
   const customerNameTriggerId = `customer-name-trigger-${currentTask.data.interaction.interactionId}`;

--- a/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
@@ -35,12 +35,16 @@ export const extractIncomingTaskData = (
     //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
     const callAssociationDetails = incomingTask?.data?.interaction?.callAssociatedDetails;
     const ani = callAssociationDetails?.ani;
+    const dn = callAssociationDetails?.dn;
     const customerName = callAssociationDetails?.customerName;
     const virtualTeamName = callAssociationDetails?.virtualTeamName;
     const ronaTimeout = callAssociationDetails?.ronaTimeout ? Number(callAssociationDetails?.ronaTimeout) : null;
     const startTimeStamp = incomingTask?.data?.interaction?.createdTimestamp;
     const mediaType = incomingTask.data.interaction.mediaType;
     const mediaChannel = incomingTask.data.interaction.mediaChannel;
+
+    // Check if this is an outdial call
+    const isOutdial = !!incomingTask?.data?.interaction?.outboundType;
 
     // Compute media type flags
     const isTelephony = mediaType === MEDIA_CHANNEL.TELEPHONY;
@@ -56,7 +60,8 @@ export const extractIncomingTaskData = (
     const declineText = !incomingTask.data.wrapUpRequired && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // For outdial calls, show the dialed number (dn) instead of the entrypoint number (ani)
+    const title = isSocial ? customerName : isOutdial ? dn || ani : ani;
 
     // Compute disable state for accept button when auto-answering
     const isAutoAnswering = incomingTask.data.isAutoAnswering || false;

--- a/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
@@ -17,6 +17,7 @@ export const extractTaskListItemData = (
     //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
     const callAssociationDetails = task?.data?.interaction?.callAssociatedDetails;
     const ani = callAssociationDetails?.ani;
+    const dn = callAssociationDetails?.dn;
     const customerName = callAssociationDetails?.customerName;
     const virtualTeamName = callAssociationDetails?.virtualTeamName;
 
@@ -29,6 +30,9 @@ export const extractTaskListItemData = (
     const mediaType = task.data.interaction.mediaType;
     const mediaChannel = task.data.interaction.mediaChannel;
 
+    // Check if this is an outdial call
+    const isOutdial = !!task?.data?.interaction?.outboundType;
+
     // Compute media type flags
     const isTelephony = mediaType === MEDIA_CHANNEL.TELEPHONY;
     const isSocial = mediaType === MEDIA_CHANNEL.SOCIAL;
@@ -39,7 +43,8 @@ export const extractTaskListItemData = (
     const declineText = isTaskIncoming && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // For outdial calls, show the dialed number (dn) instead of the entrypoint number (ani)
+    const title = isSocial ? customerName : isOutdial ? dn || ani : ani;
 
     const isAutoAnswering = task.data.isAutoAnswering || false;
 


### PR DESCRIPTION
# COMPLETES
https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7359

## This pull request addresses

When making an outdial call via dialpad, the IncomingTask, TaskList, and active task (CallControlCAD) were displaying the entrypoint/ANI number instead of the actual dialed destination number. This affected all three task display areas and occurred on every outdial call.

## by making the following changes

- **incoming-task.utils.tsx**: Check `interaction.outboundType` to detect outdial calls and use `dn` (dialed number) from `callAssociatedDetails` instead of `ani` (entrypoint) for the task title
- **task-list.utils.ts**: Same fix applied for the task list item title display
- **call-control-cad.tsx**: For outdial calls, swap `ani` and `dn` so the dialed number appears as the primary customer identifier and the entrypoint number appears as the secondary phone number

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Unit tests — all 632 cc-components tests passing
- [x] Verified outdial detection logic via `interaction.outboundType` field
- [x] Inbound calls continue to show `ani` as expected (no regression)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.