### PR TITLE
chore(cc-store): revert bump contact-center to 3.12.0-next.14

### DIFF
--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/contact-center": "3.11.0-next.20",
+    "@webex/contact-center": "3.12.0-next.1",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/contact-center": "3.12.0-next.14",
+    "@webex/contact-center": "3.11.0-next.20",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,6 +9563,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/calling@npm:3.11.0-next.15":
+  version: 3.11.0-next.15
+  resolution: "@webex/calling@npm:3.11.0-next.15"
+  dependencies:
+    "@types/platform": "npm:1.3.4"
+    "@webex/internal-media-core": "npm:2.23.1"
+    "@webex/internal-plugin-metrics": "npm:3.11.0-next.8"
+    "@webex/media-helpers": "npm:3.11.0-next.4"
+    async-mutex: "npm:0.4.0"
+    buffer: "npm:6.0.3"
+    jest-html-reporters: "npm:3.0.11"
+    platform: "npm:1.3.6"
+    uuid: "npm:8.3.2"
+    xstate: "npm:4.30.6"
+  checksum: 10c0/1b03669ed2f33d7bcde3b5996cd53805f54c1fffed0432e60e864c12e9b54327d8874d03dcbde0e4f05fa6e489ff162bd4425d9d4beb7d41a4c58971de624a2b
+  languageName: node
+  linkType: hard
+
 "@webex/cc-components@workspace:*, @webex/cc-components@workspace:packages/contact-center/cc-components":
   version: 0.0.0-use.local
   resolution: "@webex/cc-components@workspace:packages/contact-center/cc-components"
@@ -9720,7 +9738,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/contact-center": "npm:3.11.0-next.20"
+    "@webex/contact-center": "npm:3.12.0-next.1"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
@@ -10069,6 +10087,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/contact-center@npm:3.12.0-next.1":
+  version: 3.12.0-next.1
+  resolution: "@webex/contact-center@npm:3.12.0-next.1"
+  dependencies:
+    "@types/platform": "npm:1.3.4"
+    "@webex/calling": "npm:3.11.0-next.15"
+    "@webex/internal-plugin-mercury": "npm:3.11.0-next.10"
+    "@webex/internal-plugin-metrics": "npm:3.11.0-next.8"
+    "@webex/internal-plugin-support": "npm:3.11.0-next.11"
+    "@webex/plugin-authorization": "npm:3.11.0-next.8"
+    "@webex/plugin-logger": "npm:3.11.0-next.8"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    jest-html-reporters: "npm:3.0.11"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/7b280bd69fdbab3ed1203e21c48080bf3da5a40c290b241eb0d4772da3ab5ebe212d144068b2c48dd678f19eecbfae85152631ab27ff215eb9592dcb407e0c9c
+  languageName: node
+  linkType: hard
+
 "@webex/event-dictionary-ts@npm:^1.0.1930":
   version: 1.0.2091
   resolution: "@webex/event-dictionary-ts@npm:1.0.2091"
@@ -10274,6 +10310,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-media-core@npm:2.23.1":
+  version: 2.23.1
+  resolution: "@webex/internal-media-core@npm:2.23.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.18.9"
+    "@babel/runtime-corejs2": "npm:^7.25.0"
+    "@webex/rtcstats": "npm:^1.5.5"
+    "@webex/ts-sdp": "npm:1.8.2"
+    "@webex/web-capabilities": "npm:^1.10.0"
+    "@webex/web-client-media-engine": "npm:3.39.1"
+    events: "npm:^3.3.0"
+    ip-anonymize: "npm:^0.1.0"
+    typed-emitter: "npm:^2.1.0"
+    uuid: "npm:^8.3.2"
+    webrtc-adapter: "npm:^8.1.2"
+    xstate: "npm:^4.30.6"
+  checksum: 10c0/cd977c3ef4c04ac1aa8a8544fc96a4b30b64c58651dfa07c152499699f33d312ead7385e44d59aaf5a97b24834b934d9ec1776d3b806650c2ce10992515a6f65
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-calendar@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-calendar@npm:2.60.4"
@@ -10335,6 +10391,24 @@ __metadata:
     node-scr: "npm:^0.3.0"
     uuid: "npm:^3.3.2"
   checksum: 10c0/93134422c3d5ee1f5e5dde3c2f891d964dab7e8c96f108ffd5c3d692082149bfeee586ca4efe9601a2d3ad5bb4656f221c7d77dcca7d81e9948042947fdff547
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-conversation@npm:3.11.0-next.11":
+  version: 3.11.0-next.11
+  resolution: "@webex/internal-plugin-conversation@npm:3.11.0-next.11"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/helper-html": "npm:3.11.0-next.1"
+    "@webex/helper-image": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-encryption": "npm:3.11.0-next.11"
+    "@webex/internal-plugin-user": "npm:3.11.0-next.8"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    crypto-js: "npm:^4.1.1"
+    lodash: "npm:^4.17.21"
+    node-scr: "npm:^0.3.0"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/75801ea25a462679a4495be1f302ac776dee66d75e5347cc03b18607de2f3db468e0f2fbdc5df3207d84565a7259a9bfab59b44fb6779271843879a421f7ef5b
   languageName: node
   linkType: hard
 
@@ -10406,6 +10480,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-device@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/internal-plugin-device@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/common-timers": "npm:3.11.0-next.1"
+    "@webex/http-core": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-metrics": "npm:3.11.0-next.8"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    ampersand-collection: "npm:^2.0.2"
+    ampersand-state: "npm:^5.0.3"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/d67b90eb8ad5d6cb6794a72143d32dc2f8d23fdf2284b2a0d09127284ab5252a3a6b92190a2f4a3022cc229d3c11ceabf65529d2b9914ce289869a25a45ba1b3
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-dss@npm:3.11.0-next.9":
   version: 3.11.0-next.9
   resolution: "@webex/internal-plugin-dss@npm:3.11.0-next.9"
@@ -10472,6 +10563,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-encryption@npm:3.11.0-next.11":
+  version: 3.11.0-next.11
+  resolution: "@webex/internal-plugin-encryption@npm:3.11.0-next.11"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/common-timers": "npm:3.11.0-next.1"
+    "@webex/http-core": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/internal-plugin-mercury": "npm:3.11.0-next.10"
+    "@webex/test-helper-file": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    asn1js: "npm:^2.0.26"
+    debug: "npm:^4.3.4"
+    isomorphic-webcrypto: "npm:^2.3.8"
+    lodash: "npm:^4.17.21"
+    node-jose: "npm:^2.2.0"
+    node-kms: "npm:^0.4.1"
+    node-scr: "npm:^0.3.0"
+    pkijs: "npm:^2.1.84"
+    safe-buffer: "npm:^5.2.0"
+    uuid: "npm:^3.3.2"
+    valid-url: "npm:^1.0.9"
+  checksum: 10c0/ce331d6e4ffa9c1766d5acedf94dfa5791a4980e6ecfe92f79d62fa14a0bb04dfa9ea7498712cfcd3cfe5e6f23e630f3615aad7a941b19c38ee4742c00752208
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-encryption@npm:3.11.0-next.8":
   version: 3.11.0-next.8
   resolution: "@webex/internal-plugin-encryption@npm:3.11.0-next.8"
@@ -10529,6 +10646,17 @@ __metadata:
     "@webex/webex-core": "npm:3.11.0-next.7"
     lodash: "npm:^4.17.21"
   checksum: 10c0/72fb7d931e74d9140b52cd72329e2d3f7aaec7a56bd0cf41ca86f967823b9bb2cfc8e60aee4aa1c29e51f78f61594683622e6bf0d1ba1dab063d365513ce40ba
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-feature@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/internal-plugin-feature@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/090c3eb00ec381d5c9dd56fd3ff846c7130faff73f0caba4c96c9e7e6ac33174b6dc18d3008b3a27319b1d41a92b08bb05fb818f9cee61415f67aa29cb0e6abd
   languageName: node
   linkType: hard
 
@@ -10651,6 +10779,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-mercury@npm:3.11.0-next.10":
+  version: 3.11.0-next.10
+  resolution: "@webex/internal-plugin-mercury@npm:3.11.0-next.10"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/common-timers": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/internal-plugin-feature": "npm:3.11.0-next.8"
+    "@webex/internal-plugin-metrics": "npm:3.11.0-next.8"
+    "@webex/test-helper-chai": "npm:3.11.0-next.1"
+    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
+    "@webex/test-helper-mock-web-socket": "npm:3.11.0-next.1"
+    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
+    "@webex/test-helper-refresh-callback": "npm:3.11.0-next.1"
+    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    backoff: "npm:^2.5.0"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+    ws: "npm:^8.17.1"
+  checksum: 10c0/1bd648d7b1772388918ec054c0edb2198de956bebdcf5c901e1ce838cfa4512ca8cccb3ddb617446c10d91943bb883d45b340e031e98f1c066337ac669842260
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-mercury@npm:3.11.0-next.8":
   version: 3.11.0-next.8
   resolution: "@webex/internal-plugin-mercury@npm:3.11.0-next.8"
@@ -10721,6 +10873,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-metrics@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/internal-plugin-metrics@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/common-timers": "npm:3.11.0-next.1"
+    "@webex/test-helper-chai": "npm:3.11.0-next.1"
+    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    ip-anonymize: "npm:^0.1.0"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/eb8fa1acf5e5e7886667e15f17db4d49c40db7c71f02f2b2c9113d71a006c71c88fee431fef9e9bebec3bcd149bcc329a13e93c53248d2bd91219d6c34f02265
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-presence@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-presence@npm:2.60.4"
@@ -10768,6 +10936,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-search@npm:3.11.0-next.11":
+  version: 3.11.0-next.11
+  resolution: "@webex/internal-plugin-search@npm:3.11.0-next.11"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-conversation": "npm:3.11.0-next.11"
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/internal-plugin-encryption": "npm:3.11.0-next.11"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/46850372acebb6171df39b14d24b10af7f95ce648478961bf3f17c64ee29367afeca9312ebf779fb8de5d63fbc268d230539f837e864394a61a054cfa19ce783
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-search@npm:3.11.0-next.8":
   version: 3.11.0-next.8
   resolution: "@webex/internal-plugin-search@npm:3.11.0-next.8"
@@ -10797,6 +10980,23 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/c5f8f541373d24bf14920c066b10cfbf11297c1819b4063e977c6ebf7aa68259f6b9756605d0b5c2b3d4469f2c190b02d482a1b0f5c922bcf6e45ad8872c1989
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-support@npm:3.11.0-next.11":
+  version: 3.11.0-next.11
+  resolution: "@webex/internal-plugin-support@npm:3.11.0-next.11"
+  dependencies:
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/internal-plugin-search": "npm:3.11.0-next.11"
+    "@webex/test-helper-chai": "npm:3.11.0-next.1"
+    "@webex/test-helper-file": "npm:3.11.0-next.1"
+    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
+    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/d7fd4632c8fae73b3b9fe29870fec0dbad9a9a64f0d8067ad7db6d62ef31dce2c74060f63886fcc6d316e1542bbd4501d88e52aa279bc6af301f8570b2a0c516
   languageName: node
   linkType: hard
 
@@ -10879,6 +11079,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-user@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/internal-plugin-user@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/test-helper-chai": "npm:3.11.0-next.1"
+    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
+    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/24cfa30e8315124ba5db127042797afe998514128e2bf52cdfa02eed68b8e1f4a67194a573861cfde42a2256cd2281f2035e5dd940df12a08c6b7339eebd6ed6
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-voicea@npm:3.11.0-next.9":
   version: 3.11.0-next.9
   resolution: "@webex/internal-plugin-voicea@npm:3.11.0-next.9"
@@ -10919,6 +11135,17 @@ __metadata:
     "@webex/ts-events": "npm:^1.1.0"
     "@webex/web-media-effects": "npm:2.33.0"
   checksum: 10c0/c213b7ecbefd29d7d9f597748a146729ed4a75c28b1d11ed6c93f3dca4c751095587de131dc153c85d1b954b61463d379408ea27b09622ee8b93b9c6c253fc2a
+  languageName: node
+  linkType: hard
+
+"@webex/media-helpers@npm:3.11.0-next.4":
+  version: 3.11.0-next.4
+  resolution: "@webex/media-helpers@npm:3.11.0-next.4"
+  dependencies:
+    "@webex/internal-media-core": "npm:2.23.1"
+    "@webex/ts-events": "npm:^1.1.0"
+    "@webex/web-media-effects": "npm:2.33.0"
+  checksum: 10c0/14483373c32d4eb2c06538a12d099107d2bac42a3be47dd6dcb34d0f55c529a19988809f3e27d5ba46590a17d4eecf1aff4b4eeae3d74a367f9d806b54c06584
   languageName: node
   linkType: hard
 
@@ -11004,6 +11231,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/plugin-authorization-browser@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/plugin-authorization-browser@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/plugin-authorization-node": "npm:3.11.0-next.8"
+    "@webex/storage-adapter-local-storage": "npm:3.11.0-next.8"
+    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    jsonwebtoken: "npm:^9.0.2"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/f2cc4b9aa882a725eef9d994104b0a6dc3870393d8110ef5e55d2514cf4c1fe5a30737c99e3c541d59babf74e385de21b48b9860fbc04b8ed6644c6eb2a78ec6
+  languageName: node
+  linkType: hard
+
 "@webex/plugin-authorization-node@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/plugin-authorization-node@npm:2.60.4"
@@ -11030,6 +11274,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/plugin-authorization-node@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/plugin-authorization-node@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/internal-plugin-device": "npm:3.11.0-next.8"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    jsonwebtoken: "npm:^9.0.0"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/8cc84c000e1d846beebd064a9ab5daf1ed3e3463b555cbb35db35249a131df020bbb4e22f3616e664f6ae5bb28fb0126d5dc99a95144db98b06698758bf3c32d
+  languageName: node
+  linkType: hard
+
 "@webex/plugin-authorization@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/plugin-authorization@npm:2.60.4"
@@ -11047,6 +11304,16 @@ __metadata:
     "@webex/plugin-authorization-browser": "npm:3.11.0-next.7"
     "@webex/plugin-authorization-node": "npm:3.11.0-next.7"
   checksum: 10c0/552788e35a95d32f211b8fe0e3cc56b9f00cadba16b0cfab3eb157b85e431d7a0379aecf8afa2206cbed3a50fc34fd42726eaff4e0f5dc733ab9bc76e8071645
+  languageName: node
+  linkType: hard
+
+"@webex/plugin-authorization@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/plugin-authorization@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/plugin-authorization-browser": "npm:3.11.0-next.8"
+    "@webex/plugin-authorization-node": "npm:3.11.0-next.8"
+  checksum: 10c0/ae2f6b180f61d49788cf0bb2600267b3554db012f59e9364f42c5ecb8d83e75c465f15cbbf3ca50098b8486dcd453aba5c8239a8ce35bba9391d9c331d3047bd
   languageName: node
   linkType: hard
 
@@ -11121,6 +11388,20 @@ __metadata:
     "@webex/webex-core": "npm:3.11.0-next.7"
     lodash: "npm:^4.17.21"
   checksum: 10c0/ff4910c9a812ca39cb416f1229f3a9f603070fe8930389c32ba627a9a4f36c6ee646be6927b028fb3196da0db36b4fe587479cc4e293350bd4114230965c4a06
+  languageName: node
+  linkType: hard
+
+"@webex/plugin-logger@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/plugin-logger@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/test-helper-chai": "npm:3.11.0-next.1"
+    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
+    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/980a19e06f8a71c892584e3dff0dcbd83f12715482a2416cb60d373a74ccb38cb20db2eaf52df9d021904b3c585b60179f8775b547b7ee5602e55d664067faed
   languageName: node
   linkType: hard
 
@@ -11445,6 +11726,17 @@ __metadata:
     "@webex/test-helper-mocha": "npm:3.11.0-next.1"
     "@webex/webex-core": "npm:3.11.0-next.7"
   checksum: 10c0/a01b799506f77c4d9319e82ebbb8175c6c02feba45756e0372543579849ad898ff6950981a2a749ef6caa7dca4788e64e93d74d3e5ff5bf3aee4b8bc71de854c
+  languageName: node
+  linkType: hard
+
+"@webex/storage-adapter-local-storage@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/storage-adapter-local-storage@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
+    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
+    "@webex/webex-core": "npm:3.11.0-next.8"
+  checksum: 10c0/510b29ad0652e42a02c2011e5f82e7bf0d9cdb44ecb94e93683d8895b2bb4f6a31d66edeaab9487a18d5d320413a6396f5b78f701997f5f96e11e4a759085164
   languageName: node
   linkType: hard
 
@@ -11874,6 +12166,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/web-capabilities@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "@webex/web-capabilities@npm:1.10.0"
+  dependencies:
+    bowser: "npm:^2.11.0"
+  checksum: 10c0/554fa198ae88249c23035e1e3ef95c939bb26af0582141faa78261c2d364b521e017d018b3fccf2e582455bff9801aea68545a789affac63eb7dd9645513e9ca
+  languageName: node
+  linkType: hard
+
 "@webex/web-capabilities@npm:^1.6.1":
   version: 1.6.1
   resolution: "@webex/web-capabilities@npm:1.6.1"
@@ -11917,6 +12218,25 @@ __metadata:
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
   checksum: 10c0/eb24a7abe82ca5dbd96c862f0659dd08d563069273d7f1d5a1c3543bab65f3479b920caf4f3e68585970ba08785f5c547933ef6025e6e017a975a301a29f4744
+  languageName: node
+  linkType: hard
+
+"@webex/web-client-media-engine@npm:3.39.1":
+  version: 3.39.1
+  resolution: "@webex/web-client-media-engine@npm:3.39.1"
+  dependencies:
+    "@webex/json-multistream": "npm:^2.4.3"
+    "@webex/rtcstats": "npm:^1.5.5"
+    "@webex/ts-events": "npm:^1.2.1"
+    "@webex/ts-sdp": "npm:1.8.2"
+    "@webex/web-capabilities": "npm:^1.10.0"
+    "@webex/web-media-effects": "npm:2.33.0"
+    "@webex/webrtc-core": "npm:2.13.5"
+    async: "npm:^3.2.4"
+    js-logger: "npm:^1.6.1"
+    typed-emitter: "npm:^2.1.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10c0/26585ae9d354e80c3c852a9b8d36d3b610526213995e1747530d5fd5b62f60f79e0aaefa85581b68507073f055c0e7cab6ad70dd1d5f6adaf1dc91b6c30b6246
   languageName: node
   linkType: hard
 
@@ -11994,6 +12314,26 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/f78b1a17822e58f774d84339ca77671fe27af83b828cd07cc4b5ced8de4265f6ed4519332d5c267a88a5a52792b5665d608a2ec4e3628902e306e6ad30cc3a94
+  languageName: node
+  linkType: hard
+
+"@webex/webex-core@npm:3.11.0-next.8":
+  version: 3.11.0-next.8
+  resolution: "@webex/webex-core@npm:3.11.0-next.8"
+  dependencies:
+    "@webex/common": "npm:3.11.0-next.1"
+    "@webex/common-timers": "npm:3.11.0-next.1"
+    "@webex/http-core": "npm:3.11.0-next.1"
+    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
+    ampersand-collection: "npm:^2.0.2"
+    ampersand-events: "npm:^2.0.2"
+    ampersand-state: "npm:^5.0.3"
+    core-decorators: "npm:^0.20.0"
+    crypto-js: "npm:^4.1.1"
+    jsonwebtoken: "npm:^9.0.0"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/e0c76d9c88bbd1fce7f308bb9a105861b8a1dfefa7d71ebab09236117847da7d78845f6f1611d1e7d672a7b214a42b7c9948eb7b4c60960f98f728a70392fe2f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9563,24 +9563,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/calling@npm:3.12.0-next.10":
-  version: 3.12.0-next.10
-  resolution: "@webex/calling@npm:3.12.0-next.10"
-  dependencies:
-    "@types/platform": "npm:1.3.4"
-    "@webex/internal-media-core": "npm:2.23.3"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.2"
-    "@webex/media-helpers": "npm:3.12.0-next.1"
-    async-mutex: "npm:0.4.0"
-    buffer: "npm:6.0.3"
-    jest-html-reporters: "npm:3.0.11"
-    platform: "npm:1.3.6"
-    uuid: "npm:8.3.2"
-    xstate: "npm:4.30.6"
-  checksum: 10c0/b44f78b7b828d4a31dc7976d50fd6544cc43b6a21f2c3c2dc6ea17ce2598b6dda99ce757a995274923ed2da6449452220658c723f95734e38dc8040134b76a4f
-  languageName: node
-  linkType: hard
-
 "@webex/cc-components@workspace:*, @webex/cc-components@workspace:packages/contact-center/cc-components":
   version: 0.0.0-use.local
   resolution: "@webex/cc-components@workspace:packages/contact-center/cc-components"
@@ -9738,7 +9720,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/contact-center": "npm:3.12.0-next.14"
+    "@webex/contact-center": "npm:3.11.0-next.20"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
@@ -10087,24 +10069,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/contact-center@npm:3.12.0-next.14":
-  version: 3.12.0-next.14
-  resolution: "@webex/contact-center@npm:3.12.0-next.14"
-  dependencies:
-    "@types/platform": "npm:1.3.4"
-    "@webex/calling": "npm:3.12.0-next.10"
-    "@webex/internal-plugin-mercury": "npm:3.12.0-next.3"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.2"
-    "@webex/internal-plugin-support": "npm:3.12.0-next.3"
-    "@webex/plugin-authorization": "npm:3.12.0-next.2"
-    "@webex/plugin-logger": "npm:3.12.0-next.2"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    jest-html-reporters: "npm:3.0.11"
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/afb90bd91b61844b523fd8862b2ded0be3d99a0ca3caaa90ec546e699ca94f757bacd5d85d7d228ee92c1e76ed0bb5dbbf52a11e6570a8bd4a87c63bc2310212
-  languageName: node
-  linkType: hard
-
 "@webex/event-dictionary-ts@npm:^1.0.1930":
   version: 1.0.2091
   resolution: "@webex/event-dictionary-ts@npm:1.0.2091"
@@ -10310,26 +10274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-media-core@npm:2.23.3":
-  version: 2.23.3
-  resolution: "@webex/internal-media-core@npm:2.23.3"
-  dependencies:
-    "@babel/runtime": "npm:^7.18.9"
-    "@babel/runtime-corejs2": "npm:^7.25.0"
-    "@webex/rtcstats": "npm:^1.5.5"
-    "@webex/ts-sdp": "npm:1.8.2"
-    "@webex/web-capabilities": "npm:^1.10.0"
-    "@webex/web-client-media-engine": "npm:3.39.3"
-    events: "npm:^3.3.0"
-    ip-anonymize: "npm:^0.1.0"
-    typed-emitter: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
-    webrtc-adapter: "npm:^8.1.2"
-    xstate: "npm:^4.30.6"
-  checksum: 10c0/06aadf963b88210ff8ff36cba83fd0028a709e1bb35b82bec09df1b0281807551ec7d9aeea355c5f9071395b54c624867e6c27885d0458e4cba66d1a2cde2fba
-  languageName: node
-  linkType: hard
-
 "@webex/internal-plugin-calendar@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-calendar@npm:2.60.4"
@@ -10412,24 +10356,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-conversation@npm:3.12.0-next.3":
-  version: 3.12.0-next.3
-  resolution: "@webex/internal-plugin-conversation@npm:3.12.0-next.3"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/helper-html": "npm:3.11.0-next.1"
-    "@webex/helper-image": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-encryption": "npm:3.12.0-next.3"
-    "@webex/internal-plugin-user": "npm:3.12.0-next.2"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    crypto-js: "npm:^4.1.1"
-    lodash: "npm:^4.17.21"
-    node-scr: "npm:^0.3.0"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/1831ce3e16cade65c1c05d56d770f7673164ad57a71f5c6d6bfe5794b3e3fc473b5a1f4f0ca99a9976bda3564ba5a219692da633740606c455855eef3f85d143
-  languageName: node
-  linkType: hard
-
 "@webex/internal-plugin-device@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-device@npm:2.60.4"
@@ -10477,23 +10403,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/7afca9901a424553be74fc0899da05afc07d302bd328e67e5d5e3812e8abe8a33dd510a799238c0b1a99a2ba3c03d5d10bf4a77bb337563ecab9dfe8b82ddccc
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-device@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/internal-plugin-device@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/http-core": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.2"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    ampersand-collection: "npm:^2.0.2"
-    ampersand-state: "npm:^5.0.3"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/b3381809d8e27f3ccd8be080a930f1db4da50b49889815ac6f3b03828b6333ee6da6843da7d5147a7d7db57131c1fb2386960f974f6ce8376604d5babfe4bced
   languageName: node
   linkType: hard
 
@@ -10589,32 +10498,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-encryption@npm:3.12.0-next.3":
-  version: 3.12.0-next.3
-  resolution: "@webex/internal-plugin-encryption@npm:3.12.0-next.3"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/http-core": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/internal-plugin-mercury": "npm:3.12.0-next.3"
-    "@webex/test-helper-file": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    asn1js: "npm:^2.0.26"
-    debug: "npm:^4.3.4"
-    isomorphic-webcrypto: "npm:^2.3.8"
-    lodash: "npm:^4.17.21"
-    node-jose: "npm:^2.2.0"
-    node-kms: "npm:^0.4.1"
-    node-scr: "npm:^0.3.0"
-    pkijs: "npm:^2.1.84"
-    safe-buffer: "npm:^5.2.0"
-    uuid: "npm:^3.3.2"
-    valid-url: "npm:^1.0.9"
-  checksum: 10c0/e11e700f07d011c59558133be1711a66b6754ff3ee542f95782f41690f9d392441bda2ee6610ef8d2b5f924d7e5aee6c5cb6a8fad9a097aeec24b687b9a98196
-  languageName: node
-  linkType: hard
-
 "@webex/internal-plugin-feature@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-feature@npm:2.60.4"
@@ -10646,17 +10529,6 @@ __metadata:
     "@webex/webex-core": "npm:3.11.0-next.7"
     lodash: "npm:^4.17.21"
   checksum: 10c0/72fb7d931e74d9140b52cd72329e2d3f7aaec7a56bd0cf41ca86f967823b9bb2cfc8e60aee4aa1c29e51f78f61594683622e6bf0d1ba1dab063d365513ce40ba
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-feature@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/internal-plugin-feature@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/ecf27e45b15e73b37b6b04c4a6395c5bb4c1c4cc0c6315bb96dd795ee16720e8b78515e9e863e90424208183803e717af37bc53add013e2d4e77dc571fdbaa63
   languageName: node
   linkType: hard
 
@@ -10803,30 +10675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-mercury@npm:3.12.0-next.3":
-  version: 3.12.0-next.3
-  resolution: "@webex/internal-plugin-mercury@npm:3.12.0-next.3"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/internal-plugin-feature": "npm:3.12.0-next.2"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.2"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-web-socket": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-refresh-callback": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    backoff: "npm:^2.5.0"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-    ws: "npm:^8.17.1"
-  checksum: 10c0/14bc522908ce1e49258633f72d1f2e90d443da1972b3558a144e0f2c2ad582466f1e6ad46040d0fdea5e1747f43e0879f9e49df6a698611d5b6e74b8fea395d1
-  languageName: node
-  linkType: hard
-
 "@webex/internal-plugin-metrics@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-metrics@npm:2.60.4"
@@ -10870,22 +10718,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/ac19f4baadfce385c9c3e10e309bc84bd6792a6f651fab10026894e754cb330824cb3b07397d3f5ceb6d89a6b9a5eef37571c8182267e3ed366e48a307f40c52
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-metrics@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/internal-plugin-metrics@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    ip-anonymize: "npm:^0.1.0"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/7a9210e93fd87c7ab63097ee1ef23be79f878b5c415adbbafd4bce673511e5da46b65af4be931ecf4b36b1ff729b7a865a7246e79b3fe8fd6c0604af03c8a2fd
   languageName: node
   linkType: hard
 
@@ -10951,21 +10783,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-search@npm:3.12.0-next.3":
-  version: 3.12.0-next.3
-  resolution: "@webex/internal-plugin-search@npm:3.12.0-next.3"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.12.0-next.3"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/internal-plugin-encryption": "npm:3.12.0-next.3"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/941f05e67ab5556e22f7b2dd01cb1541e91b40b7953a33c1cb14b3697149387e1fa17eb4415a7efd7fca1003e7e594edc1724e900918848d7b7696b97d73f675
-  languageName: node
-  linkType: hard
-
 "@webex/internal-plugin-support@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-support@npm:2.60.4"
@@ -10997,23 +10814,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/8941e8d7534cd57b4dae28f4bbd399b273e7bae6833d7f489c7ebd1cdcbbb8a2957728cdb01f1cd2c651bb65f5df4fa91a658d75fd4226de95e944aa4c5b43e8
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-support@npm:3.12.0-next.3":
-  version: 3.12.0-next.3
-  resolution: "@webex/internal-plugin-support@npm:3.12.0-next.3"
-  dependencies:
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/internal-plugin-search": "npm:3.12.0-next.3"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-file": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/16c3d2b25083019e8c0ce96fd240ca5554351fabbb70939ed3158cd9e507166e5a1977a9350a105d53497aeb19ece37ce5f9f534b70f54116c5b174b39a16962
   languageName: node
   linkType: hard
 
@@ -11079,22 +10879,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-user@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/internal-plugin-user@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/6180efaed0dbab8f72230e0787b221b278ee6d816657ad9fdd65814c3de512e9cf543ac49aa7660c602a3bc5e80ee5ced081456e9d7313fbc6017643f0eb45d7
-  languageName: node
-  linkType: hard
-
 "@webex/internal-plugin-voicea@npm:3.11.0-next.9":
   version: 3.11.0-next.9
   resolution: "@webex/internal-plugin-voicea@npm:3.11.0-next.9"
@@ -11135,17 +10919,6 @@ __metadata:
     "@webex/ts-events": "npm:^1.1.0"
     "@webex/web-media-effects": "npm:2.33.0"
   checksum: 10c0/c213b7ecbefd29d7d9f597748a146729ed4a75c28b1d11ed6c93f3dca4c751095587de131dc153c85d1b954b61463d379408ea27b09622ee8b93b9c6c253fc2a
-  languageName: node
-  linkType: hard
-
-"@webex/media-helpers@npm:3.12.0-next.1":
-  version: 3.12.0-next.1
-  resolution: "@webex/media-helpers@npm:3.12.0-next.1"
-  dependencies:
-    "@webex/internal-media-core": "npm:2.23.3"
-    "@webex/ts-events": "npm:^1.1.0"
-    "@webex/web-media-effects": "npm:2.33.5"
-  checksum: 10c0/f24e7c3a555df46e50745037b2810a9e0122c07091ec2fbee1deea0cbe348be243ea13bfa6a4c91f7fe48914a5893f29235a097948c7a46e8edb7acb44191a58
   languageName: node
   linkType: hard
 
@@ -11231,23 +11004,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization-browser@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/plugin-authorization-browser@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/plugin-authorization-node": "npm:3.12.0-next.2"
-    "@webex/storage-adapter-local-storage": "npm:3.12.0-next.2"
-    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    jsonwebtoken: "npm:^9.0.2"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/9c103e69e22e6e0f58ac6f7fea1b4251fac55810041cfa930a4a70525464e55af8fd9f45ec989a3d8e0f556ee0ccc0a1285ec7e23b40d23af40a3b3e8db6c1fe
-  languageName: node
-  linkType: hard
-
 "@webex/plugin-authorization-node@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/plugin-authorization-node@npm:2.60.4"
@@ -11274,19 +11030,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization-node@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/plugin-authorization-node@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.2"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    jsonwebtoken: "npm:^9.0.0"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/cadeab8eb4cf98122d8bcde2dda0fe290f4caf6042b6019a30195bdd1f7aac2d1178cd53b973593f31c4c7c4b7fcfe8fcfd8650caa3ca59b882f81e63478135b
-  languageName: node
-  linkType: hard
-
 "@webex/plugin-authorization@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/plugin-authorization@npm:2.60.4"
@@ -11304,16 +11047,6 @@ __metadata:
     "@webex/plugin-authorization-browser": "npm:3.11.0-next.7"
     "@webex/plugin-authorization-node": "npm:3.11.0-next.7"
   checksum: 10c0/552788e35a95d32f211b8fe0e3cc56b9f00cadba16b0cfab3eb157b85e431d7a0379aecf8afa2206cbed3a50fc34fd42726eaff4e0f5dc733ab9bc76e8071645
-  languageName: node
-  linkType: hard
-
-"@webex/plugin-authorization@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/plugin-authorization@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/plugin-authorization-browser": "npm:3.12.0-next.2"
-    "@webex/plugin-authorization-node": "npm:3.12.0-next.2"
-  checksum: 10c0/ecac030f20f4fbfd1387e93379ac2c51c3f041a5aed3631990c17de5c7248ecf703a98ca558dca14dfe0b1b31cf8c25b3a03caa5845e837d5052a0da931b4faa
   languageName: node
   linkType: hard
 
@@ -11388,20 +11121,6 @@ __metadata:
     "@webex/webex-core": "npm:3.11.0-next.7"
     lodash: "npm:^4.17.21"
   checksum: 10c0/ff4910c9a812ca39cb416f1229f3a9f603070fe8930389c32ba627a9a4f36c6ee646be6927b028fb3196da0db36b4fe587479cc4e293350bd4114230965c4a06
-  languageName: node
-  linkType: hard
-
-"@webex/plugin-logger@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/plugin-logger@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/3403014494ac83591e96a9ca0e2af8cef2c47058252969700f0f4806e4863cef94c1cee8a5b23a39e2ae241f1bf41788a464aff14f15462ce44ab686ea24244f
   languageName: node
   linkType: hard
 
@@ -11726,17 +11445,6 @@ __metadata:
     "@webex/test-helper-mocha": "npm:3.11.0-next.1"
     "@webex/webex-core": "npm:3.11.0-next.7"
   checksum: 10c0/a01b799506f77c4d9319e82ebbb8175c6c02feba45756e0372543579849ad898ff6950981a2a749ef6caa7dca4788e64e93d74d3e5ff5bf3aee4b8bc71de854c
-  languageName: node
-  linkType: hard
-
-"@webex/storage-adapter-local-storage@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/storage-adapter-local-storage@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.12.0-next.2"
-  checksum: 10c0/5cdb4040a8205ab7f485e5a00c9e344f13195d65c3f7543093c0d14a0a7aef3528104c978e9f2bf10f0b4dc0b37070b1ebed6f7b197b8d694c007dbe4bd74b9b
   languageName: node
   linkType: hard
 
@@ -12145,7 +11853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/ts-sdp@npm:1.8.2, @webex/ts-sdp@npm:^1.8.1":
+"@webex/ts-sdp@npm:1.8.2":
   version: 1.8.2
   resolution: "@webex/ts-sdp@npm:1.8.2"
   checksum: 10c0/d336f6d3599cbee418de6f02621028266a53c07a0a965e82eb18c9e3993ab9d29d569f5398072de43d9448972776734ca76c1ae2f257859a38793e33f8a519aa
@@ -12159,12 +11867,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-capabilities@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@webex/web-capabilities@npm:1.10.0"
-  dependencies:
-    bowser: "npm:^2.11.0"
-  checksum: 10c0/554fa198ae88249c23035e1e3ef95c939bb26af0582141faa78261c2d364b521e017d018b3fccf2e582455bff9801aea68545a789affac63eb7dd9645513e9ca
+"@webex/ts-sdp@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@webex/ts-sdp@npm:1.8.1"
+  checksum: 10c0/9dc7c63d3274cdbf1cf42c17a2d7bc5afef640bf8200e7c812732c9a19f97d3a84df5bfecba9abc349c19c199ede22c9b7d0db32c1cf802af3d5eb56fda3fefa
   languageName: node
   linkType: hard
 
@@ -12214,25 +11920,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-client-media-engine@npm:3.39.3":
-  version: 3.39.3
-  resolution: "@webex/web-client-media-engine@npm:3.39.3"
-  dependencies:
-    "@webex/json-multistream": "npm:^2.4.3"
-    "@webex/rtcstats": "npm:^1.5.5"
-    "@webex/ts-events": "npm:^1.2.1"
-    "@webex/ts-sdp": "npm:1.8.2"
-    "@webex/web-capabilities": "npm:^1.10.0"
-    "@webex/web-media-effects": "npm:2.33.5"
-    "@webex/webrtc-core": "npm:2.13.7"
-    async: "npm:^3.2.4"
-    js-logger: "npm:^1.6.1"
-    typed-emitter: "npm:^2.1.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10c0/a32ce03b347a0451c1ee59a79c7c3eb2408d4dafaeb2c4143918d161b8961a67c6843a9f0d9a8676ba2d15dc2369d66de30a23fe2eff909c12eab23db08db400
-  languageName: node
-  linkType: hard
-
 "@webex/web-media-effects@npm:2.33.0":
   version: 2.33.0
   resolution: "@webex/web-media-effects@npm:2.33.0"
@@ -12245,21 +11932,6 @@ __metadata:
     worker-timers: "npm:^8.0.21"
     yarn: "npm:^1.22.22"
   checksum: 10c0/885bb91393a68836154d7c246c20296ebbaf3727ba569fe7a7a6362dfb67dc36bf74ce5020c87656762b06f1a7bb4766212f1404757855721e74b9740a7bf6aa
-  languageName: node
-  linkType: hard
-
-"@webex/web-media-effects@npm:2.33.5":
-  version: 2.33.5
-  resolution: "@webex/web-media-effects@npm:2.33.5"
-  dependencies:
-    "@webex/ladon-ts": "npm:^5.10.0"
-    events: "npm:^3.3.0"
-    js-logger: "npm:^1.6.1"
-    typed-emitter: "npm:^1.4.0"
-    uuid: "npm:^9.0.1"
-    worker-timers: "npm:^8.0.21"
-    yarn: "npm:^1.22.22"
-  checksum: 10c0/d09da2ca72143a5d79f3e46e2c04f13b38b8351490440b2d1142f926ca0b5df499962e8c6411241f588e74f1757cb8904f029783b25a6751a762e3abdfdf8642
   languageName: node
   linkType: hard
 
@@ -12325,26 +11997,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/webex-core@npm:3.12.0-next.2":
-  version: 3.12.0-next.2
-  resolution: "@webex/webex-core@npm:3.12.0-next.2"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/http-core": "npm:3.11.0-next.1"
-    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
-    ampersand-collection: "npm:^2.0.2"
-    ampersand-events: "npm:^2.0.2"
-    ampersand-state: "npm:^5.0.3"
-    core-decorators: "npm:^0.20.0"
-    crypto-js: "npm:^4.1.1"
-    jsonwebtoken: "npm:^9.0.0"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/12f6906d583b838bd06f80afcadcf06da5934bcb088504a7496606b2f994cc9f2d989aecd5a7a6f8db410d5cedef82d74f2429cbe2cf334dcec780684f88f4c5
-  languageName: node
-  linkType: hard
-
 "@webex/webrtc-core@npm:2.13.5":
   version: 2.13.5
   resolution: "@webex/webrtc-core@npm:2.13.5"
@@ -12357,21 +12009,6 @@ __metadata:
     typed-emitter: "npm:^2.1.0"
     webrtc-adapter: "npm:^8.1.2"
   checksum: 10c0/5f48734cc7ff1eaf87fe84ac781be7991f58feaf13e22c902fd2386b42c4059e53ab6e2db225a7f842fcacd0555abbbab54554d99d06d9f16cb7b044b05327c9
-  languageName: node
-  linkType: hard
-
-"@webex/webrtc-core@npm:2.13.7":
-  version: 2.13.7
-  resolution: "@webex/webrtc-core@npm:2.13.7"
-  dependencies:
-    "@webex/ts-events": "npm:^1.2.1"
-    "@webex/web-capabilities": "npm:^1.6.1"
-    "@webex/web-media-effects": "npm:2.33.5"
-    events: "npm:^3.3.0"
-    js-logger: "npm:^1.6.1"
-    typed-emitter: "npm:^2.1.0"
-    webrtc-adapter: "npm:^8.1.2"
-  checksum: 10c0/48f781ca9d57330b6498e155e2b46bd914773dfc8ce21df80d0d79bf902a224ca4961f848999a3d1b779b49aef8ce7e797374e9c42eec016f88cd2fdc433895a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts webex/widgets#672

This reverts the bump to @webex/contact-center 3.12.0-next.14 and restores version 3.11.0-next.20.
