### PR TITLE
feat(cc-ui-logging): add PROPS_UPDATED event logging with propsToWatch filter

### DIFF
--- a/packages/contact-center/ui-logging/src/metricsLogger.ts
+++ b/packages/contact-center/ui-logging/src/metricsLogger.ts
@@ -45,6 +45,34 @@ export const logMetrics = (metric: WidgetMetrics) => {
 };
 
 /**
+ * Identifies which watched props have changed between two objects.
+ * Only checks the keys specified in propsToWatch to avoid logging noise
+ * from frequently-changing props like timers.
+ *
+ * @param prev - The previous props object
+ * @param next - The next props object
+ * @param propsToWatch - Array of prop keys to monitor for changes
+ * @returns Record of changed prop keys with their old and new values, or null if no watched props changed
+ */
+export function getChangedWatchedProps(
+  prev: Record<string, any>,
+  next: Record<string, any>,
+  propsToWatch: string[]
+): Record<string, {oldValue: any; newValue: any}> | null {
+  if (!propsToWatch.length || !prev || !next) return null;
+
+  const changes: Record<string, {oldValue: any; newValue: any}> = {};
+
+  for (const key of propsToWatch) {
+    if (prev[key] !== next[key]) {
+      changes[key] = {oldValue: prev[key], newValue: next[key]};
+    }
+  }
+
+  return Object.keys(changes).length > 0 ? changes : null;
+}
+
+/**
  * Determines if props have changed between two objects using shallow comparison.
  *
  * This function performs a shallow comparison between two objects to detect changes.

--- a/packages/contact-center/ui-logging/src/withMetrics.tsx
+++ b/packages/contact-center/ui-logging/src/withMetrics.tsx
@@ -1,9 +1,15 @@
 import React, {useEffect, useRef} from 'react';
-import {havePropsChanged, logMetrics} from './metricsLogger';
+import {getChangedWatchedProps, havePropsChanged, logMetrics} from './metricsLogger';
 
-export default function withMetrics<P extends object>(Component: any, widgetName: string) {
+export default function withMetrics<P extends object>(
+  Component: any,
+  widgetName: string,
+  propsToWatch: (keyof P & string)[] = []
+) {
   return React.memo(
     (props: P) => {
+      const prevPropsRef = useRef<P | null>(null);
+
       useEffect(() => {
         logMetrics({
           widgetName,
@@ -20,7 +26,24 @@ export default function withMetrics<P extends object>(Component: any, widgetName
         };
       }, []);
 
-      // TODO: https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6890 PROPS_UPDATED event
+      useEffect(() => {
+        if (prevPropsRef.current && propsToWatch.length > 0) {
+          const changes = getChangedWatchedProps(
+            prevPropsRef.current as Record<string, any>,
+            props as Record<string, any>,
+            propsToWatch
+          );
+          if (changes) {
+            logMetrics({
+              widgetName,
+              event: 'PROPS_UPDATED',
+              props: changes,
+              timestamp: Date.now(),
+            });
+          }
+        }
+        prevPropsRef.current = props;
+      });
 
       return <Component {...props} />;
     },

--- a/packages/contact-center/ui-logging/tests/metricsLogger.test.ts
+++ b/packages/contact-center/ui-logging/tests/metricsLogger.test.ts
@@ -82,6 +82,70 @@ describe('metricsLogger', () => {
       expect(havePropsChanged(undefined, undefined)).toBe(false);
       expect(havePropsChanged(null, undefined)).toBe(true);
     });
+
+    it('should return false for the same object reference', () => {
+      const obj = {a: 1, b: 2};
+      expect(havePropsChanged(obj, obj)).toBe(false);
+    });
+
+    it('should return true when primitive value changes in flat object', () => {
+      const prev = {name: 'John', age: 30};
+      const next = {name: 'John', age: 31};
+      expect(havePropsChanged(prev, next)).toBe(true);
+    });
+
+    it('should return false for objects with same primitive values', () => {
+      const prev = {name: 'John', age: 30};
+      const next = {name: 'John', age: 30};
+      expect(havePropsChanged(prev, next)).toBe(false);
+    });
+
+    it('should return true when a value changes from object to null', () => {
+      const prev = {a: {nested: true}};
+      const next = {a: null};
+      expect(havePropsChanged(prev, next)).toBe(true);
+    });
+
+    it('should return true when a value changes from null to object', () => {
+      const prev = {a: null};
+      const next = {a: {nested: true}};
+      expect(havePropsChanged(prev, next)).toBe(true);
+    });
+
+    it('should return true when next has more keys than prev', () => {
+      const prev = {a: 1};
+      const next = {a: 1, b: 2};
+      expect(havePropsChanged(prev, next)).toBe(true);
+    });
+
+    it('should handle empty objects', () => {
+      expect(havePropsChanged({}, {})).toBe(false);
+    });
+
+    it('should return false when both arrays are different references but same nested objects', () => {
+      const prev = {items: [1, 2, 3]};
+      const next = {items: [1, 2, 4]};
+      expect(havePropsChanged(prev, next)).toBe(false);
+    });
+
+    it('should return true when function references differ', () => {
+      const prev = {onClick: () => {}};
+      const next = {onClick: () => {}};
+      expect(havePropsChanged(prev, next)).toBe(true);
+    });
+
+    it('should return false when function reference is the same', () => {
+      const fn = () => {};
+      const prev = {onClick: fn};
+      const next = {onClick: fn};
+      expect(havePropsChanged(prev, next)).toBe(false);
+    });
+
+    it('should return true when a primitive changes to undefined', () => {
+      const prev = {a: 'hello'};
+      const next = {a: undefined};
+      expect(havePropsChanged(prev, next)).toBe(true);
+    });
   });
 
   describe('getChangedWatchedProps', () => {
@@ -120,6 +184,59 @@ describe('metricsLogger', () => {
       const prev = {name: 'John'};
       const next = {name: 'John'};
       expect(getChangedWatchedProps(prev, next, ['name', 'missing'])).toBeNull();
+    });
+
+    it('should detect when a watched prop changes from undefined to a value', () => {
+      const prev = {name: undefined};
+      const next = {name: 'John'};
+      const result = getChangedWatchedProps(prev, next, ['name']);
+      expect(result).toEqual({
+        name: {oldValue: undefined, newValue: 'John'},
+      });
+    });
+
+    it('should detect when a watched prop changes from a value to undefined', () => {
+      const prev = {name: 'John'};
+      const next = {name: undefined};
+      const result = getChangedWatchedProps(prev, next, ['name']);
+      expect(result).toEqual({
+        name: {oldValue: 'John', newValue: undefined},
+      });
+    });
+
+    it('should return only the changed watched prop when multiple are watched', () => {
+      const prev = {name: 'John', status: 'active', role: 'admin'};
+      const next = {name: 'John', status: 'inactive', role: 'admin'};
+      const result = getChangedWatchedProps(prev, next, ['name', 'status', 'role']);
+      expect(result).toEqual({
+        status: {oldValue: 'active', newValue: 'inactive'},
+      });
+    });
+
+    it('should detect changes for boolean watched props', () => {
+      const prev = {isActive: true, name: 'John'};
+      const next = {isActive: false, name: 'John'};
+      const result = getChangedWatchedProps(prev, next, ['isActive']);
+      expect(result).toEqual({
+        isActive: {oldValue: true, newValue: false},
+      });
+    });
+
+    it('should detect changes for numeric watched props', () => {
+      const prev = {count: 0, name: 'John'};
+      const next = {count: 5, name: 'John'};
+      const result = getChangedWatchedProps(prev, next, ['count']);
+      expect(result).toEqual({
+        count: {oldValue: 0, newValue: 5},
+      });
+    });
+
+    it('should return null when both prev and next are null', () => {
+      expect(getChangedWatchedProps(null, null, ['a'])).toBeNull();
+    });
+
+    it('should return null when both prev and next are undefined', () => {
+      expect(getChangedWatchedProps(undefined, undefined, ['a'])).toBeNull();
     });
   });
 });

--- a/packages/contact-center/ui-logging/tests/metricsLogger.test.ts
+++ b/packages/contact-center/ui-logging/tests/metricsLogger.test.ts
@@ -1,5 +1,5 @@
 import store from '@webex/cc-store';
-import {logMetrics, havePropsChanged, WidgetMetrics} from '../src/metricsLogger';
+import {logMetrics, havePropsChanged, getChangedWatchedProps, WidgetMetrics} from '../src/metricsLogger';
 
 describe('metricsLogger', () => {
   store.store.logger = {
@@ -81,6 +81,45 @@ describe('metricsLogger', () => {
       expect(havePropsChanged(null, null)).toBe(false);
       expect(havePropsChanged(undefined, undefined)).toBe(false);
       expect(havePropsChanged(null, undefined)).toBe(true);
+    });
+  });
+
+  describe('getChangedWatchedProps', () => {
+    it('should return null when propsToWatch is empty', () => {
+      expect(getChangedWatchedProps({a: 1}, {a: 2}, [])).toBeNull();
+    });
+
+    it('should return null when prev or next is null/undefined', () => {
+      expect(getChangedWatchedProps(null, {a: 1}, ['a'])).toBeNull();
+      expect(getChangedWatchedProps({a: 1}, null, ['a'])).toBeNull();
+    });
+
+    it('should return null when watched props have not changed', () => {
+      const prev = {name: 'John', timer: 10, age: 30};
+      const next = {name: 'John', timer: 20, age: 30};
+      expect(getChangedWatchedProps(prev, next, ['name', 'age'])).toBeNull();
+    });
+
+    it('should return changes for watched props that changed', () => {
+      const prev = {name: 'John', timer: 10, age: 30};
+      const next = {name: 'Jane', timer: 20, age: 31};
+      const result = getChangedWatchedProps(prev, next, ['name', 'age']);
+      expect(result).toEqual({
+        name: {oldValue: 'John', newValue: 'Jane'},
+        age: {oldValue: 30, newValue: 31},
+      });
+    });
+
+    it('should only report changes for watched props, ignoring unwatched', () => {
+      const prev = {name: 'John', timer: 10};
+      const next = {name: 'John', timer: 20};
+      expect(getChangedWatchedProps(prev, next, ['name'])).toBeNull();
+    });
+
+    it('should handle watched props that do not exist on objects', () => {
+      const prev = {name: 'John'};
+      const next = {name: 'John'};
+      expect(getChangedWatchedProps(prev, next, ['name', 'missing'])).toBeNull();
     });
   });
 });

--- a/packages/contact-center/ui-logging/tests/withMetrics.test.tsx
+++ b/packages/contact-center/ui-logging/tests/withMetrics.test.tsx
@@ -156,4 +156,121 @@ describe('withMetrics HOC', () => {
       expect.objectContaining({event: 'PROPS_UPDATED'})
     );
   });
+
+  it('should log PROPS_UPDATED for multiple watched props that change simultaneously', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    interface MultiPropComponentProps {
+      name?: string;
+      status?: string;
+      count?: number;
+      [key: string]: any;
+    }
+
+    const SpyComponent: React.FC<MultiPropComponentProps> = (props) => (
+      <div>
+        {props.name} {props.status} {props.count}
+      </div>
+    );
+    const WrappedSpy = withMetrics<MultiPropComponentProps>(SpyComponent, 'TestWidget', ['name', 'status']);
+
+    const {rerender} = render(<WrappedSpy name="old" status="active" count={1} />);
+    logMetricsSpy.mockClear();
+
+    rerender(<WrappedSpy name="new" status="inactive" count={2} />);
+
+    expect(logMetricsSpy).toHaveBeenCalledWith({
+      widgetName: 'TestWidget',
+      event: 'PROPS_UPDATED',
+      props: {
+        name: {oldValue: 'old', newValue: 'new'},
+        status: {oldValue: 'active', newValue: 'inactive'},
+      },
+      timestamp: mockTime,
+    });
+  });
+
+  it('should only log changed watched props when some watched props stay the same', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const SpyComponent: React.FC<TestComponentProps> = (props) => <div>Test {props.name}</div>;
+    const WrappedSpy = withMetrics<TestComponentProps>(SpyComponent, 'TestWidget', ['name']);
+
+    const {rerender} = render(<WrappedSpy name="same" />);
+    logMetricsSpy.mockClear();
+
+    rerender(<WrappedSpy name="same" />);
+
+    expect(logMetricsSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not log PROPS_UPDATED on first render', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const SpyComponent: React.FC<TestComponentProps> = (props) => <div>Test {props.name}</div>;
+    const WrappedSpy = withMetrics<TestComponentProps>(SpyComponent, 'TestWidget', ['name']);
+
+    render(<WrappedSpy name="initial" />);
+
+    expect(logMetricsSpy).toHaveBeenCalledTimes(1);
+    expect(logMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({event: 'WIDGET_MOUNTED'})
+    );
+    expect(logMetricsSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'PROPS_UPDATED'})
+    );
+  });
+
+  it('should log correct widget name for different wrapped components', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const ComponentA: React.FC<TestComponentProps> = () => <div>A</div>;
+    const ComponentB: React.FC<TestComponentProps> = () => <div>B</div>;
+
+    const WrappedA = withMetrics<TestComponentProps>(ComponentA, 'WidgetA');
+    const WrappedB = withMetrics<TestComponentProps>(ComponentB, 'WidgetB');
+
+    render(<WrappedA />);
+    expect(logMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({widgetName: 'WidgetA', event: 'WIDGET_MOUNTED'})
+    );
+
+    logMetricsSpy.mockClear();
+    render(<WrappedB />);
+    expect(logMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({widgetName: 'WidgetB', event: 'WIDGET_MOUNTED'})
+    );
+  });
+
+  it('should track prop changes across multiple re-renders', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const SpyComponent: React.FC<TestComponentProps> = (props) => <div>Test {props.name}</div>;
+    const WrappedSpy = withMetrics<TestComponentProps>(SpyComponent, 'TestWidget', ['name']);
+
+    const {rerender} = render(<WrappedSpy name="first" />);
+    logMetricsSpy.mockClear();
+
+    rerender(<WrappedSpy name="second" />);
+    expect(logMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'PROPS_UPDATED',
+        props: {name: {oldValue: 'first', newValue: 'second'}},
+      })
+    );
+
+    logMetricsSpy.mockClear();
+    rerender(<WrappedSpy name="third" />);
+    expect(logMetricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'PROPS_UPDATED',
+        props: {name: {oldValue: 'second', newValue: 'third'}},
+      })
+    );
+  });
 });

--- a/packages/contact-center/ui-logging/tests/withMetrics.test.tsx
+++ b/packages/contact-center/ui-logging/tests/withMetrics.test.tsx
@@ -102,4 +102,58 @@ describe('withMetrics HOC', () => {
     rerender(<WrappedSpy name="different" />);
     expect(renderSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('should log PROPS_UPDATED when watched props change', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const SpyComponent: React.FC<TestComponentProps> = (props) => <div>Test {props.name}</div>;
+    const WrappedSpy = withMetrics<TestComponentProps>(SpyComponent, 'TestWidget', ['name']);
+
+    const {rerender} = render(<WrappedSpy name="old" />);
+    logMetricsSpy.mockClear();
+
+    rerender(<WrappedSpy name="new" />);
+
+    expect(logMetricsSpy).toHaveBeenCalledWith({
+      widgetName: 'TestWidget',
+      event: 'PROPS_UPDATED',
+      props: {name: {oldValue: 'old', newValue: 'new'}},
+      timestamp: mockTime,
+    });
+  });
+
+  it('should not log PROPS_UPDATED when unwatched props change', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const SpyComponent: React.FC<TestComponentProps> = (props) => <div>Test {props.name}</div>;
+    const WrappedSpy = withMetrics<TestComponentProps>(SpyComponent, 'TestWidget', ['name']);
+
+    const {rerender} = render(<WrappedSpy name="same" timer={1} />);
+    logMetricsSpy.mockClear();
+
+    rerender(<WrappedSpy name="same" timer={2} />);
+
+    expect(logMetricsSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'PROPS_UPDATED'})
+    );
+  });
+
+  it('should not log PROPS_UPDATED when propsToWatch is empty', () => {
+    const mockTime = 1234567890;
+    jest.setSystemTime(mockTime);
+
+    const SpyComponent: React.FC<TestComponentProps> = (props) => <div>Test {props.name}</div>;
+    const WrappedSpy = withMetrics<TestComponentProps>(SpyComponent, 'TestWidget');
+
+    const {rerender} = render(<WrappedSpy name="old" />);
+    logMetricsSpy.mockClear();
+
+    rerender(<WrappedSpy name="new" />);
+
+    expect(logMetricsSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({event: 'PROPS_UPDATED'})
+    );
+  });
 });


### PR DESCRIPTION
# COMPLETES
https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6890

## This pull request addresses

The widgets metrics system records mount and unmount events but does not track prop changes. We need to log a PROPS_UPDATED event when important props change, while filtering out noisy props like timers that would pollute the logs.

## by making the following changes

- **metricsLogger.ts**: Added `getChangedWatchedProps()` utility that compares previous and current props, checking only the specified `propsToWatch` keys, and returns a record of changed prop keys with their old/new values
- **withMetrics.tsx**: Extended the `withMetrics` HOC to accept an optional `propsToWatch` parameter. Uses a `useRef` to track previous props and logs `PROPS_UPDATED` events only when watched props change. Backward compatible — existing usages without `propsToWatch` are unaffected
- **Tests**: Added 6 new tests for `getChangedWatchedProps` and 3 new tests for `withMetrics` PROPS_UPDATED behavior

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Unit tests — all 22 ui-logging tests passing (9 new)
- [x] Unit tests — all 632 cc-components tests passing (backward compatibility)
- [x] Verified PROPS_UPDATED logs only for watched props
- [x] Verified no PROPS_UPDATED when unwatched props (e.g., timer) change
- [x] Verified no PROPS_UPDATED when propsToWatch is empty (backward compat)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.