### PR TITLE
feat(cc-ui-logging): add PROPS_UPDATED event for watched props changes

### DIFF
--- a/packages/contact-center/ui-logging/src/withMetrics.tsx
+++ b/packages/contact-center/ui-logging/src/withMetrics.tsx
@@ -1,9 +1,11 @@
 import React, {useEffect, useRef} from 'react';
 import {havePropsChanged, logMetrics} from './metricsLogger';
 
-export default function withMetrics<P extends object>(Component: any, widgetName: string) {
+export default function withMetrics<P extends object>(Component: any, widgetName: string, propsToWatch?: string[]) {
   return React.memo(
     (props: P) => {
+      const prevWatchedPropsRef = useRef<Record<string, any> | null>(null);
+
       useEffect(() => {
         logMetrics({
           widgetName,
@@ -20,7 +22,25 @@ export default function withMetrics<P extends object>(Component: any, widgetName
         };
       }, []);
 
-      // TODO: https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6890 PROPS_UPDATED event
+      useEffect(() => {
+        if (!propsToWatch || propsToWatch.length === 0) return;
+
+        const currentWatchedProps: Record<string, any> = {};
+        for (const key of propsToWatch) {
+          currentWatchedProps[key] = (props as Record<string, any>)[key];
+        }
+
+        if (prevWatchedPropsRef.current !== null && havePropsChanged(prevWatchedPropsRef.current, currentWatchedProps)) {
+          logMetrics({
+            widgetName,
+            event: 'PROPS_UPDATED',
+            props: currentWatchedProps,
+            timestamp: Date.now(),
+          });
+        }
+
+        prevWatchedPropsRef.current = currentWatchedProps;
+      });
 
       return <Component {...props} />;
     },

--- a/packages/contact-center/ui-logging/tests/withMetrics.test.tsx
+++ b/packages/contact-center/ui-logging/tests/withMetrics.test.tsx
@@ -102,4 +102,89 @@ describe('withMetrics HOC', () => {
     rerender(<WrappedSpy name="different" />);
     expect(renderSpy).toHaveBeenCalledTimes(2);
   });
+
+  describe('PROPS_UPDATED event', () => {
+    it('should log PROPS_UPDATED when watched props change', () => {
+      const mockTime = 1234567890;
+      jest.setSystemTime(mockTime);
+
+      const WrappedWithWatch = withMetrics<TestComponentProps>(TestComponent, 'TestWidget', ['name']);
+
+      const {rerender} = render(<WrappedWithWatch name="initial" />);
+      logMetricsSpy.mockClear();
+
+      rerender(<WrappedWithWatch name="updated" />);
+
+      expect(logMetricsSpy).toHaveBeenCalledWith({
+        widgetName: 'TestWidget',
+        event: 'PROPS_UPDATED',
+        props: {name: 'updated'},
+        timestamp: mockTime,
+      });
+    });
+
+    it('should not log PROPS_UPDATED when only unwatched props change', () => {
+      const mockTime = 1234567890;
+      jest.setSystemTime(mockTime);
+
+      const WrappedWithWatch = withMetrics<TestComponentProps>(TestComponent, 'TestWidget', ['name']);
+
+      const {rerender} = render(<WrappedWithWatch name="test" otherProp="a" />);
+      logMetricsSpy.mockClear();
+
+      rerender(<WrappedWithWatch name="test" otherProp="b" />);
+
+      expect(logMetricsSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({event: 'PROPS_UPDATED'})
+      );
+    });
+
+    it('should not log PROPS_UPDATED when no propsToWatch is provided', () => {
+      const mockTime = 1234567890;
+      jest.setSystemTime(mockTime);
+
+      const WrappedNoWatch = withMetrics<TestComponentProps>(TestComponent, 'TestWidget');
+
+      const {rerender} = render(<WrappedNoWatch name="test" />);
+      logMetricsSpy.mockClear();
+
+      rerender(<WrappedNoWatch name="different" />);
+
+      expect(logMetricsSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({event: 'PROPS_UPDATED'})
+      );
+    });
+
+    it('should not log PROPS_UPDATED on initial render', () => {
+      const mockTime = 1234567890;
+      jest.setSystemTime(mockTime);
+
+      const WrappedWithWatch = withMetrics<TestComponentProps>(TestComponent, 'TestWidget', ['name']);
+
+      render(<WrappedWithWatch name="initial" />);
+
+      expect(logMetricsSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({event: 'PROPS_UPDATED'})
+      );
+    });
+
+    it('should only include watched props in the log payload', () => {
+      const mockTime = 1234567890;
+      jest.setSystemTime(mockTime);
+
+      const WrappedWithWatch = withMetrics<TestComponentProps>(TestComponent, 'TestWidget', ['name']);
+
+      const {rerender} = render(<WrappedWithWatch name="initial" otherProp="secret" />);
+      logMetricsSpy.mockClear();
+
+      rerender(<WrappedWithWatch name="updated" otherProp="secret" />);
+
+      const propsUpdatedCall = logMetricsSpy.mock.calls.find(
+        (call) => call[0].event === 'PROPS_UPDATED'
+      );
+      expect(propsUpdatedCall).toBeDefined();
+      expect(propsUpdatedCall[0].props).toEqual({name: 'updated'});
+      expect(propsUpdatedCall[0].props).not.toHaveProperty('otherProp');
+    });
+  });
 });


### PR DESCRIPTION
# COMPLETES
https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6890

## This pull request addresses

Widgets currently record mount and unmount events but do not track when important props change. This makes it harder to monitor widget behavior and debug issues related to prop updates.

## by making the following changes

- Added optional `propsToWatch` parameter to `withMetrics()` HOC in `@webex/cc-ui-logging`
- When `propsToWatch` is provided, the HOC tracks previous values of watched props using `useRef`
- On re-render, if any watched prop has changed (shallow comparison via existing `havePropsChanged`), a `PROPS_UPDATED` event is logged with only the watched props in the payload
- Initial render does not trigger `PROPS_UPDATED` (only subsequent changes)
- Unwatched props (like timers) are excluded from logging to avoid log pollution
- Added 5 unit tests covering: watched prop change logging, unwatched prop filtering, no-watch passthrough, initial render skip, and payload correctness
- 100% code coverage on withMetrics.tsx

**Usage by components (follow-up):** Each component can now pass a `propsToWatch` array:
```typescript
const WrappedComponent = withMetrics(MyComponent, 'MyWidget', ['importantProp', 'anotherProp']);
```

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- [x] Unit tests added/updated and passing (18 tests, all passing)
- [x] PROPS_UPDATED logged when watched props change
- [x] PROPS_UPDATED NOT logged when only unwatched props change
- [x] PROPS_UPDATED NOT logged on initial render
- [x] Only watched props included in log payload
- [x] Backward compatible — existing withMetrics calls work without propsToWatch

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [x] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.