### PR TITLE
fix(claude): correct hook schema in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "hooks": [".claude/hooks/check-ai-docs-drift.sh"]
+        "hooks": [{"type": "command", "command": ".claude/hooks/check-ai-docs-drift.sh"}]
       }
     ]
   }


### PR DESCRIPTION
# COMPLETES #N/A

## This pull request addresses

The `PreToolUse` hook in `.claude/settings.json` was malformed — the `hooks` array contained a bare string instead of the required object format, causing `claude /doctor` to report a validation error: "Expected object, but received string".

## by making the following changes

- Updated the hook entry from a bare string `".claude/hooks/check-ai-docs-drift.sh"` to the correct object format `{"type": "command", "command": ".claude/hooks/check-ai-docs-drift.sh"}`

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [x] Ran `claude /doctor` — settings validation error no longer appears
- [x] Verified the spec-drift pre-commit hook still triggers correctly with the new format

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link