### PR TITLE
fix(cc-components): show dialed number instead of entrypoint for outdial calls

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -79,7 +79,11 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   const phoneNumberTooltipId = `phone-number-tooltip-${currentTask.data.interaction.interactionId}`;
 
   const renderCustomerName = () => {
-    const customerText = isSocial ? customerName || NO_CUSTOMER_NAME : isOutdial ? (dn || ani || NO_CALLER_ID) : (ani || NO_CALLER_ID);
+    const customerText = isSocial
+      ? customerName || NO_CUSTOMER_NAME
+      : isOutdial
+        ? dn || ani || NO_CALLER_ID
+        : ani || NO_CALLER_ID;
 
     const textComponent = (
       <Text

--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -123,7 +123,7 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
       ? customerName || NO_CUSTOMER_NAME
       : isTelephony
         ? ani || NO_PHONE_NUMBER
-        : NO_PHONE_NUMBER;
+        : ani || NO_PHONE_NUMBER;
     const labelText = isSocial ? CUSTOMER_NAME : PHONE_NUMBER;
 
     const textComponent = (

--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -78,12 +78,13 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   const phoneNumberTriggerId = `phone-number-trigger-${currentTask.data.interaction.interactionId}`;
   const phoneNumberTooltipId = `phone-number-tooltip-${currentTask.data.interaction.interactionId}`;
 
+  // For telephony calls, ani is the phone number and dn is the entry point/DNIS.
+  // Inbound: ani = caller's number, dn = entry point dialed by caller
+  // Outdial: ani = customer's number dialed by agent, dn = agent's entry point
+  const callerNumber = isOutdial ? dn || ani : ani;
+
   const renderCustomerName = () => {
-    const customerText = isSocial
-      ? customerName || NO_CUSTOMER_NAME
-      : isOutdial
-        ? dn || ani || NO_CALLER_ID
-        : ani || NO_CALLER_ID;
+    const customerText = isSocial ? customerName || NO_CUSTOMER_NAME : callerNumber || NO_CALLER_ID;
 
     const textComponent = (
       <Text
@@ -120,7 +121,7 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   };
 
   const renderPhoneNumber = () => {
-    const phoneText = isSocial ? customerName || NO_CUSTOMER_NAME : dn || NO_PHONE_NUMBER;
+    const phoneText = isSocial ? customerName || NO_CUSTOMER_NAME : ani || NO_PHONE_NUMBER;
     const labelText = isSocial ? CUSTOMER_NAME : PHONE_NUMBER;
 
     const textComponent = (

--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -5,7 +5,7 @@ import {Brandvisual, Icon, Tooltip, Button} from '@momentum-design/components/di
 import './call-control-cad.styles.scss';
 import TaskTimer from '../TaskTimer/index';
 import CallControlConsultComponent from '../CallControl/CallControlCustom/call-control-consult';
-import {MEDIA_CHANNEL as MediaChannelType, CallControlComponentProps} from '../task.types';
+import {MEDIA_CHANNEL as MediaChannelType, CallControlComponentProps, getCallerIdentifier} from '../task.types';
 
 import {getMediaTypeInfo} from '../../../utils';
 import {
@@ -69,19 +69,17 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
   const dn = currentTask?.data?.interaction?.callAssociatedDetails?.dn;
 
-  // Check if this is an outdial call - for outdial, show dialed number instead of entrypoint
-  const isOutdial = currentTask?.data?.interaction?.outboundType === 'OUTDIAL';
-
   // Create unique IDs for tooltips
   const customerNameTriggerId = `customer-name-trigger-${currentTask.data.interaction.interactionId}`;
   const customerNameTooltipId = `customer-name-tooltip-${currentTask.data.interaction.interactionId}`;
   const phoneNumberTriggerId = `phone-number-trigger-${currentTask.data.interaction.interactionId}`;
   const phoneNumberTooltipId = `phone-number-tooltip-${currentTask.data.interaction.interactionId}`;
 
-  // For telephony calls, ani is the phone number and dn is the entry point/DNIS.
+  // For telephony calls, ani is the originating number and dn is the destination.
   // Inbound: ani = caller's number, dn = entry point dialed by caller
-  // Outdial: ani = customer's number dialed by agent, dn = agent's entry point
-  const callerNumber = isOutdial ? dn || ani : ani;
+  // Outdial: ani = agent's originating number (entry point), dn = customer's dialed number
+  const outboundType = currentTask?.data?.interaction?.outboundType;
+  const callerNumber = getCallerIdentifier(ani, dn, outboundType);
 
   const renderCustomerName = () => {
     const customerText = isSocial ? customerName || NO_CUSTOMER_NAME : callerNumber || NO_CALLER_ID;
@@ -121,7 +119,11 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   };
 
   const renderPhoneNumber = () => {
-    const phoneText = isSocial ? customerName || NO_CUSTOMER_NAME : ani || NO_PHONE_NUMBER;
+    const phoneText = isSocial
+      ? customerName || NO_CUSTOMER_NAME
+      : isTelephony
+        ? ani || NO_PHONE_NUMBER
+        : NO_PHONE_NUMBER;
     const labelText = isSocial ? CUSTOMER_NAME : PHONE_NUMBER;
 
     const textComponent = (

--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -69,6 +69,9 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
   const dn = currentTask?.data?.interaction?.callAssociatedDetails?.dn;
 
+  // Check if this is an outdial call - for outdial, show dialed number instead of entrypoint
+  const isOutdial = currentTask?.data?.interaction?.outboundType === 'OUTDIAL';
+
   // Create unique IDs for tooltips
   const customerNameTriggerId = `customer-name-trigger-${currentTask.data.interaction.interactionId}`;
   const customerNameTooltipId = `customer-name-tooltip-${currentTask.data.interaction.interactionId}`;
@@ -76,7 +79,7 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   const phoneNumberTooltipId = `phone-number-tooltip-${currentTask.data.interaction.interactionId}`;
 
   const renderCustomerName = () => {
-    const customerText = isSocial ? customerName || NO_CUSTOMER_NAME : ani || NO_CALLER_ID;
+    const customerText = isSocial ? customerName || NO_CUSTOMER_NAME : isOutdial ? (dn || ani || NO_CALLER_ID) : (ani || NO_CALLER_ID);
 
     const textComponent = (
       <Text

--- a/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
@@ -35,6 +35,7 @@ export const extractIncomingTaskData = (
     //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
     const callAssociationDetails = incomingTask?.data?.interaction?.callAssociatedDetails;
     const ani = callAssociationDetails?.ani;
+    const dn = callAssociationDetails?.dn;
     const customerName = callAssociationDetails?.customerName;
     const virtualTeamName = callAssociationDetails?.virtualTeamName;
     const ronaTimeout = callAssociationDetails?.ronaTimeout ? Number(callAssociationDetails?.ronaTimeout) : null;
@@ -46,6 +47,9 @@ export const extractIncomingTaskData = (
     const isTelephony = mediaType === MEDIA_CHANNEL.TELEPHONY;
     const isSocial = mediaType === MEDIA_CHANNEL.SOCIAL;
 
+    // Check if this is an outdial call
+    const isOutdial = incomingTask?.data?.interaction?.outboundType === 'OUTDIAL';
+
     // Compute button text based on conditions
     const acceptText = !incomingTask.data.wrapUpRequired
       ? isTelephony && !isBrowser
@@ -56,7 +60,8 @@ export const extractIncomingTaskData = (
     const declineText = !incomingTask.data.wrapUpRequired && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // For outdial calls, show the dialed number (dn) instead of the entrypoint (ani)
+    const title = isSocial ? customerName : isOutdial ? (dn || ani) : ani;
 
     // Compute disable state for accept button when auto-answering
     const isAutoAnswering = incomingTask.data.isAutoAnswering || false;

--- a/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
@@ -61,7 +61,7 @@ export const extractIncomingTaskData = (
 
     // Compute title based on media type
     // For outdial calls, show the dialed number (dn) instead of the entrypoint (ani)
-    const title = isSocial ? customerName : isOutdial ? (dn || ani) : ani;
+    const title = isSocial ? customerName : isOutdial ? dn || ani : ani;
 
     // Compute disable state for accept button when auto-answering
     const isAutoAnswering = incomingTask.data.isAutoAnswering || false;

--- a/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/src/components/task/IncomingTask/incoming-task.utils.tsx
@@ -1,4 +1,4 @@
-import {MEDIA_CHANNEL} from '../task.types';
+import {MEDIA_CHANNEL, getCallerIdentifier} from '../task.types';
 import {ITask} from '@webex/cc-store';
 
 export interface IncomingTaskData {
@@ -47,9 +47,6 @@ export const extractIncomingTaskData = (
     const isTelephony = mediaType === MEDIA_CHANNEL.TELEPHONY;
     const isSocial = mediaType === MEDIA_CHANNEL.SOCIAL;
 
-    // Check if this is an outdial call
-    const isOutdial = incomingTask?.data?.interaction?.outboundType === 'OUTDIAL';
-
     // Compute button text based on conditions
     const acceptText = !incomingTask.data.wrapUpRequired
       ? isTelephony && !isBrowser
@@ -60,8 +57,8 @@ export const extractIncomingTaskData = (
     const declineText = !incomingTask.data.wrapUpRequired && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    // For outdial calls, show the dialed number (dn) instead of the entrypoint (ani)
-    const title = isSocial ? customerName : isOutdial ? dn || ani : ani;
+    const outboundType = incomingTask?.data?.interaction?.outboundType;
+    const title = isSocial ? customerName : getCallerIdentifier(ani, dn, outboundType);
 
     // Compute disable state for accept button when auto-answering
     const isAutoAnswering = incomingTask.data.isAutoAnswering || false;

--- a/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
@@ -44,7 +44,7 @@ export const extractTaskListItemData = (
 
     // Compute title based on media type
     // For outdial calls, show the dialed number (dn) instead of the entrypoint (ani)
-    const title = isSocial ? customerName : isOutdial ? (dn || ani) : ani;
+    const title = isSocial ? customerName : isOutdial ? dn || ani : ani;
 
     const isAutoAnswering = task.data.isAutoAnswering || false;
 

--- a/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
@@ -1,4 +1,4 @@
-import {MEDIA_CHANNEL, TaskListItemData} from '../task.types';
+import {MEDIA_CHANNEL, TaskListItemData, getCallerIdentifier} from '../task.types';
 import store, {isIncomingTask, ILogger, ITask} from '@webex/cc-store';
 /**
  * Extracts and processes data from a task for rendering in the task list
@@ -34,17 +34,14 @@ export const extractTaskListItemData = (
     const isTelephony = mediaType === MEDIA_CHANNEL.TELEPHONY;
     const isSocial = mediaType === MEDIA_CHANNEL.SOCIAL;
 
-    // Check if this is an outdial call
-    const isOutdial = task?.data?.interaction?.outboundType === 'OUTDIAL';
-
     // Compute button text based on conditions
     const acceptText = isTaskIncoming ? (isTelephony && !isBrowser ? 'Ringing...' : 'Accept') : undefined;
 
     const declineText = isTaskIncoming && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    // For outdial calls, show the dialed number (dn) instead of the entrypoint (ani)
-    const title = isSocial ? customerName : isOutdial ? dn || ani : ani;
+    const outboundType = task?.data?.interaction?.outboundType;
+    const title = isSocial ? customerName : getCallerIdentifier(ani, dn, outboundType);
 
     const isAutoAnswering = task.data.isAutoAnswering || false;
 

--- a/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
+++ b/packages/contact-center/cc-components/src/components/task/TaskList/task-list.utils.ts
@@ -17,6 +17,7 @@ export const extractTaskListItemData = (
     //@ts-expect-error  To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
     const callAssociationDetails = task?.data?.interaction?.callAssociatedDetails;
     const ani = callAssociationDetails?.ani;
+    const dn = callAssociationDetails?.dn;
     const customerName = callAssociationDetails?.customerName;
     const virtualTeamName = callAssociationDetails?.virtualTeamName;
 
@@ -33,13 +34,17 @@ export const extractTaskListItemData = (
     const isTelephony = mediaType === MEDIA_CHANNEL.TELEPHONY;
     const isSocial = mediaType === MEDIA_CHANNEL.SOCIAL;
 
+    // Check if this is an outdial call
+    const isOutdial = task?.data?.interaction?.outboundType === 'OUTDIAL';
+
     // Compute button text based on conditions
     const acceptText = isTaskIncoming ? (isTelephony && !isBrowser ? 'Ringing...' : 'Accept') : undefined;
 
     const declineText = isTaskIncoming && isTelephony && isBrowser ? 'Decline' : undefined;
 
     // Compute title based on media type
-    const title = isSocial ? customerName : ani;
+    // For outdial calls, show the dialed number (dn) instead of the entrypoint (ani)
+    const title = isSocial ? customerName : isOutdial ? (dn || ani) : ani;
 
     const isAutoAnswering = task.data.isAutoAnswering || false;
 

--- a/packages/contact-center/cc-components/src/components/task/task.types.ts
+++ b/packages/contact-center/cc-components/src/components/task/task.types.ts
@@ -771,6 +771,19 @@ export interface TaskListItemData {
   displayState: string;
 }
 
+export enum OUTBOUND_TYPE {
+  OUTDIAL = 'OUTDIAL',
+  CALLBACK = 'CALLBACK',
+}
+
+/**
+ * Returns the appropriate caller identifier based on outbound type.
+ * For outdial calls, the customer's number is in `dn`; for all others it's in `ani`.
+ */
+export const getCallerIdentifier = (ani: string, dn: string, outboundType?: string): string => {
+  return outboundType === OUTBOUND_TYPE.OUTDIAL ? dn || ani : ani;
+};
+
 export enum TaskState {
   NEW = 'new',
   ACTIVE = 'active',

--- a/packages/contact-center/cc-components/tests/components/task/CallControlCAD/__snapshots__/call-control-cad.snapshot.tsx.snap
+++ b/packages/contact-center/cc-components/tests/components/task/CallControlCAD/__snapshots__/call-control-cad.snapshot.tsx.snap
@@ -198,7 +198,7 @@ exports[`CallControlCADComponent Snapshots should handle edge cases and control 
         </strong>
          
         <span>
-          No Phone Number
+          555-123-4567
         </span>
       </mdc-text>
     </div>
@@ -376,7 +376,7 @@ exports[`CallControlCADComponent Snapshots should handle edge cases and control 
       </strong>
        
       <span>
-        No Phone Number
+        555-123-4567
       </span>
     </mdc-text>
   </div>
@@ -908,7 +908,7 @@ exports[`CallControlCADComponent Snapshots should render basic call states and m
       </strong>
        
       <span>
-        No Phone Number
+        chat-customer@example.com
       </span>
     </mdc-text>
     <mdc-tooltip
@@ -918,7 +918,7 @@ exports[`CallControlCADComponent Snapshots should render basic call states and m
       <mdc-text
         class="md-text-wrapper"
       >
-        No Phone Number
+        chat-customer@example.com
       </mdc-text>
     </mdc-tooltip>
   </div>
@@ -1178,7 +1178,7 @@ exports[`CallControlCADComponent Snapshots should render basic call states and m
       </strong>
        
       <span>
-        No Phone Number
+        555-123-4567
       </span>
     </mdc-text>
   </div>
@@ -1438,7 +1438,7 @@ exports[`CallControlCADComponent Snapshots should render basic call states and m
       </strong>
        
       <span>
-        No Phone Number
+        555-123-4567
       </span>
     </mdc-text>
   </div>
@@ -1925,7 +1925,7 @@ exports[`CallControlCADComponent Snapshots should render consultation and wrapup
         </strong>
          
         <span>
-          No Phone Number
+          555-123-4567
         </span>
       </mdc-text>
     </div>
@@ -2219,7 +2219,7 @@ exports[`CallControlCADComponent Snapshots should render consultation and wrapup
       </strong>
        
       <span>
-        No Phone Number
+        555-123-4567
       </span>
     </mdc-text>
   </div>
@@ -2480,7 +2480,7 @@ exports[`CallControlCADComponent Snapshots should render consultation and wrapup
         </strong>
          
         <span>
-          No Phone Number
+          555-123-4567
         </span>
       </mdc-text>
     </div>
@@ -2741,7 +2741,7 @@ exports[`CallControlCADComponent Snapshots should render consultation and wrapup
       </strong>
        
       <span>
-        No Phone Number
+        555-123-4567
       </span>
     </mdc-text>
   </div>

--- a/packages/contact-center/cc-components/tests/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/CallControlCAD/call-control-cad.tsx
@@ -55,6 +55,7 @@ describe('CallControlCADComponent', () => {
         callAssociatedDetails: {
           customerName: 'John Doe',
           ani: '555-123-4567',
+          dn: '555-999-0000',
           virtualTeamName: 'Support Team',
           ronaTimeout: '30',
         },
@@ -263,6 +264,40 @@ describe('CallControlCADComponent', () => {
     const chatConsultContainer = chatConsultScreen.container.querySelector('.call-control-consult-container');
     expect(chatConsultContainer).not.toBeInTheDocument();
     chatConsultScreen.unmount();
+  });
+
+  it('should display correct phone number for inbound vs outdial calls', () => {
+    // Inbound call: caller ID = ani, phone number = ani
+    const inboundScreen = render(<CallControlCADComponent {...defaultProps} />);
+    // ani (555-123-4567) should appear as both caller ID and phone number
+    const aniElements = inboundScreen.getAllByText('555-123-4567');
+    expect(aniElements.length).toBe(2); // caller ID + phone number
+    // dn (555-999-0000) should NOT appear anywhere
+    expect(inboundScreen.queryByText('555-999-0000')).not.toBeInTheDocument();
+    inboundScreen.unmount();
+
+    // Outdial call: caller ID = dn, phone number = ani
+    const outdialProps = {
+      ...defaultProps,
+      currentTask: {
+        ...defaultProps.currentTask,
+        data: {
+          ...defaultProps.currentTask.data,
+          interaction: {
+            ...defaultProps.currentTask.data.interaction,
+            outboundType: 'OUTDIAL',
+          },
+        },
+      },
+    };
+    const outdialScreen = render(<CallControlCADComponent {...outdialProps} />);
+    // Caller ID should show dn (555-999-0000)
+    expect(outdialScreen.getByText('555-999-0000')).toBeInTheDocument();
+    // Phone number should show ani (555-123-4567)
+    const phoneLabel = outdialScreen.getByText('Phone Number:');
+    const phoneValue = phoneLabel.nextElementSibling;
+    expect(phoneValue?.textContent).toBe('555-123-4567');
+    outdialScreen.unmount();
   });
 
   it('should handle wrapup mode and edge cases', () => {

--- a/packages/contact-center/cc-components/tests/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/CallControlCAD/call-control-cad.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {render} from '@testing-library/react';
 import CallControlCADComponent from '../../../../src/components/task/CallControlCAD/call-control-cad';
-import {CallControlComponentProps, TARGET_TYPE} from '../../../../src/components/task/task.types';
+import {CallControlComponentProps, TARGET_TYPE, OUTBOUND_TYPE} from '../../../../src/components/task/task.types';
 import {mockTask} from '@webex/test-fixtures';
 import {BuddyDetails} from '@webex/cc-store';
 import '@testing-library/jest-dom';
@@ -285,7 +285,7 @@ describe('CallControlCADComponent', () => {
           ...defaultProps.currentTask.data,
           interaction: {
             ...defaultProps.currentTask.data.interaction,
-            outboundType: 'OUTDIAL',
+            outboundType: OUTBOUND_TYPE.OUTDIAL,
           },
         },
       },

--- a/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
@@ -105,6 +105,76 @@ describe('incoming-task.utils', () => {
       });
     });
 
+    describe('Outdial tasks', () => {
+      it('should use dn (dialed number) as title for outdial telephony tasks', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+          ronaTimeout: '30',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+14155559876'); // Should show dn, not ani
+        expect(result.ani).toBe('+18005551234');
+        expect(result.isTelephony).toBe(true);
+
+        // Restore
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should fall back to ani when dn is not available for outdial tasks', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+18005551234'); // Falls back to ani
+
+        // Restore
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should use ani as title for non-outdial telephony tasks', () => {
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Inbound Customer',
+          virtualTeamName: 'Support Team',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+18005551234'); // Should show ani for inbound
+
+        // Restore
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+      });
+    });
+
     describe('Edge cases', () => {
       it('should handle missing call association details', () => {
         const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;

--- a/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
@@ -173,6 +173,109 @@ describe('incoming-task.utils', () => {
         // Restore
         mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
       });
+
+      it('should fall back to ani when dn is empty string for outdial tasks', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+18005551234'); // Empty dn falls back to ani
+
+        // Restore
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should use ani for CALLBACK outboundType (not OUTDIAL)', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'CALLBACK';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Callback Customer',
+          virtualTeamName: 'Callback Team',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+18005551234'); // CALLBACK uses ani, not dn
+
+        // Restore
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should still use customerName for social media outdial tasks', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.SOCIAL;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: 'social-ani',
+          dn: 'social-dn',
+          customerName: 'Social Outdial Customer',
+          virtualTeamName: 'Social Team',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('Social Outdial Customer'); // Social always uses customerName
+
+        // Restore
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should extract correct button states for outdial telephony on non-browser', () => {
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+        const originalWrapUpRequired = mockTask.data.wrapUpRequired;
+
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.wrapUpRequired = false;
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+          ronaTimeout: '30',
+        };
+
+        const result = extractIncomingTaskData(mockTask, false);
+
+        expect(result.title).toBe('+14155559876');
+        expect(result.acceptText).toBe('Ringing...');
+        expect(result.declineText).toBeUndefined();
+        expect(result.disableAccept).toBe(true);
+
+        // Restore
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+        mockTask.data.wrapUpRequired = originalWrapUpRequired;
+      });
     });
 
     describe('Edge cases', () => {

--- a/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/IncomingTask/incoming-task.utils.tsx
@@ -1,5 +1,5 @@
 import {extractIncomingTaskData} from '../../../../src/components/task/IncomingTask/incoming-task.utils';
-import {MEDIA_CHANNEL} from '../../../../src/components/task/task.types';
+import {MEDIA_CHANNEL, OUTBOUND_TYPE} from '../../../../src/components/task/task.types';
 import {mockTask} from '@webex/test-fixtures';
 
 describe('incoming-task.utils', () => {
@@ -112,7 +112,7 @@ describe('incoming-task.utils', () => {
         const originalOutboundType = mockTask.data.interaction.outboundType;
 
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           dn: '+14155559876',
@@ -139,7 +139,7 @@ describe('incoming-task.utils', () => {
         const originalOutboundType = mockTask.data.interaction.outboundType;
 
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           customerName: 'Outdial Customer',
@@ -180,7 +180,7 @@ describe('incoming-task.utils', () => {
         const originalOutboundType = mockTask.data.interaction.outboundType;
 
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           dn: '',
@@ -204,7 +204,7 @@ describe('incoming-task.utils', () => {
         const originalOutboundType = mockTask.data.interaction.outboundType;
 
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'CALLBACK';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.CALLBACK;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           dn: '+14155559876',
@@ -228,7 +228,7 @@ describe('incoming-task.utils', () => {
         const originalOutboundType = mockTask.data.interaction.outboundType;
 
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.SOCIAL;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: 'social-ani',
           dn: 'social-dn',
@@ -253,7 +253,7 @@ describe('incoming-task.utils', () => {
         const originalWrapUpRequired = mockTask.data.wrapUpRequired;
 
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.wrapUpRequired = false;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
@@ -275,6 +275,29 @@ describe('incoming-task.utils', () => {
         mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
         mockTask.data.interaction.outboundType = originalOutboundType;
         mockTask.data.wrapUpRequired = originalWrapUpRequired;
+      });
+    });
+
+    describe('Standard inbound tasks', () => {
+      it('should use ani for title when outboundType is undefined (standard inbound)', () => {
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.outboundType = undefined;
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Inbound Customer',
+          virtualTeamName: 'Support Team',
+        };
+
+        const result = extractIncomingTaskData(mockTask, true);
+
+        expect(result.title).toBe('+18005551234'); // Standard inbound uses ani
+
+        // Restore
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.outboundType = originalOutboundType;
       });
     });
 

--- a/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
@@ -323,6 +323,124 @@ describe('task-list.utils', () => {
         mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
         mockTask.data.interaction.mediaType = originalMediaType;
       });
+
+      it('should fall back to ani when dn is empty string for outdial tasks', () => {
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('+18005551234'); // Empty dn falls back to ani
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should use ani for CALLBACK outboundType (not OUTDIAL)', () => {
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'CALLBACK';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Callback Customer',
+          virtualTeamName: 'Callback Team',
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('+18005551234'); // CALLBACK uses ani, not dn
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should still use customerName for social media outdial tasks', () => {
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.SOCIAL;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: 'social-ani',
+          dn: 'social-dn',
+          customerName: 'Social Outdial Customer',
+          virtualTeamName: 'Social Team',
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('Social Outdial Customer'); // Social always uses customerName
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should extract correct button states for incoming outdial telephony on non-browser', () => {
+        // Mock isIncomingTask to return true for this test
+        (isIncomingTask as jest.Mock).mockReturnValueOnce(true);
+
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+        const originalWrapUpRequired = mockTask.data.wrapUpRequired;
+
+        mockTask.data.interaction.state = 'new';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.wrapUpRequired = false;
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+          ronaTimeout: '30',
+        };
+
+        const result = extractTaskListItemData(mockTask, false, mockTask.data.agentId);
+
+        expect(result.title).toBe('+14155559876');
+        expect(result.acceptText).toBe('Ringing...');
+        expect(result.declineText).toBeUndefined();
+        expect(result.disableAccept).toBe(true);
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+        mockTask.data.wrapUpRequired = originalWrapUpRequired;
+      });
     });
   });
 

--- a/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
@@ -243,6 +243,87 @@ describe('task-list.utils', () => {
         mockTask.data.interaction.mediaType = originalMediaType;
       });
     });
+
+    describe('Outdial tasks', () => {
+      it('should use dn (dialed number) as title for outdial telephony tasks', () => {
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('+14155559876'); // Should show dn, not ani
+        expect(result.ani).toBe('+18005551234');
+        expect(result.isTelephony).toBe(true);
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should fall back to ani when dn is not available for outdial tasks', () => {
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+        const originalOutboundType = mockTask.data.interaction.outboundType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          customerName: 'Outdial Customer',
+          virtualTeamName: 'Outbound Team',
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('+18005551234'); // Falls back to ani
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+        mockTask.data.interaction.outboundType = originalOutboundType;
+      });
+
+      it('should use ani as title for non-outdial telephony tasks even when dn is present', () => {
+        const originalState = mockTask.data.interaction.state;
+        const originalCallAssociatedDetails = mockTask.data.interaction.callAssociatedDetails;
+        const originalMediaType = mockTask.data.interaction.mediaType;
+
+        mockTask.data.interaction.state = 'connected';
+        mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
+        mockTask.data.interaction.callAssociatedDetails = {
+          ani: '+18005551234',
+          dn: '+14155559876',
+          customerName: 'Inbound Customer',
+          virtualTeamName: 'Support Team',
+        };
+
+        const result = extractTaskListItemData(mockTask, true, mockTask.data.agentId);
+
+        expect(result.title).toBe('+18005551234'); // Should show ani for inbound
+
+        // Restore
+        mockTask.data.interaction.state = originalState;
+        mockTask.data.interaction.callAssociatedDetails = originalCallAssociatedDetails;
+        mockTask.data.interaction.mediaType = originalMediaType;
+      });
+    });
   });
 
   describe('isTaskSelectable', () => {

--- a/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/TaskList/task-list.utils.tsx
@@ -6,7 +6,7 @@ import {
   getTasksArray,
   createTaskSelectHandler,
 } from '../../../../src/components/task/TaskList/task-list.utils';
-import {MEDIA_CHANNEL, TaskListItemData} from '../../../../src/components/task/task.types';
+import {MEDIA_CHANNEL, TaskListItemData, OUTBOUND_TYPE} from '../../../../src/components/task/task.types';
 import {mockTask} from '@webex/test-fixtures';
 
 // Mock the store with a mockable isIncomingTask function
@@ -253,7 +253,7 @@ describe('task-list.utils', () => {
 
         mockTask.data.interaction.state = 'connected';
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           dn: '+14155559876',
@@ -282,7 +282,7 @@ describe('task-list.utils', () => {
 
         mockTask.data.interaction.state = 'connected';
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           customerName: 'Outdial Customer',
@@ -332,7 +332,7 @@ describe('task-list.utils', () => {
 
         mockTask.data.interaction.state = 'connected';
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           dn: '',
@@ -359,7 +359,7 @@ describe('task-list.utils', () => {
 
         mockTask.data.interaction.state = 'connected';
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'CALLBACK';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.CALLBACK;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',
           dn: '+14155559876',
@@ -386,7 +386,7 @@ describe('task-list.utils', () => {
 
         mockTask.data.interaction.state = 'connected';
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.SOCIAL;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: 'social-ani',
           dn: 'social-dn',
@@ -417,7 +417,7 @@ describe('task-list.utils', () => {
 
         mockTask.data.interaction.state = 'new';
         mockTask.data.interaction.mediaType = MEDIA_CHANNEL.TELEPHONY;
-        mockTask.data.interaction.outboundType = 'OUTDIAL';
+        mockTask.data.interaction.outboundType = OUTBOUND_TYPE.OUTDIAL;
         mockTask.data.wrapUpRequired = false;
         mockTask.data.interaction.callAssociatedDetails = {
           ani: '+18005551234',


### PR DESCRIPTION
# COMPLETES [CAI-7359](https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7359)

## This pull request addresses

Two related display issues in the CallControlCAD, IncomingTask, and TaskList widgets:

1. **Caller ID (title):** Outdial calls incorrectly showed the entrypoint number (ANI) instead of the dialed number (DN) in the caller ID across all three task display surfaces.
2. **Phone Number field (CAD section):** The Phone Number field in CallControlCAD was showing `dn` (entry point/DNIS) instead of `ani` (the actual phone number) for both inbound and outdial calls, mismatching the desktop client.

## by making the following changes

### Caller ID fix (title display)
- Modified `extractIncomingTaskData` in `incoming-task.utils.tsx` to check `outboundType === 'OUTDIAL'` and use `dn` (dialed number) instead of `ani` for the title
- Applied the same fix to `extractTaskListItemData` in `task-list.utils.ts` for the task list display
- Updated `CallControlCAD` component to use a `callerNumber` variable (`dn || ani` for outdial, `ani` for inbound) for the caller ID
- Falls back to `ani` if `dn` is not available, maintaining backward compatibility

### Phone Number field fix (CAD section)
- Changed `renderPhoneNumber` in `CallControlCAD` to use `ani` instead of `dn`, matching desktop client behavior:
  - Inbound: Phone Number = `ani` (caller's number)
  - Outdial: Phone Number = `ani` (customer's number dialed by agent)

### Tests
- Added outdial test suites for `incoming-task.utils` (7 tests) and `task-list.utils` (7 tests) covering: outdial title display, dn fallback to ani, empty dn fallback, CALLBACK outboundType, social media outdial, and button states
- Added `dn` field to CallControlCAD unit test mock data to verify `dn` is not incorrectly used for Phone Number
- Added inbound vs outdial phone number display test in CallControlCAD
- Updated 9 snapshots reflecting the Phone Number field now correctly showing `ani`

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
Vidcast: https://app.vidcast.io/share/2e933e24-985f-49a1-ad81-99c31f444c63
- [x] The testing is done with the amplify link
- [x] Unit tests added/updated and passing (647 tests, all passing, 224 snapshots)
- [x] Inbound call: Caller ID shows ANI, Phone Number shows ANI (matches desktop)
- [x] Outdial call: Caller ID shows DN, Phone Number shows ANI (matches desktop)
- [x] Outdial task falls back to ANI when DN is unavailable
- [x] Inbound telephony tasks continue to show ANI as caller ID (non-regression)
- [x] Social media tasks continue to use customerName (non-regression)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [x] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [x] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.