### PR TITLE
fix(cc-task): fix hold/resume not working after recording pause/resume

### DIFF
--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -447,16 +447,20 @@ export const useCallControl = (props: useCallControlProps) => {
     }
   }, [currentTask, logger, lastTargetType, consultAgentName, setConsultAgentName]);
 
-  // Sync local hold state from task data when currentTask changes
+  // Sync local hold state from task data only when a different task is selected
+  // (not on every currentTask reference change, which would overwrite event-driven state)
   useEffect(() => {
     if (currentTask?.data?.interaction) {
       try {
         setIsHeld(findHoldStatus(currentTask, 'mainCall', agentId));
-      } catch {
-        // findHoldStatus may fail if task data is incomplete
+      } catch (error) {
+        logger?.warn(`CC-Widgets: Task: Error syncing hold state - ${error?.message || error}`, {
+          module: 'useCallControl',
+          method: 'syncHoldState',
+        });
       }
     }
-  }, [currentTask, agentId]);
+  }, [currentTask?.data?.interactionId, agentId]);
 
   // Extract main call timestamp whenever currentTask changes
   useEffect(() => {
@@ -952,10 +956,7 @@ export const useCallControl = (props: useCallControlProps) => {
   );
 
   // Override isHeld with event-driven local state to avoid stale task data from getAllTasks()
-  const controlVisibility = useMemo(
-    () => ({...controlVisibilityBase, isHeld}),
-    [controlVisibilityBase, isHeld]
-  );
+  const controlVisibility = useMemo(() => ({...controlVisibilityBase, isHeld}), [controlVisibilityBase, isHeld]);
 
   // Add useEffect for auto wrap-up timer
   useEffect(() => {

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -595,10 +595,12 @@ export const useCallControl = (props: useCallControlProps) => {
   const pauseRecordingCallback = () => {
     try {
       setIsRecording(false);
-      onRecordingToggle({
-        isRecording: false,
-        task: currentTask,
-      });
+      if (onRecordingToggle) {
+        onRecordingToggle({
+          isRecording: false,
+          task: currentTask,
+        });
+      }
     } catch (error) {
       logger?.error(`CC-Widgets: Task: Error in pauseRecordingCallback - ${error.message}`, {
         module: 'useCallControl',
@@ -610,10 +612,12 @@ export const useCallControl = (props: useCallControlProps) => {
   const resumeRecordingCallback = () => {
     try {
       setIsRecording(true);
-      onRecordingToggle({
-        isRecording: true,
-        task: currentTask,
-      });
+      if (onRecordingToggle) {
+        onRecordingToggle({
+          isRecording: true,
+          task: currentTask,
+        });
+      }
     } catch (error) {
       logger?.error(`CC-Widgets: Task: Error in resumeRecordingCallback - ${error.message}`, {
         module: 'useCallControl',
@@ -648,8 +652,8 @@ export const useCallControl = (props: useCallControlProps) => {
       store.removeTaskCallback(TASK_EVENTS.TASK_RESUME, resumeCallback, interactionId);
       store.removeTaskCallback(TASK_EVENTS.TASK_END, endCallCallback, interactionId);
       store.removeTaskCallback(TASK_EVENTS.AGENT_WRAPPEDUP, wrapupCallCallback, interactionId);
-      store.removeTaskCallback(TASK_EVENTS.CONTACT_RECORDING_PAUSED, pauseRecordingCallback, interactionId);
-      store.removeTaskCallback(TASK_EVENTS.CONTACT_RECORDING_RESUMED, resumeRecordingCallback, interactionId);
+      store.removeTaskCallback(TASK_EVENTS.TASK_RECORDING_PAUSED, pauseRecordingCallback, interactionId);
+      store.removeTaskCallback(TASK_EVENTS.TASK_RECORDING_RESUMED, resumeRecordingCallback, interactionId);
     };
   }, [currentTask]);
 

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -16,7 +16,6 @@ import store, {
   getConferenceParticipants,
   Participant,
   findMediaResourceId,
-  findHoldStatus,
   MEDIA_TYPE_TELEPHONY_LOWER,
 } from '@webex/cc-store';
 import {getControlsVisibility} from './Utils/task-util';
@@ -447,19 +446,11 @@ export const useCallControl = (props: useCallControlProps) => {
     }
   }, [currentTask, logger, lastTargetType, consultAgentName, setConsultAgentName]);
 
-  // Sync local hold state from task data only when a different task is selected
+  // Sync local hold state from controlVisibilityBase only when a different task is selected
   // (not on every currentTask reference change, which would overwrite event-driven state)
   useEffect(() => {
-    if (currentTask?.data?.interaction) {
-      try {
-        setIsHeld(findHoldStatus(currentTask, 'mainCall', agentId));
-      } catch (error) {
-        logger?.warn(`CC-Widgets: Task: Error syncing hold state - ${error?.message || error}`, {
-          module: 'useCallControl',
-          method: 'syncHoldState',
-        });
-      }
-    }
+    setIsHeld(controlVisibilityBase?.isHeld ?? false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentTask?.data?.interactionId, agentId]);
 
   // Extract main call timestamp whenever currentTask changes

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -16,6 +16,7 @@ import store, {
   getConferenceParticipants,
   Participant,
   findMediaResourceId,
+  findHoldStatus,
   MEDIA_TYPE_TELEPHONY_LOWER,
 } from '@webex/cc-store';
 import {getControlsVisibility} from './Utils/task-util';
@@ -297,6 +298,7 @@ export const useCallControl = (props: useCallControlProps) => {
     agentId,
   } = props;
   const [isRecording, setIsRecording] = useState(true);
+  const [isHeld, setIsHeld] = useState(false);
   const [buddyAgents, setBuddyAgents] = useState<BuddyDetails[]>([]);
   const [loadingBuddyAgents, setLoadingBuddyAgents] = useState(false);
   const [consultAgentName, setConsultAgentName] = useState<string>('Consult Agent');
@@ -445,6 +447,17 @@ export const useCallControl = (props: useCallControlProps) => {
     }
   }, [currentTask, logger, lastTargetType, consultAgentName, setConsultAgentName]);
 
+  // Sync local hold state from task data when currentTask changes
+  useEffect(() => {
+    if (currentTask?.data?.interaction) {
+      try {
+        setIsHeld(findHoldStatus(currentTask, 'mainCall', agentId));
+      } catch {
+        // findHoldStatus may fail if task data is incomplete
+      }
+    }
+  }, [currentTask, agentId]);
+
   // Extract main call timestamp whenever currentTask changes
   useEffect(() => {
     extractConsultingAgent();
@@ -530,6 +543,7 @@ export const useCallControl = (props: useCallControlProps) => {
 
   const holdCallback = () => {
     try {
+      setIsHeld(true);
       if (onHoldResume) {
         onHoldResume({
           isHeld: true,
@@ -546,6 +560,7 @@ export const useCallControl = (props: useCallControlProps) => {
 
   const resumeCallback = () => {
     try {
+      setIsHeld(false);
       if (onHoldResume) {
         onHoldResume({
           isHeld: false,
@@ -931,9 +946,15 @@ export const useCallControl = (props: useCallControlProps) => {
     currentTask.cancelAutoWrapupTimer();
   };
 
-  const controlVisibility = useMemo(
+  const controlVisibilityBase = useMemo(
     () => getControlsVisibility(deviceType, featureFlags, currentTask, agentId, conferenceEnabled, logger),
     [deviceType, featureFlags, currentTask, agentId, conferenceEnabled, logger]
+  );
+
+  // Override isHeld with event-driven local state to avoid stale task data from getAllTasks()
+  const controlVisibility = useMemo(
+    () => ({...controlVisibilityBase, isHeld}),
+    [controlVisibilityBase, isHeld]
   );
 
   // Add useEffect for auto wrap-up timer

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -5730,6 +5730,64 @@ describe('Task Hook Error Handling and Logging', () => {
       );
     });
 
+    it('should not throw when onRecordingToggle is not provided and pauseRecordingCallback fires', () => {
+      const setTaskCallbackSpy = jest.spyOn(store, 'setTaskCallback');
+
+      renderHook(() =>
+        useCallControl({
+          currentTask: mockTaskWithInteraction,
+          logger,
+          deviceType: 'BROWSER',
+          featureFlags: {},
+          isMuted: false,
+          conferenceEnabled: false,
+          agentId: 'agent1',
+        })
+      );
+
+      const pauseCallback = setTaskCallbackSpy.mock.calls.find(
+        (call) => call[0] === TASK_EVENTS.TASK_RECORDING_PAUSED
+      )?.[1];
+
+      act(() => {
+        pauseCallback();
+      });
+
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('pauseRecordingCallback'),
+        expect.any(Object)
+      );
+    });
+
+    it('should not throw when onRecordingToggle is not provided and resumeRecordingCallback fires', () => {
+      const setTaskCallbackSpy = jest.spyOn(store, 'setTaskCallback');
+
+      renderHook(() =>
+        useCallControl({
+          currentTask: mockTaskWithInteraction,
+          logger,
+          deviceType: 'BROWSER',
+          featureFlags: {},
+          isMuted: false,
+          conferenceEnabled: false,
+          agentId: 'agent1',
+        })
+      );
+
+      const resumeCallback = setTaskCallbackSpy.mock.calls.find(
+        (call) => call[0] === TASK_EVENTS.TASK_RECORDING_RESUMED
+      )?.[1];
+
+      act(() => {
+        resumeCallback();
+      });
+
+      expect(logger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('resumeRecordingCallback'),
+        expect.any(Object)
+      );
+    });
+
     it('should handle synchronous errors in toggleRecording', () => {
       const errorTask = {
         ...mockTaskWithInteraction,

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -1023,8 +1023,8 @@ describe('useCallControl', () => {
     expect(result.current.controlVisibility.isHeld).toBe(false);
   });
 
-  it('should override getControlsVisibility isHeld with local event-driven state', async () => {
-    // Mock getControlsVisibility to return isHeld: true (simulating stale task data)
+  it('should override getControlsVisibility isHeld with event-driven state from callbacks', async () => {
+    // Mock getControlsVisibility to return isHeld: true (simulating stale task data after refreshTaskList)
     mockGetControlsVisibility.mockReturnValue({
       ...mockGetControlsVisibility.mock.results[0]?.value,
       muteUnmute: {isVisible: true, isEnabled: true},
@@ -1051,23 +1051,19 @@ describe('useCallControl', () => {
       })
     );
 
-    // Even though getControlsVisibility returns isHeld: true,
-    // the local state starts as false, so controlVisibility.isHeld should be false
-    expect(result.current.controlVisibility.isHeld).toBe(false);
-
-    // After holdCallback, it should be true (event-driven, not from getControlsVisibility)
-    const holdCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_HOLD)?.[1];
-    act(() => {
-      holdCallback();
-    });
-    expect(result.current.controlVisibility.isHeld).toBe(true);
-
-    // After resumeCallback, it should be false again
+    // resumeCallback should override getControlsVisibility isHeld: true with false
     const resumeCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_RESUME)?.[1];
     act(() => {
       resumeCallback();
     });
     expect(result.current.controlVisibility.isHeld).toBe(false);
+
+    // holdCallback should set it back to true
+    const holdCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_HOLD)?.[1];
+    act(() => {
+      holdCallback();
+    });
+    expect(result.current.controlVisibility.isHeld).toBe(true);
   });
 
   it('should log an error if hold fails', async () => {

--- a/packages/contact-center/task/tests/helper.ts
+++ b/packages/contact-center/task/tests/helper.ts
@@ -957,6 +957,119 @@ describe('useCallControl', () => {
     expect(mockOnHoldResume).toHaveBeenCalledWith({isHeld: false, task: mockCurrentTask});
   });
 
+  it('should set controlVisibility.isHeld to true when holdCallback fires', async () => {
+    const setTaskCallbackSpy = jest.spyOn(store, 'setTaskCallback');
+
+    const {result} = renderHook(() =>
+      useCallControl({
+        currentTask: mockCurrentTask,
+        onHoldResume: mockOnHoldResume,
+        onEnd: mockOnEnd,
+        onWrapUp: mockOnWrapUp,
+        logger: mockLogger,
+        featureFlags: store.featureFlags,
+        deviceType: store.deviceType,
+        isMuted: false,
+        conferenceEnabled: true,
+        agentId: 'test-agent-id',
+      })
+    );
+
+    // Initially isHeld should be false
+    expect(result.current.controlVisibility.isHeld).toBe(false);
+
+    // Find the hold callback registered via setTaskCallback
+    const holdCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_HOLD)?.[1];
+
+    act(() => {
+      holdCallback();
+    });
+
+    // After holdCallback fires, isHeld should be true
+    expect(result.current.controlVisibility.isHeld).toBe(true);
+  });
+
+  it('should set controlVisibility.isHeld to false when resumeCallback fires', async () => {
+    const setTaskCallbackSpy = jest.spyOn(store, 'setTaskCallback');
+
+    const {result} = renderHook(() =>
+      useCallControl({
+        currentTask: mockCurrentTask,
+        onHoldResume: mockOnHoldResume,
+        onEnd: mockOnEnd,
+        onWrapUp: mockOnWrapUp,
+        logger: mockLogger,
+        featureFlags: store.featureFlags,
+        deviceType: store.deviceType,
+        isMuted: false,
+        conferenceEnabled: true,
+        agentId: 'test-agent-id',
+      })
+    );
+
+    // First hold the call
+    const holdCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_HOLD)?.[1];
+    act(() => {
+      holdCallback();
+    });
+    expect(result.current.controlVisibility.isHeld).toBe(true);
+
+    // Then resume — isHeld should go back to false
+    const resumeCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_RESUME)?.[1];
+    act(() => {
+      resumeCallback();
+    });
+
+    expect(result.current.controlVisibility.isHeld).toBe(false);
+  });
+
+  it('should override getControlsVisibility isHeld with local event-driven state', async () => {
+    // Mock getControlsVisibility to return isHeld: true (simulating stale task data)
+    mockGetControlsVisibility.mockReturnValue({
+      ...mockGetControlsVisibility.mock.results[0]?.value,
+      muteUnmute: {isVisible: true, isEnabled: true},
+      holdResume: {isVisible: true, isEnabled: true},
+      end: {isVisible: true, isEnabled: true},
+      isHeld: true,
+      wrapup: {isVisible: false, isEnabled: false},
+    });
+
+    const setTaskCallbackSpy = jest.spyOn(store, 'setTaskCallback');
+
+    const {result} = renderHook(() =>
+      useCallControl({
+        currentTask: mockCurrentTask,
+        onHoldResume: mockOnHoldResume,
+        onEnd: mockOnEnd,
+        onWrapUp: mockOnWrapUp,
+        logger: mockLogger,
+        featureFlags: store.featureFlags,
+        deviceType: store.deviceType,
+        isMuted: false,
+        conferenceEnabled: true,
+        agentId: 'test-agent-id',
+      })
+    );
+
+    // Even though getControlsVisibility returns isHeld: true,
+    // the local state starts as false, so controlVisibility.isHeld should be false
+    expect(result.current.controlVisibility.isHeld).toBe(false);
+
+    // After holdCallback, it should be true (event-driven, not from getControlsVisibility)
+    const holdCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_HOLD)?.[1];
+    act(() => {
+      holdCallback();
+    });
+    expect(result.current.controlVisibility.isHeld).toBe(true);
+
+    // After resumeCallback, it should be false again
+    const resumeCallback = setTaskCallbackSpy.mock.calls.find((call) => call[0] === TASK_EVENTS.TASK_RESUME)?.[1];
+    act(() => {
+      resumeCallback();
+    });
+    expect(result.current.controlVisibility.isHeld).toBe(false);
+  });
+
   it('should log an error if hold fails', async () => {
     mockCurrentTask.hold.mockRejectedValueOnce(new Error('Hold error'));
 


### PR DESCRIPTION
# COMPLETES https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7507

## This pull request addresses

Hold followed by recording Pause or Resume stops working — the hold/resume button stays stuck as "Hold the call" even though the SDK successfully processes the hold request.

## by making the following changes

### Fix 1: Track hold state locally via TASK_HOLD/TASK_RESUME events

**Root cause**: The SDK fires TASK_HOLD events before updating its internal task data. When `refreshTaskList` runs in response and calls `getAllTasks()`, the returned data still has `isHold: false`. Since `controlVisibility.isHeld` reads from this stale task data, the UI never reflects the held state.

**Fix**: Track `isHeld` locally in `useCallControl` using `useState`, driven by `holdCallback`/`resumeCallback` events (same pattern already used for `isRecording`). The local state is synced from task data on `currentTask` changes and overrides `controlVisibility.isHeld`.

### Fix 2: Guard optional onRecordingToggle callback

`onRecordingToggle` is an optional prop but was called unconditionally in `pauseRecordingCallback` and `resumeRecordingCallback`, unlike other callbacks (`onHoldResume`, `onEnd`, `onWrapUp`) which all have null checks.

### Fix 3: Fix event name mismatch in useEffect cleanup

Registration used `TASK_EVENTS.TASK_RECORDING_PAUSED` (`'task:recordingPaused'`) but cleanup used `TASK_EVENTS.CONTACT_RECORDING_PAUSED` (`'ContactRecordingPaused'`). These are different string values, so `removeTaskCallback` never matched the registered listeners.

Vidcast: https://app.vidcast.io/share/355ef012-b9ce-4b84-b35a-cc0f3cc5e303
### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Verified hold/resume UI correctly toggles after recording pause using Playwright (React sample app, live call)
- [x] Verified recording pause/resume no longer throws TypeError when onRecordingToggle is not provided
- [x] Verified callback cleanup correctly removes recording event listeners on re-render
- [x] Unit tests pass (168/168 in helper.ts test suite)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link