### PR TITLE
fix(ci): prevent command injection vulnerability in PR title validation [PSIRT-0974799192]

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,20 +45,38 @@ jobs:
     if: contains(toJson(github.event.pull_request.labels), 'validated')
 
     steps:
-      - name: Validate PR title
-        run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          echo "PR Title is: '$TITLE'"
+      - name: Validate PR title safely
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = (context.payload.pull_request?.title ?? "").normalize("NFC");
 
-          regex="^(fix|feat|chore|docs)\([^()]+\): .+"
+            // 1) Required
+            if (!title.length) {
+              core.setFailed("PR title is empty.");
+              return;
+            }
 
-          if [[ $TITLE =~ $regex ]]; then
-            echo "PR title is valid."
-          else
-            echo "Error: PR title does NOT follow the required convention."
-            echo "Expected format: fix|feat|chore(some-text): description..."
-            exit 1
-          fi
+            // 2) Length guard
+            if (title.length > 200) {
+              core.setFailed("PR title is too long (max 200 chars).");
+              return;
+            }
+
+            // 3) Hardened control-char guard (all Unicode control/invisible chars)
+            if (/[\p{C}]/u.test(title)) {
+              core.setFailed("PR title contains disallowed control/invisible characters.");
+              return;
+            }
+
+            // 4) Enforce convention (scope is optional)
+            const regex = /^(fix|feat|chore|docs)(\([^()\s][^()]{0,78}[^()\s]?\))?: [^\s].*$/u;
+            if (!regex.test(title)) {
+              core.setFailed("PR title must follow: fix|feat|chore|docs(scope): description OR fix|feat|chore|docs: description");
+              return;
+            }
+
+            core.info(`PR title is valid: "${title}"`);
 
   install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fixes command injection vulnerability reported in PSIRT-0974799192
- Replaces unsafe bash string interpolation with `github-script` action
- Makes PR title scope optional (both `fix: description` and `fix(scope): description` are now valid)
- Adds security hardening: Unicode normalization, control character detection, 200-char length limit

## Security Impact
The previous implementation using `TITLE="${{ github.event.pull_request.title }}"` in a bash `run:` block was vulnerable to command injection. Attackers could execute arbitrary code by crafting malicious PR titles with shell metacharacters.

This fix uses GitHub's `github-script` action which safely accesses the PR title through the context object without shell interpretation.

## Test Plan
- [x] Tested against all 20 recently merged PRs - all would pass
- [x] Validated regex allows both with and without scope
- [x] Confirmed empty scopes `feat():` are rejected
- [x] Verified control character detection works

<img width="1248" height="477" alt="02_53_59" src="https://github.com/user-attachments/assets/10a40500-5b0d-412b-ab15-3ecf5bb63892" />
<img width="1040" height="613" alt="02_40_31" src="https://github.com/user-attachments/assets/e43211f7-a733-4038-9a9e-9a3d527bd0b2" />



Jira:https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-793315