### PR TITLE
fix(ci): diagnostic - bump sample app webex SDK

### DIFF
--- a/widgets-samples/cc/samples-cc-react-app/package.json
+++ b/widgets-samples/cc/samples-cc-react-app/package.json
@@ -32,7 +32,7 @@
     "react-dom": "18.3.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.6.3",
-    "webex": "3.11.0-next.50",
+    "webex": "3.12.0",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,13 +12,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aml-org/amf-antlr-parsers@npm:0.8.34":
-  version: 0.8.34
-  resolution: "@aml-org/amf-antlr-parsers@npm:0.8.34"
-  checksum: 10c0/0a8fa2f13df8dd027364e27a258ae23fe6592ea8c55cd898424132b663d3b39ab98d1f1e44f63d808b1c5b47f1e9ec55752ac495b9a56159944c506579eef778
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -2648,18 +2641,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bcherny/json-schema-ref-parser@npm:10.0.5-fork":
-  version: 10.0.5-fork
-  resolution: "@bcherny/json-schema-ref-parser@npm:10.0.5-fork"
-  dependencies:
-    "@jsdevtools/ono": "npm:^7.1.3"
-    "@types/json-schema": "npm:^7.0.6"
-    call-me-maybe: "npm:^1.0.1"
-    js-yaml: "npm:^4.1.0"
-  checksum: 10c0/3fb8aa660e4ec457df56224cda531ad92495a24aa8c05788761b74716169c781aebceb3476b072d327efe48b52c1a0c3ddc57823c0e8c4503abb2a7d82b43235
-  languageName: node
-  linkType: hard
-
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
@@ -3698,13 +3679,6 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
-  languageName: node
-  linkType: hard
-
-"@jsdevtools/ono@npm:^7.1.3":
-  version: 7.1.3
-  resolution: "@jsdevtools/ono@npm:7.1.3"
-  checksum: 10c0/a9f7e3e8e3bc315a34959934a5e2f874c423cf4eae64377d3fc9de0400ed9f36cb5fd5ebce3300d2e8f4085f557c4a8b591427a583729a87841fda46e6c216b9
   languageName: node
   linkType: hard
 
@@ -8051,7 +8025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:^7.1.1, @types/glob@npm:^7.1.3":
+"@types/glob@npm:^7.1.1":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
   dependencies:
@@ -8189,7 +8163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.11, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.6, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.3, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -8275,13 +8249,6 @@ __metadata:
   version: 4.17.15
   resolution: "@types/lodash@npm:4.17.15"
   checksum: 10c0/2eb2dc6d231f5fb4603d176c08c8d7af688f574d09af47466a179cd7812d9f64144ba74bb32ca014570ffdc544eedc51b7a5657212bad083b6eecbd72223f9bb
-  languageName: node
-  linkType: hard
-
-"@types/lodash@npm:^4.14.182":
-  version: 4.17.24
-  resolution: "@types/lodash@npm:4.17.24"
-  checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
   languageName: node
   linkType: hard
 
@@ -8415,13 +8382,6 @@ __metadata:
   version: 1.3.4
   resolution: "@types/platform@npm:1.3.4"
   checksum: 10c0/726c90a6a98cc5cd640b539bf8064c432921efbffcf9f4a531c028731b7e91cab1d9bb6016ef0717e25cd2c98727abd8e45fbec400670b1f2e1ebc2c14c850d5
-  languageName: node
-  linkType: hard
-
-"@types/prettier@npm:^2.6.1":
-  version: 2.7.3
-  resolution: "@types/prettier@npm:2.7.3"
-  checksum: 10c0/0960b5c1115bb25e979009d0b44c42cf3d792accf24085e4bfce15aef5794ea042e04e70c2139a2c3387f781f18c89b5706f000ddb089e9a4a2ccb7536a2c5f0
   languageName: node
   linkType: hard
 
@@ -9545,21 +9505,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/calling@npm:3.11.0-next.13":
-  version: 3.11.0-next.13
-  resolution: "@webex/calling@npm:3.11.0-next.13"
+"@webex/calling@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/calling@npm:3.12.0"
   dependencies:
     "@types/platform": "npm:1.3.4"
-    "@webex/internal-media-core": "npm:2.22.1"
-    "@webex/internal-plugin-metrics": "npm:3.11.0-next.7"
-    "@webex/media-helpers": "npm:3.11.0-next.3"
+    "@webex/internal-media-core": "npm:2.23.1"
+    "@webex/internal-plugin-metrics": "npm:3.12.0"
+    "@webex/media-helpers": "npm:3.12.0"
     async-mutex: "npm:0.4.0"
     buffer: "npm:6.0.3"
     jest-html-reporters: "npm:3.0.11"
     platform: "npm:1.3.6"
     uuid: "npm:8.3.2"
     xstate: "npm:4.30.6"
-  checksum: 10c0/05d7e796fd93a65f375c641d912b514103be53dfe0504381eb6d8b96f58d6513a31ea79954b7d6416055c3a2b79a8a9dc9e51e2eb8939898f6f28598ef5cefcb
+  checksum: 10c0/1644cca7c811e04093430e49f14c94d1c1e6df991d7500aaeb2ba2911c87a0038a3856ae39867f2ad8b521d7c13e2daff929fef3a829700f5697192fdf036bf7
   languageName: node
   linkType: hard
 
@@ -9956,17 +9916,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/common-timers@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/common-timers@npm:3.11.0"
-  checksum: 10c0/fbf07e8124086ac363c77593682984b30aa84b4914ee2e544b2242296438314ee9f9b761fb1988c8abce7c7a6870005304dbdfff7db172555a6337fadcdcee4e
-  languageName: node
-  linkType: hard
-
 "@webex/common-timers@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/common-timers@npm:3.11.0-next.1"
   checksum: 10c0/1f5711cbbe872368686cfbe8835d26278b10072da05e9a4af16b8d44022a5833c58df890c8a8b64bb4fd93ea45a80d6e53e95c7e2a6567840e2f8b1f631e402d
+  languageName: node
+  linkType: hard
+
+"@webex/common-timers@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/common-timers@npm:3.12.0"
+  checksum: 10c0/2874a0c207981b94f7a071821403e0c2aee75b3b7fb4faf96658178e1f403b967dafc9a00a407de168a457196aac3282c5b32e05900367c2c582615c8d1e68ef
   languageName: node
   linkType: hard
 
@@ -10003,21 +9963,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/common@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/common@npm:3.11.0"
-  dependencies:
-    backoff: "npm:^2.5.0"
-    bowser: "npm:^2.11.0"
-    core-decorators: "npm:^0.20.0"
-    global: "npm:^4.4.0"
-    lodash: "npm:^4.17.21"
-    safe-buffer: "npm:^5.2.0"
-    urlsafe-base64: "npm:^1.0.0"
-  checksum: 10c0/8c6c824a9925295a6e4e46b3ca91508fec201b838b618a02fb4e98c32f64ecb4f13118cac9fe79cb9e1986c423dcdbb33c236b94bd00e7864a2776e799fd9e78
-  languageName: node
-  linkType: hard
-
 "@webex/common@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/common@npm:3.11.0-next.1"
@@ -10030,6 +9975,21 @@ __metadata:
     safe-buffer: "npm:^5.2.0"
     urlsafe-base64: "npm:^1.0.0"
   checksum: 10c0/ffd90ea4d29d70ee541e62170674bc469e6211836a8f5aa09da9f0ced5226c9f373417fd5f734917877e00d128d2a291a459f6e1c0e1f7c870c86f0bc74cd967
+  languageName: node
+  linkType: hard
+
+"@webex/common@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/common@npm:3.12.0"
+  dependencies:
+    backoff: "npm:^2.5.0"
+    bowser: "npm:^2.11.0"
+    core-decorators: "npm:^0.20.0"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    safe-buffer: "npm:^5.2.0"
+    urlsafe-base64: "npm:^1.0.0"
+  checksum: 10c0/c3c0be0bcfdc8693e8dd83a0443d279bb0da5da22368d521b33372bbae699fcf1884b33ab5a50d8e9616274b849cee20f77fcce8a96c24a0eef23417dd4a2f6d
   languageName: node
   linkType: hard
 
@@ -10069,21 +10029,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/contact-center@npm:3.11.0-next.20":
-  version: 3.11.0-next.20
-  resolution: "@webex/contact-center@npm:3.11.0-next.20"
+"@webex/contact-center@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/contact-center@npm:3.12.0"
   dependencies:
     "@types/platform": "npm:1.3.4"
-    "@webex/calling": "npm:3.11.0-next.13"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-metrics": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-support": "npm:3.11.0-next.8"
-    "@webex/plugin-authorization": "npm:3.11.0-next.7"
-    "@webex/plugin-logger": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/calling": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/internal-plugin-metrics": "npm:3.12.0"
+    "@webex/internal-plugin-support": "npm:3.12.0"
+    "@webex/plugin-authorization": "npm:3.12.0"
+    "@webex/plugin-logger": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     jest-html-reporters: "npm:3.0.11"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/05c9c68e677eb4fd5acbfa34d37da569c300649f6ac42d08497c59c10cc7898fc33a65c32a6eb55caf64d72b2b9fccf969aa312eb90c53a39555a43877d75935
+  checksum: 10c0/3be1ce90a9fee76fb8146f4a1868d9ddd46f10b6d109ad36bffcc4cedc5fd7ac1e015244f9712ed14ff57228014a829196fe192a38628d81d34bcb1ac68578c1
   languageName: node
   linkType: hard
 
@@ -10105,19 +10065,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/event-dictionary-ts@npm:^1.0.1930":
-  version: 1.0.2091
-  resolution: "@webex/event-dictionary-ts@npm:1.0.2091"
-  dependencies:
-    amf-client-js: "npm:^5.2.6"
-    json-schema-to-typescript: "npm:^12.0.0"
-    minimist: "npm:^1.2.8"
-    shelljs: "npm:^0.8.5"
-    webapi-parser: "npm:^0.5.0"
-  checksum: 10c0/20d0983cebc323593d7a15c8dd26cb7c9d373b0d5e810d6dd818cbb891d42fba844c45fe859ceda810c9daf283fffe939fafcfe0b0068563d34c9731bf8e183e
-  languageName: node
-  linkType: hard
-
 "@webex/helper-html@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/helper-html@npm:2.60.4"
@@ -10127,21 +10074,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/helper-html@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/helper-html@npm:3.11.0"
-  dependencies:
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/f4ec20a68df69b00598b819c9b3d8ea38ff51fe4ad9cca1fa2a470d44caaf500aae322d98a4157504637fd0788ea5ba4032a1e4e1951a3ee576b826cddc44c3a
-  languageName: node
-  linkType: hard
-
 "@webex/helper-html@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/helper-html@npm:3.11.0-next.1"
   dependencies:
     lodash: "npm:^4.17.21"
   checksum: 10c0/e488f4c9563a5c1a649528b7fce01603199f39e7a1a19ed3ed9113251562019d4f69754e06dfea718e83890427838b12a9a4d829d8a26524012784da67416667
+  languageName: node
+  linkType: hard
+
+"@webex/helper-html@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/helper-html@npm:3.12.0"
+  dependencies:
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/e8fea6cde10b409b98cc1f95bb2f3df7fde279a99101c1a2e21e9dac06831de1d0bfe27179f53de8b5c660783b4fdbb22013a33a2798ce42384af6f9fa2ae603
   languageName: node
   linkType: hard
 
@@ -10162,23 +10109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/helper-image@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/helper-image@npm:3.11.0"
-  dependencies:
-    "@webex/http-core": "npm:3.11.0"
-    "@webex/test-helper-chai": "npm:3.11.0"
-    "@webex/test-helper-file": "npm:3.11.0"
-    "@webex/test-helper-mocha": "npm:3.11.0"
-    exifr: "npm:^5.0.3"
-    gm: "npm:^1.23.1"
-    lodash: "npm:^4.17.21"
-    mime: "npm:^2.4.4"
-    safe-buffer: "npm:^5.2.0"
-  checksum: 10c0/2e5ca54d47899764f596efccea5d0e9d2a900fffcbada22cbfaac69b3ca45b7bbe7bb0de895e926b8513b47de473dcf68ac19761ee598bf215b74de23eb1f2a5
-  languageName: node
-  linkType: hard
-
 "@webex/helper-image@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/helper-image@npm:3.11.0-next.1"
@@ -10193,6 +10123,23 @@ __metadata:
     mime: "npm:^2.4.4"
     safe-buffer: "npm:^5.2.0"
   checksum: 10c0/4d36319dde64ddcaa1e1897597cd0bd92dc685e5ba15fa9102b993ee3a8b414be60b89a7c5fa7708b698aca925652487956660a459b37509112f479e1755c87c
+  languageName: node
+  linkType: hard
+
+"@webex/helper-image@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/helper-image@npm:3.12.0"
+  dependencies:
+    "@webex/http-core": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-file": "npm:3.12.0"
+    "@webex/test-helper-mocha": "npm:3.12.0"
+    exifr: "npm:^5.0.3"
+    gm: "npm:^1.23.1"
+    lodash: "npm:^4.17.21"
+    mime: "npm:^2.4.4"
+    safe-buffer: "npm:^5.2.0"
+  checksum: 10c0/9eb22b6b725430c580fa25790f359b6c6dd4277984c782f33e56bd84d8c4dfb248d7f9393484d98f8e757a2eab12e840961bbccc9cecbc6638d8f015efe16617
   languageName: node
   linkType: hard
 
@@ -10237,24 +10184,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/http-core@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/http-core@npm:3.11.0"
-  dependencies:
-    "@webex/common": "npm:3.11.0"
-    file-type: "npm:^16.0.1"
-    global: "npm:^4.4.0"
-    is-function: "npm:^1.0.1"
-    lodash: "npm:^4.17.21"
-    parse-headers: "npm:^2.0.2"
-    qs: "npm:^6.7.3"
-    request: "npm:^2.88.0"
-    safe-buffer: "npm:^5.2.0"
-    xtend: "npm:^4.0.2"
-  checksum: 10c0/fe9ed0a9cc2906fbd39955fe51f01ba0729995e98acb08a5237c72ecc06ef419e4fe659570e8273cf852ba571268f5f9e30ed9bd8174fe5f5067f689b3fd149f
-  languageName: node
-  linkType: hard
-
 "@webex/http-core@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/http-core@npm:3.11.0-next.1"
@@ -10270,6 +10199,24 @@ __metadata:
     safe-buffer: "npm:^5.2.0"
     xtend: "npm:^4.0.2"
   checksum: 10c0/680949253ab28572cad13f72f214de12d406e3d9897980713cd9ed037198c2be23f4409e6a89af5ae58fdda30d0ee1a9b726ac9c9156d7467c3aa3325ad41ff1
+  languageName: node
+  linkType: hard
+
+"@webex/http-core@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/http-core@npm:3.12.0"
+  dependencies:
+    "@webex/common": "npm:3.12.0"
+    file-type: "npm:^16.0.1"
+    global: "npm:^4.4.0"
+    is-function: "npm:^1.0.1"
+    lodash: "npm:^4.17.21"
+    parse-headers: "npm:^2.0.2"
+    qs: "npm:^6.7.3"
+    request: "npm:^2.88.0"
+    safe-buffer: "npm:^5.2.0"
+    xtend: "npm:^4.0.2"
+  checksum: 10c0/eb4e168d660b6898aae8cb121036e1120a045363fcd21aeb7452bff38a581c6c55ddbd8b006c1ee0619f311847c0e016225b2a33361d1a941bc1ddb8210beefc
   languageName: node
   linkType: hard
 
@@ -10290,23 +10237,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-media-core@npm:2.22.1":
-  version: 2.22.1
-  resolution: "@webex/internal-media-core@npm:2.22.1"
+"@webex/internal-media-core@npm:2.23.1":
+  version: 2.23.1
+  resolution: "@webex/internal-media-core@npm:2.23.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@babel/runtime-corejs2": "npm:^7.25.0"
     "@webex/rtcstats": "npm:^1.5.5"
     "@webex/ts-sdp": "npm:1.8.2"
-    "@webex/web-capabilities": "npm:^1.9.0"
-    "@webex/web-client-media-engine": "npm:3.37.1"
+    "@webex/web-capabilities": "npm:^1.10.0"
+    "@webex/web-client-media-engine": "npm:3.39.1"
     events: "npm:^3.3.0"
     ip-anonymize: "npm:^0.1.0"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
-  checksum: 10c0/2f1b0e1d5219063da3c458c9bb37a3f601850ab92893c12fdb0c78c6c721ce9ad7dbe4e5b67177fbd6ca29ebda0b36f3685c8ac58ace32597540a70832f5003d
+  checksum: 10c0/cd977c3ef4c04ac1aa8a8544fc96a4b30b64c58651dfa07c152499699f33d312ead7385e44d59aaf5a97b24834b934d9ec1776d3b806650c2ce10992515a6f65
   languageName: node
   linkType: hard
 
@@ -10344,17 +10291,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-calendar@npm:3.11.0-next.9":
-  version: 3.11.0-next.9
-  resolution: "@webex/internal-plugin-calendar@npm:3.11.0-next.9"
+"@webex/internal-plugin-calendar@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-calendar@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-encryption": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-encryption": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/2869d0478afcd3ed9f3b1b703b14497ad24aec52bca5bd1077c62d921cdce4886c5e50532b3c9282d4e5aed022df2453ba21692bc16d5e3c77134166575ea0ba
+  checksum: 10c0/e7e9c94c671d084653d9185548bcb12fbfe2861b98785210cb345d468c197c85898acc9482b8f14b1ea57f7666baacec735f57e3bf4b8f19acacaa7e70b3687a
   languageName: node
   linkType: hard
 
@@ -10376,39 +10323,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-conversation@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-conversation@npm:3.11.0"
+"@webex/internal-plugin-conversation@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-conversation@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/helper-html": "npm:3.11.0"
-    "@webex/helper-image": "npm:3.11.0"
-    "@webex/internal-plugin-encryption": "npm:3.11.0"
-    "@webex/internal-plugin-user": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/helper-html": "npm:3.12.0"
+    "@webex/helper-image": "npm:3.12.0"
+    "@webex/internal-plugin-encryption": "npm:3.12.0"
+    "@webex/internal-plugin-user": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     crypto-js: "npm:^4.1.1"
     lodash: "npm:^4.17.21"
     node-scr: "npm:^0.3.0"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/93134422c3d5ee1f5e5dde3c2f891d964dab7e8c96f108ffd5c3d692082149bfeee586ca4efe9601a2d3ad5bb4656f221c7d77dcca7d81e9948042947fdff547
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-conversation@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-conversation@npm:3.11.0-next.8"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/helper-html": "npm:3.11.0-next.1"
-    "@webex/helper-image": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-encryption": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-user": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    crypto-js: "npm:^4.1.1"
-    lodash: "npm:^4.17.21"
-    node-scr: "npm:^0.3.0"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/474641ebc4b5a228d28573da985f4e52ea99fe1b718b0f80c13aa25fbf96708b190a666f020ed17f4034c934fd594b972f5b279bce5fdf3a17cbd0058b3bff98
+  checksum: 10c0/13f4592599ebbcf994431258f8d330d0b9472943e17d7ece14428abd45c521c2ad375e4c649d1ca3c4c719497c3e4b054421e6d39d62bbfd99ec0d994f7fafb1
   languageName: node
   linkType: hard
 
@@ -10446,37 +10375,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-device@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-device@npm:3.11.0"
+"@webex/internal-plugin-device@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-device@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/common-timers": "npm:3.11.0"
-    "@webex/http-core": "npm:3.11.0"
-    "@webex/internal-plugin-metrics": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/common-timers": "npm:3.12.0"
+    "@webex/http-core": "npm:3.12.0"
+    "@webex/internal-plugin-metrics": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     ampersand-collection: "npm:^2.0.2"
     ampersand-state: "npm:^5.0.3"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/ebb7111daeccc136fa7f95e56b823696e2a73fef095a6117dc33e5f112b6d2a25080d7f1f8606148e1084214af575fa9b2496907ce33240dce8be1024685ccc6
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-device@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/internal-plugin-device@npm:3.11.0-next.7"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/http-core": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-metrics": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    ampersand-collection: "npm:^2.0.2"
-    ampersand-state: "npm:^5.0.3"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/7afca9901a424553be74fc0899da05afc07d302bd328e67e5d5e3812e8abe8a33dd510a799238c0b1a99a2ba3c03d5d10bf4a77bb337563ecab9dfe8b82ddccc
+  checksum: 10c0/1469ca57dc65b885679179d52908f273248140e8e06247817749d5db951cd690348ad5d4549de64554d4c155e6f522d5555f695395596d767c8f6bd7128ff35c
   languageName: node
   linkType: hard
 
@@ -10497,17 +10409,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-dss@npm:3.11.0-next.9":
-  version: 3.11.0-next.9
-  resolution: "@webex/internal-plugin-dss@npm:3.11.0-next.9"
+"@webex/internal-plugin-dss@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-dss@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/common-timers": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/8918c52184a09f01504efb52dd1a07f1ae9746b2922d8b021d84c23a4c30d8bedf75e281b3b4447508b2c164e3e3ecccadae4c22506c43aed52886dd018ef75b
+  checksum: 10c0/2dd6346122e08332beed5ca37f5a515c2dc6fa88ef39fa9b79bb34e322d11fae90c28f1d2938f68d52fbe1b9f0cc894650e7ef065a1d74a40fe833ce9537ee48
   languageName: node
   linkType: hard
 
@@ -10537,17 +10449,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-encryption@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-encryption@npm:3.11.0"
+"@webex/internal-plugin-encryption@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-encryption@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/common-timers": "npm:3.11.0"
-    "@webex/http-core": "npm:3.11.0"
-    "@webex/internal-plugin-device": "npm:3.11.0"
-    "@webex/internal-plugin-mercury": "npm:3.11.0"
-    "@webex/test-helper-file": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/common-timers": "npm:3.12.0"
+    "@webex/http-core": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/test-helper-file": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     asn1js: "npm:^2.0.26"
     debug: "npm:^4.3.4"
     isomorphic-webcrypto: "npm:^2.3.8"
@@ -10559,33 +10471,7 @@ __metadata:
     safe-buffer: "npm:^5.2.0"
     uuid: "npm:^3.3.2"
     valid-url: "npm:^1.0.9"
-  checksum: 10c0/95a99e78be5bef4ea50175e88c88c471197846a7a232ed173105e550e5815b54dd9976d2e6166a3be76f7a687cbecae5756e5d7910b0526f2220287edaa342b3
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-encryption@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-encryption@npm:3.11.0-next.8"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/http-core": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/test-helper-file": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    asn1js: "npm:^2.0.26"
-    debug: "npm:^4.3.4"
-    isomorphic-webcrypto: "npm:^2.3.8"
-    lodash: "npm:^4.17.21"
-    node-jose: "npm:^2.2.0"
-    node-kms: "npm:^0.4.1"
-    node-scr: "npm:^0.3.0"
-    pkijs: "npm:^2.1.84"
-    safe-buffer: "npm:^5.2.0"
-    uuid: "npm:^3.3.2"
-    valid-url: "npm:^1.0.9"
-  checksum: 10c0/cd055861a03c55af3112388e116d8a1246e85ee1587ad49ef34a03954c809b42c8f1c0ab6da14b408e9252d42b93d635438985e29b4d68f448ff685003bf7765
+  checksum: 10c0/b9731753b49b6515f0fffffdce1c074bbc219e668199867e56f5dca45d6328390227f5b2498c75fa5fdc07e4179fee007c527203d7e9e160d55ac9e67f4b2d16
   languageName: node
   linkType: hard
 
@@ -10627,25 +10513,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-feature@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-feature@npm:3.11.0"
+"@webex/internal-plugin-feature@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-feature@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/5f2a7dd01f8340268b5e1711051731bf2a57fe59c6859c9f174282cfe277a0b1e2a0651599741a17526d09140aecd94eb48317d575cc5a6d117e1666254ccf29
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-feature@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/internal-plugin-feature@npm:3.11.0-next.7"
-  dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/72fb7d931e74d9140b52cd72329e2d3f7aaec7a56bd0cf41ca86f967823b9bb2cfc8e60aee4aa1c29e51f78f61594683622e6bf0d1ba1dab063d365513ce40ba
+  checksum: 10c0/47aa60b505cd2a0a19787d8aa21bce237def8a5bff969e6c5672da6e8506d87a5e3f1b0c18a21111a1549cfcea5aaba1ba6df3e34fc95b286d1acff57de8f715
   languageName: node
   linkType: hard
 
@@ -10660,12 +10535,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-llm@npm:3.11.0-next.9":
-  version: 3.11.0-next.9
-  resolution: "@webex/internal-plugin-llm@npm:3.11.0-next.9"
+"@webex/internal-plugin-llm@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-llm@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-  checksum: 10c0/1c8cad820ff98b5b1964830ed38a30c6f7ad27597ec391f52bc46dae1f0a48e185ad0aa35ceb55e775fec2d16633b2dc709ceb40e56c60475bf926e7ac989776
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+  checksum: 10c0/0272bdb0fb93d87f7c09a1cb3bf8b50488f2b26ae65aad0fec17e09a3bb77265c1893489856ecc1b643d4001c9e503248c313ecb5a0fb7e5a8bb912e36317af2
   languageName: node
   linkType: hard
 
@@ -10683,17 +10558,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-locus@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-locus@npm:3.11.0-next.8"
+"@webex/internal-plugin-locus@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-locus@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/efecb81cf7405bf18181fcdb4bea1b63a5df20443fa70478867118dce640396f455c9c37eb2b17d741edd2f2cfd2b8f43e971b47dc5adc816098a8155dc34566
+  checksum: 10c0/e4aea8b2d832228d0d0517457933418dcb180435e45cce186eba8985316fae57dceea129616ec0bca3b8c710e0167d071f08d2319e71e3f058b4f689f8e4cb4c
   languageName: node
   linkType: hard
 
@@ -10714,20 +10589,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-lyra@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-lyra@npm:3.11.0-next.8"
+"@webex/internal-plugin-lyra@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-lyra@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-encryption": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-feature": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-locus": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-encryption": "npm:3.12.0"
+    "@webex/internal-plugin-feature": "npm:3.12.0"
+    "@webex/internal-plugin-locus": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     bowser: "npm:^2.11.0"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/5a6d956ebf8a9780c81ace7abefb2acce5b32c718bfb45901261634b941a6ee65e3659fe214a6d8f9234d0d2675bfb83f4fac93c5866c0e4f41c2dc0f73f57ae
+  checksum: 10c0/44c2268db6f6812639858f47421ef6504dc5eb6c1fbbdaa7888decd11fd37f9066b60452c4fa9a79ca8148854a8a264ece9440059dc9e96e1fcf2aea36ef9901
   languageName: node
   linkType: hard
 
@@ -10755,51 +10630,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-mercury@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-mercury@npm:3.11.0"
+"@webex/internal-plugin-mercury@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-mercury@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/common-timers": "npm:3.11.0"
-    "@webex/internal-plugin-device": "npm:3.11.0"
-    "@webex/internal-plugin-feature": "npm:3.11.0"
-    "@webex/internal-plugin-metrics": "npm:3.11.0"
-    "@webex/test-helper-chai": "npm:3.11.0"
-    "@webex/test-helper-mocha": "npm:3.11.0"
-    "@webex/test-helper-mock-web-socket": "npm:3.11.0"
-    "@webex/test-helper-mock-webex": "npm:3.11.0"
-    "@webex/test-helper-refresh-callback": "npm:3.11.0"
-    "@webex/test-helper-test-users": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/common-timers": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-feature": "npm:3.12.0"
+    "@webex/internal-plugin-metrics": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-mocha": "npm:3.12.0"
+    "@webex/test-helper-mock-web-socket": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/test-helper-refresh-callback": "npm:3.12.0"
+    "@webex/test-helper-test-users": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     backoff: "npm:^2.5.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     ws: "npm:^8.17.1"
-  checksum: 10c0/acde061737fea32b1c89f0ab58ed6de8af6c2aa126c3c225886822aad30ca485511a6f3498ec29a358bdc84a7ce797a65f3ee6974f2e463ab65bb095ad232e2f
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-mercury@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-mercury@npm:3.11.0-next.8"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-feature": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-metrics": "npm:3.11.0-next.7"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-web-socket": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-refresh-callback": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    backoff: "npm:^2.5.0"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-    ws: "npm:^8.17.1"
-  checksum: 10c0/66cce605dc9d148c8ab144a4a4ad8e7d41bcb986c02eb46d99b8ecf880164383833d99321560e3f792340427b249b6bc75743b47030f68de5e8519074f0165a8
+  checksum: 10c0/8911540034b9800dcbd8d23fe618f646d569b064ff1cd59d0680536489df51c1afc4bef4f39826234bed3872133e4d966cde8bee60cc9d6de901b09ebfbf81ef
   languageName: node
   linkType: hard
 
@@ -10840,36 +10691,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-metrics@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-metrics@npm:3.11.0"
+"@webex/internal-plugin-metrics@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-metrics@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/common-timers": "npm:3.11.0"
-    "@webex/event-dictionary-ts": "npm:^1.0.1930"
-    "@webex/test-helper-chai": "npm:3.11.0"
-    "@webex/test-helper-mock-webex": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/common-timers": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     ip-anonymize: "npm:^0.1.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/b75aceb55081ddc54a66f0810e259bacec8e9512aa27cb76ced95393356230de4c19c461e7ed08a10885c74e613377fa57a3df57daaa0d18789e8cd8f2221b14
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-metrics@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/internal-plugin-metrics@npm:3.11.0-next.7"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    ip-anonymize: "npm:^0.1.0"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/ac19f4baadfce385c9c3e10e309bc84bd6792a6f651fab10026894e754cb330824cb3b07397d3f5ceb6d89a6b9a5eef37571c8182267e3ed366e48a307f40c52
+  checksum: 10c0/3e90dad77d0d9eecb2e933a90736b3f460232a86d4ddc0eec2a0750d87412c6f4ec74e89ec6b0089fd99f263dc36d91f1177c58e6ff1b0c8e7faaabbf1129e68
   languageName: node
   linkType: hard
 
@@ -10905,19 +10739,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-presence@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-presence@npm:3.11.0-next.8"
+"@webex/internal-plugin-presence@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-presence@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-mocha": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/test-helper-test-users": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/3bcc97bce842e95373d874652dd0a50ae827eac2677f5a3ba191290d6af26c65781dc9b3be015a37454593dbe9891f565051aff072828f55884d33e78fd4fab9
+  checksum: 10c0/9b457c4f045404c24f102c4fe8b0815c7c117c9d4632baa197e745323606d6da04128bc2c5aef6d340842059ceb88c42223db4659830a920a72613f61ca1ff56
   languageName: node
   linkType: hard
 
@@ -10936,18 +10770,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-search@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-search@npm:3.11.0-next.8"
+"@webex/internal-plugin-search@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-search@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-encryption": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-encryption": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/d8052a91c45dcbca907f34fa52f5453c20ca9a0fcad0231bcfe8e0810f5640a33749f0f921bc986535db5cedec380583977fcac10d859a0d789db181d4ece03f
+  checksum: 10c0/89e3adfd003c76e324969b13df1b074e19c029582f70463383b72b3887bddbe93e2cc6095b0cf7074e66eccebfe506c76d8e120ecb50ff80d0b5a30078d5ab7e
   languageName: node
   linkType: hard
 
@@ -10983,20 +10817,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-support@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/internal-plugin-support@npm:3.11.0-next.8"
+"@webex/internal-plugin-support@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-support@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-search": "npm:3.11.0-next.8"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-file": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-search": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-file": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/test-helper-test-users": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/8941e8d7534cd57b4dae28f4bbd399b273e7bae6833d7f489c7ebd1cdcbbb8a2957728cdb01f1cd2c651bb65f5df4fa91a658d75fd4226de95e944aa4c5b43e8
+  checksum: 10c0/90d1bdd89881506a305bf96ddfe261a64640760a3939cbe6d04e5f79df827e2cea769c92773790f8ad0cf5c077ec5fbb18c76131ebd7193bac8f2f15517271ba
   languageName: node
   linkType: hard
 
@@ -11017,17 +10851,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-task@npm:^3.11.0-next.8":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-task@npm:3.11.0"
+"@webex/internal-plugin-task@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-task@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-conversation": "npm:3.11.0"
-    "@webex/internal-plugin-device": "npm:3.11.0"
-    "@webex/internal-plugin-encryption": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-encryption": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/90eac51484c92c579dc8119d6fb7b8cddb5562b1b3826bc0c17dc9a58de07c4d8351fff1087c9cd1c3c918f7305a83c2ca19e26b878489f534b3edf2e8089cbb
+  checksum: 10c0/9658d286ce667766aaaf0c8e53f37d28085643d9fcfcf81f1157f85dcdb33ddae882965fadd446f63812cea8a919a425adc04f57c799bc8747d1f0b89bc9c470
   languageName: node
   linkType: hard
 
@@ -11047,35 +10881,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-user@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/internal-plugin-user@npm:3.11.0"
+"@webex/internal-plugin-user@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-user@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/internal-plugin-device": "npm:3.11.0"
-    "@webex/test-helper-chai": "npm:3.11.0"
-    "@webex/test-helper-mock-webex": "npm:3.11.0"
-    "@webex/test-helper-test-users": "npm:3.11.0"
-    "@webex/webex-core": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/test-helper-test-users": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/d831fc1bd0098487800996274642d828ac81dba71fda52868aeefeec8aaccecba72a6d7f57b55d012e678e2f681f37994b3f5b3c27591d09b7ec1056d5400fe7
-  languageName: node
-  linkType: hard
-
-"@webex/internal-plugin-user@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/internal-plugin-user@npm:3.11.0-next.7"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/test-helper-test-users": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/5234090867b33924c4cafd827f60c06445a1ab0c7a6308a9aac0b1b70dec8e92eff260abdd04cb159d3fd415a52680a37c7456c6c9791587ac0be52612dccd2b
+  checksum: 10c0/93a85e67d863537d22d5a0df76007f093407045f4eea76d4b56ee8abf5abfa739b511773ae9993eb6230d7098a6829203a8f56b553fd2106ce8e410f239d51be
   languageName: node
   linkType: hard
 
@@ -11095,15 +10913,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-voicea@npm:3.11.0-next.9":
-  version: 3.11.0-next.9
-  resolution: "@webex/internal-plugin-voicea@npm:3.11.0-next.9"
+"@webex/internal-plugin-voicea@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/internal-plugin-voicea@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-llm": "npm:3.11.0-next.9"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-llm": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/895f7eefc03c35eecbe55fd239bd3fc13697fd4fcf61f74a1b218943f705bb3a10a17fe507aa9b138e46927d427eed5364fe76580f8caf25e73586a2d2f84fd7
+  checksum: 10c0/639eb23255ddcfc3f14b48a99e587b545abc7dbf488f1079b4e9ba76ff07aef66777ff35d6cf90f67920b646abcf8ecc0a7d0fdcf177dab818697c4257fec872
   languageName: node
   linkType: hard
 
@@ -11127,14 +10945,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/media-helpers@npm:3.11.0-next.3":
-  version: 3.11.0-next.3
-  resolution: "@webex/media-helpers@npm:3.11.0-next.3"
+"@webex/media-helpers@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/media-helpers@npm:3.12.0"
   dependencies:
-    "@webex/internal-media-core": "npm:2.22.1"
+    "@webex/internal-media-core": "npm:2.23.1"
     "@webex/ts-events": "npm:^1.1.0"
     "@webex/web-media-effects": "npm:2.33.0"
-  checksum: 10c0/c213b7ecbefd29d7d9f597748a146729ed4a75c28b1d11ed6c93f3dca4c751095587de131dc153c85d1b954b61463d379408ea27b09622ee8b93b9c6c253fc2a
+  checksum: 10c0/494d1f55a798cbb5f8b16d0b4a1c236255e0e8717c98dba931487c79a75c1b2d2b453a1d56136193138220c758be3b71c4cee5c5326c3706f3ba4d6b69688dbf
   languageName: node
   linkType: hard
 
@@ -11179,21 +10997,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-attachment-actions@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/plugin-attachment-actions@npm:3.11.0-next.8"
+"@webex/plugin-attachment-actions@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-attachment-actions@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     debug: "npm:^4.3.4"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-messages": 3.11.0-next.8
-    "@webex/plugin-people": 3.11.0-next.8
-  checksum: 10c0/a4ca00c1db96897b29da5f5ead1713506a2986b634b9e50c06a70ef23caef2aaf3bf1ab7a5c1aa41041df3e1ad2af4b606d1d8b8e5c851f2e4b8df2357873cb9
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-messages": 3.12.0
+    "@webex/plugin-people": 3.12.0
+  checksum: 10c0/28237ee0a188b6b39f573785223dce1df49b2c6b5b70046a01509b6e7c96b32be5200d426085c2c172d53aa978debf4535ca81a05f3d2c359a0dac33f2af5c97
   languageName: node
   linkType: hard
 
@@ -11214,20 +11032,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization-browser@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-authorization-browser@npm:3.11.0-next.7"
+"@webex/plugin-authorization-browser@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-authorization-browser@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/plugin-authorization-node": "npm:3.11.0-next.7"
-    "@webex/storage-adapter-local-storage": "npm:3.11.0-next.7"
-    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/plugin-authorization-node": "npm:3.12.0"
+    "@webex/storage-adapter-local-storage": "npm:3.12.0"
+    "@webex/storage-adapter-spec": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     jsonwebtoken: "npm:^9.0.2"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/1e154c9037e6f7fe6657a451c89d9229ddb8d8b0005c859cc192425e54ac1031939d47e728528771f4c88ef86f9c47437ff0c26fab406cc6114628b2ce9a0896
+  checksum: 10c0/a42542f28e9dc22c80ab75ca8439ede1c8010d991fbf53a97f9056f3c71c63a69040560b614fc00a967bc1adb24891a45084a6337e69cc1fda10258b85e57f6b
   languageName: node
   linkType: hard
 
@@ -11261,16 +11079,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization-node@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-authorization-node@npm:3.11.0-next.7"
+"@webex/plugin-authorization-node@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-authorization-node@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     jsonwebtoken: "npm:^9.0.0"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/70559cc7f57aaf3667b13dd3135c144c3f020ca7a3c74c5cb934d7549ccb55d3b0ee7bffe2cea1b87aabb8a500360ab84ece4c29e99634bad0409c76bec33b78
+  checksum: 10c0/52b2a9bbd227f44cdde0ae6c6d6f353d8ed88473229cfdd0ee38033cd8a5634ebefbbbac0a77c42982adc28753732934eabeae4d531c2e360ffdb0becff98fac
   languageName: node
   linkType: hard
 
@@ -11297,13 +11115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-authorization@npm:3.11.0-next.7"
+"@webex/plugin-authorization@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-authorization@npm:3.12.0"
   dependencies:
-    "@webex/plugin-authorization-browser": "npm:3.11.0-next.7"
-    "@webex/plugin-authorization-node": "npm:3.11.0-next.7"
-  checksum: 10c0/552788e35a95d32f211b8fe0e3cc56b9f00cadba16b0cfab3eb157b85e431d7a0379aecf8afa2206cbed3a50fc34fd42726eaff4e0f5dc733ab9bc76e8071645
+    "@webex/plugin-authorization-browser": "npm:3.12.0"
+    "@webex/plugin-authorization-node": "npm:3.12.0"
+  checksum: 10c0/f6bdf318d4ba5bda7654f0aa782dfb39e9c269caf384eac1cfea7d1c124218416095bdd8ac602d6c58b9a30c150cd8ccc1896a871ba4903bdcd3f7d8ba3e6dd4
   languageName: node
   linkType: hard
 
@@ -11335,31 +11153,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-device-manager@npm:3.11.0-next.9":
-  version: 3.11.0-next.9
-  resolution: "@webex/plugin-device-manager@npm:3.11.0-next.9"
+"@webex/plugin-device-manager@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-device-manager@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-calendar": "npm:3.11.0-next.9"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-lyra": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-search": "npm:3.11.0-next.8"
-    "@webex/plugin-authorization": "npm:3.11.0-next.7"
-    "@webex/plugin-logger": "npm:3.11.0-next.7"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-calendar": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-lyra": "npm:3.12.0"
+    "@webex/internal-plugin-search": "npm:3.12.0"
+    "@webex/plugin-authorization": "npm:3.12.0"
+    "@webex/plugin-logger": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/aa54400740b65666727b61b94dad447ea24d6989380b2c4621b89c80c5838713b5b78fc30b73cfa6f5f3a348ae77c13c09715a6d7e9369f4be348c26c279e676
+  checksum: 10c0/935ba9a4469892a79cb44069365b12448a698e8e3abba10f5dc708d84fd572a8a99d12a4426974a3b4103c8ce663aa42ffd45ac6a0220e0ede08de1b9be34757
   languageName: node
   linkType: hard
 
-"@webex/plugin-encryption@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/plugin-encryption@npm:3.11.0-next.8"
+"@webex/plugin-encryption@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-encryption@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-encryption": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-  checksum: 10c0/4e35a37d2be026ad0522e774e6e4e5ba4ad301ec56526b12ea26527dcca3a5744628210e74b3bb48ca3f150e7568b05830f9b9afb15ad1d97cf3b8c9b6068d94
+    "@webex/internal-plugin-encryption": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
+  checksum: 10c0/7c1617239742374e4aaef11d325c3f29fe696f1e8a218baf0a78b5bb528092592359802191cbce60d83b34825ad08a74b1c4f94d5f73c98566c2f0451fab9fad
   languageName: node
   linkType: hard
 
@@ -11377,17 +11195,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-logger@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-logger@npm:3.11.0-next.7"
+"@webex/plugin-logger@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-logger@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/test-helper-chai": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/test-helper-mock-webex": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/test-helper-chai": "npm:3.12.0"
+    "@webex/test-helper-mocha": "npm:3.12.0"
+    "@webex/test-helper-mock-webex": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/ff4910c9a812ca39cb416f1229f3a9f603070fe8930389c32ba627a9a4f36c6ee646be6927b028fb3196da0db36b4fe587479cc4e293350bd4114230965c4a06
+  checksum: 10c0/86c159cf1dba346e12caa77958a05c7119f891c90658acbbbec5a5f101dd6cac263de3394059aff254facbcf62e4c7234c2671f0a64bb5b3e1409df1cfe7ca4a
   languageName: node
   linkType: hard
 
@@ -11432,26 +11250,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-meetings@npm:3.11.0-next.37":
-  version: 3.11.0-next.37
-  resolution: "@webex/plugin-meetings@npm:3.11.0-next.37"
+"@webex/plugin-meetings@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-meetings@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-media-core": "npm:2.22.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-llm": "npm:3.11.0-next.9"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-metrics": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-support": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-user": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-voicea": "npm:3.11.0-next.9"
-    "@webex/media-helpers": "npm:3.11.0-next.3"
-    "@webex/plugin-people": "npm:3.11.0-next.8"
-    "@webex/plugin-rooms": "npm:3.11.0-next.8"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-media-core": "npm:2.23.1"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-llm": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/internal-plugin-metrics": "npm:3.12.0"
+    "@webex/internal-plugin-support": "npm:3.12.0"
+    "@webex/internal-plugin-user": "npm:3.12.0"
+    "@webex/internal-plugin-voicea": "npm:3.12.0"
+    "@webex/media-helpers": "npm:3.12.0"
+    "@webex/plugin-people": "npm:3.12.0"
+    "@webex/plugin-rooms": "npm:3.12.0"
     "@webex/ts-sdp": "npm:^1.8.1"
-    "@webex/web-capabilities": "npm:^1.9.0"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/web-capabilities": "npm:^1.10.0"
+    "@webex/webex-core": "npm:3.12.0"
     ampersand-collection: "npm:^2.0.2"
     bowser: "npm:^2.11.0"
     btoa: "npm:^1.2.1"
@@ -11459,12 +11277,13 @@ __metadata:
     global: "npm:^4.4.0"
     ip-anonymize: "npm:^0.1.0"
     javascript-state-machine: "npm:^3.1.0"
+    jose: "npm:^5.8.0"
     jwt-decode: "npm:3.1.2"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     webrtc-adapter: "npm:^8.1.2"
     xxh3-ts: "npm:^2.0.1"
-  checksum: 10c0/18d5cb7000d5414a0ab26f389aa91d81bae0c647cf5e9b20ad459eaf73f63558d274959e7fa3b0aefea643448b8884f8aff6a8046dfd900af256630fd85e89c6
+  checksum: 10c0/b86869390ebe8028e03c8fad1512c46b7eca5d4a769002ab72fc2e091f8bb6b13827d974d63d93a75d4e10d4c21e42d5b729f8a786d541fdacd7c3b2ac2818df
   languageName: node
   linkType: hard
 
@@ -11486,22 +11305,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-memberships@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/plugin-memberships@npm:3.11.0-next.8"
+"@webex/plugin-memberships@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-memberships@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     debug: "npm:^4.3.4"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-messages": 3.11.0-next.8
-    "@webex/plugin-people": 3.11.0-next.8
-    "@webex/plugin-rooms": 3.11.0-next.8
-  checksum: 10c0/ab32c6268194b94c1f184893ab27ea2298310fe12b61ac176e78257584880dbf1dcb168dbf2d09e3140e22a3f9ce3cbaa00dc33944a1bee1717e2b463ebcb50b
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-messages": 3.12.0
+    "@webex/plugin-people": 3.12.0
+    "@webex/plugin-rooms": 3.12.0
+  checksum: 10c0/204b3013c45bca2d6d1ed520e1100a8f12068b9a00b1278e18b0f26863078ff0a3a0bdd64bf046c234af05e6bea612a57ec65a42394420c25cb77dfbb67c50d0
   languageName: node
   linkType: hard
 
@@ -11523,22 +11342,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-messages@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/plugin-messages@npm:3.11.0-next.8"
+"@webex/plugin-messages@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-messages@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     debug: "npm:^4.3.4"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-people": 3.11.0-next.8
-    "@webex/plugin-rooms": 3.11.0-next.8
-  checksum: 10c0/3891f22e7a514058c18f2f6ed0ea73a1d94b08f9ddf027d1e4263f4df2e71fad4ef41fcad29e2a46a20e17c30276b8649bdfaecb491e3f23e5872693d959214a
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-people": 3.12.0
+    "@webex/plugin-rooms": 3.12.0
+  checksum: 10c0/9b62fbca7faaf41556809f53b5b66367cf851ca0839ad62619e7d2b23b00b5b1ce30cfbfe21d4b87ea502662c12b010723ed613b35cc8b50a0d4a8ddb49fc04f
   languageName: node
   linkType: hard
 
@@ -11553,14 +11372,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-people@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/plugin-people@npm:3.11.0-next.8"
+"@webex/plugin-people@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-people@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-  checksum: 10c0/aa55642122821d4ea9e5f68bbdc504233ffdfb8f42af0e9df33cf8fd2cbb1cc20d93038663e43084a6e172889274af92de4d784b94a7bc1ca0ebc53bc0d8de98
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
+  checksum: 10c0/8dbca16b8f156ba2e730a027a4b84ed03b56b257390fe3a323f17e2f5db0fd0143a3a2583c33c9c0ac3aad40799ee6df73690b188aaaf354b3b5896fe2609917
   languageName: node
   linkType: hard
 
@@ -11582,20 +11401,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-rooms@npm:3.11.0-next.8":
-  version: 3.11.0-next.8
-  resolution: "@webex/plugin-rooms@npm:3.11.0-next.8"
+"@webex/plugin-rooms@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-rooms@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/internal-plugin-conversation": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/common": "npm:3.12.0"
+    "@webex/internal-plugin-conversation": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     debug: "npm:^4.3.4"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-people": 3.11.0-next.8
-  checksum: 10c0/8176113f6fd324fb98c39fa9a05ff40d2f4717690ed6e028d19ca87d3e77ad32da764b361ee4c6bcfef10c32fa893bb2c384736c3e198005428a58253b538c73
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-people": 3.12.0
+  checksum: 10c0/3420446a7bcede5bc357b6e6cfa8fa46ef9772a37cbddd3f9ce7853c96f740b227b8d39479fcbdf3bd4f04fdc61c90e9666815b5b78cc5a2b0844d266505d85d
   languageName: node
   linkType: hard
 
@@ -11612,17 +11431,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-team-memberships@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-team-memberships@npm:3.11.0-next.7"
+"@webex/plugin-team-memberships@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-team-memberships@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-rooms": 3.11.0-next.8
-    "@webex/plugin-teams": 3.11.0-next.7
-  checksum: 10c0/5a30b4d8d5cf0e5848f2757c1eec4befdcf32d63252e19ace75d89c3b19006dee645b0180bd1f19da69962e0eb143c15e00a4b524b5cd855313f12012c2fdade
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-rooms": 3.12.0
+    "@webex/plugin-teams": 3.12.0
+  checksum: 10c0/4ab06b80ccdc8316031adf3e283fe2020a9a20c714c48e90aee6875a0bddf019d298f2d02a82cb525523efc77cca55a69b601c8b4d6e198bf4027e8cd2d81bf6
   languageName: node
   linkType: hard
 
@@ -11642,18 +11461,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-teams@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-teams@npm:3.11.0-next.7"
+"@webex/plugin-teams@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-teams@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-memberships": 3.11.0-next.8
-    "@webex/plugin-rooms": 3.11.0-next.8
-  checksum: 10c0/10abe2da2db8d596cb93107578cfce7ffa2e358e8e8a46c94ffecc34600b9735880276402aff76190ae5344860a96ffa768d361aafd036af94aea1453a2f2039
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-memberships": 3.12.0
+    "@webex/plugin-rooms": 3.12.0
+  checksum: 10c0/10186f7e3d978cd6dbe28f61fa73f250f90a04ea956f1e7a7671f0d163efef46060ef17e31beb032a1aea22e8f4745d8499851839a5b5d8d25cd863ff4ee8c7b
   languageName: node
   linkType: hard
 
@@ -11669,16 +11488,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-webhooks@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/plugin-webhooks@npm:3.11.0-next.7"
+"@webex/plugin-webhooks@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/plugin-webhooks@npm:3.12.0"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
   peerDependencies:
-    "@webex/plugin-logger": 3.11.0-next.7
-    "@webex/plugin-rooms": 3.11.0-next.8
-  checksum: 10c0/f4cd42378e81fffb94e1d82fcde289fe22a9e9fee5f6874a9c5cfe067a90c2b809b857b6faddc788adabe5133d174fd0d61e94abb3e9e05d441c0db0becc38f7
+    "@webex/plugin-logger": 3.12.0
+    "@webex/plugin-rooms": 3.12.0
+  checksum: 10c0/dbf474221e9490e5e507553c4739f64a446a6df335a372d75943a2c96d17843c276044d93bee5fe01b047760a134b2c9c830f8624926e5a086e0282bd73376ed
   languageName: node
   linkType: hard
 
@@ -11718,14 +11537,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/storage-adapter-local-storage@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/storage-adapter-local-storage@npm:3.11.0-next.7"
+"@webex/storage-adapter-local-storage@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/storage-adapter-local-storage@npm:3.12.0"
   dependencies:
-    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
-    "@webex/test-helper-mocha": "npm:3.11.0-next.1"
-    "@webex/webex-core": "npm:3.11.0-next.7"
-  checksum: 10c0/a01b799506f77c4d9319e82ebbb8175c6c02feba45756e0372543579849ad898ff6950981a2a749ef6caa7dca4788e64e93d74d3e5ff5bf3aee4b8bc71de854c
+    "@webex/storage-adapter-spec": "npm:3.12.0"
+    "@webex/test-helper-mocha": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
+  checksum: 10c0/7461f7b2ff96aed1e0b291b1e5da4a2d36e4bb09b2dfc963bbeb936f22b93fe60f65da6c22118bfee9f1dadc3eea152620de0814c214420a738272c828d4f8d5
   languageName: node
   linkType: hard
 
@@ -11749,21 +11568,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/storage-adapter-spec@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/storage-adapter-spec@npm:3.11.0"
-  dependencies:
-    "@webex/test-helper-chai": "npm:3.11.0"
-  checksum: 10c0/57e30fea905d9a6fc5d8667765abfc3ce517f8ae67b7f1508c64930ff512ffe1b9102b9432d1ec5e5adcb8ef966967906050ea22d30a502837259c4f569657c5
-  languageName: node
-  linkType: hard
-
 "@webex/storage-adapter-spec@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/storage-adapter-spec@npm:3.11.0-next.1"
   dependencies:
     "@webex/test-helper-chai": "npm:3.11.0-next.1"
   checksum: 10c0/c3cce1146cecde45a72d8613da7ec12ea1f70444c75f0d1cbdaf2552e0946694527ceb1e5087e12933130cbbe6ccfe3eda43b20a8c54fda20232f9c8da661409
+  languageName: node
+  linkType: hard
+
+"@webex/storage-adapter-spec@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/storage-adapter-spec@npm:3.12.0"
+  dependencies:
+    "@webex/test-helper-chai": "npm:3.12.0"
+  checksum: 10c0/7ec7649da02a94ab72531f95e3b78dfb0ca3ba6deb7005f817be1cd8f97122c7b64707d8258d27428f90d78b43a908db86cb888bb70aa4cfab10cf6f7f0caba8
   languageName: node
   linkType: hard
 
@@ -11809,17 +11628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-chai@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-chai@npm:3.11.0"
-  dependencies:
-    "@webex/test-helper-file": "npm:3.11.0"
-    check-error: "npm:^1.0.2"
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/cb8738d29b17660a7beaef42e611368a35a589c41bce5b8a00ea4891be637b1a6d3b807a0d077bdbf76d1cfa40d0102382424da8376d835a0d8ba953b89ea451
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-chai@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-chai@npm:3.11.0-next.1"
@@ -11828,6 +11636,17 @@ __metadata:
     check-error: "npm:^1.0.2"
     lodash: "npm:^4.17.21"
   checksum: 10c0/828a58cadc513ba07d64059bf9f81409c3427f3bf17beb304e16c5cdede6caa0ac512db91df7571299e60b7568a45db4cddd0726803bb9b764626a3d40246a2c
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-chai@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-chai@npm:3.12.0"
+  dependencies:
+    "@webex/test-helper-file": "npm:3.12.0"
+    check-error: "npm:^1.0.2"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/c23ab7b504b631f4e706c1116d02f8ec086d23e7238ed4ea6faa2f4848051fc63d09977cb79e240231b9d71795a0e2c6b7f643acca9fcd06ff987f5016033e0c
   languageName: node
   linkType: hard
 
@@ -11844,19 +11663,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-file@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-file@npm:3.11.0"
-  dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/test-helper-make-local-url": "npm:3.11.0"
-    es6-promise: "npm:^4.2.8"
-    file-type: "npm:^16.0.1"
-    xhr: "npm:^2.5.0"
-  checksum: 10c0/b86eea14bd2076eb59c271020fa2d932bbdf5307ab1a03e0d4c08f03b3ad1b5dbcdd02ef32e948fa7fff35b591b6f84fa34b4e15798c54f52c1f7f2a62fc66be
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-file@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-file@npm:3.11.0-next.1"
@@ -11870,6 +11676,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/test-helper-file@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-file@npm:3.12.0"
+  dependencies:
+    "@webex/common": "npm:3.12.0"
+    "@webex/test-helper-make-local-url": "npm:3.12.0"
+    es6-promise: "npm:^4.2.8"
+    file-type: "npm:^16.0.1"
+    xhr: "npm:^2.5.0"
+  checksum: 10c0/4b5f7386a79aa398259f2f4d5074527a4d7b6d75e62b1e07fadfa0b4fd3362e2230a00767e80f55b3a3cd417e0d7d6a56627849be81a4f18f6d0bcbb2152e1f2
+  languageName: node
+  linkType: hard
+
 "@webex/test-helper-make-local-url@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/test-helper-make-local-url@npm:2.60.4"
@@ -11877,17 +11696,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-make-local-url@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-make-local-url@npm:3.11.0"
-  checksum: 10c0/c55a834341e12a24f52e92586a6a30d8c1e895f89964592cc630d96299cd694e9427aa399cada4102f4165468fb6d94007f5288bae4f42dfd4bad59f70335ad1
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-make-local-url@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-make-local-url@npm:3.11.0-next.1"
   checksum: 10c0/55ed4222e529600ef143664a644e1683818f3c5fe11e6b3d8da4c3b729560cfc959b035d6bf40a3e0f6ee55540ce249af210bc87688bec95bd6e989579f73311
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-make-local-url@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-make-local-url@npm:3.12.0"
+  checksum: 10c0/169bdce1b75c66d47c5dfae3b0ea33c1947142690e6a9bb15f12786669b29a389e91113ebc355e36ddf0673416544bf561b29ec4adf39eb8e117f6d9a01cb6e9
   languageName: node
   linkType: hard
 
@@ -11900,21 +11719,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-mocha@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-mocha@npm:3.11.0"
-  dependencies:
-    bowser: "npm:^2.11.0"
-  checksum: 10c0/4e762a6b1d8d89aca37b5080b18a9af7b2b02a85f300738a79da6b5a25961ce64a549bf42360ef036b3621916ba117c03dc60836818935ce4a6cb481425c0e7f
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-mocha@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-mocha@npm:3.11.0-next.1"
   dependencies:
     bowser: "npm:^2.11.0"
   checksum: 10c0/53107ae53088602941a66e1c076d74e9a658db9f08723227d70974d49a3ae914c51bb1bf76205dd2166e0312a0a564b203d0583575801c5af6b13f4e5b2f8907
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-mocha@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-mocha@npm:3.12.0"
+  dependencies:
+    bowser: "npm:^2.11.0"
+  checksum: 10c0/840ba0f639d582ab80435900205358c65c34e658b197f9eedd983ca99d02893d5a620d591ac832c890c05bdf795ce7205aef6feea763df72454bfcb82b302815
   languageName: node
   linkType: hard
 
@@ -11925,17 +11744,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-mock-web-socket@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-mock-web-socket@npm:3.11.0"
-  checksum: 10c0/3b58c53ea4a249f6e4b726de09be928fba3c33d271e867dd2b4aef40be8788dd7a7f6111189605eda11018beabd38367eee77687b1eca98cec99ae79eba5f406
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-mock-web-socket@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-mock-web-socket@npm:3.11.0-next.1"
   checksum: 10c0/a5d052a134e6bc264cf9faba9c88e35ee9d0405b9e283459a023d70a361d08348cfb8db315cc1119b35c7d7a628d830aec17e1b1c20cb9e5525a56d7a9f95537
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-mock-web-socket@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-mock-web-socket@npm:3.12.0"
+  checksum: 10c0/c806f7431db295e09128f551f692dd289650899c8e47955ba6db002566c70ed63f8abec60d808f0a590752deed19242f6945b9bf0e0b731d07001826d7c9e5ea
   languageName: node
   linkType: hard
 
@@ -11950,17 +11769,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-mock-webex@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-mock-webex@npm:3.11.0"
-  dependencies:
-    ampersand-state: "npm:^5.0.3"
-    es6-promise: "npm:^4.2.8"
-    lodash: "npm:^4.17.21"
-  checksum: 10c0/0c439642d9aede7361437703378056ad677df07a93f60aab7d8bfef5845cc034afccde2a918d42d6cf47470b281c4448d6cd60db888f2ca28631d6c7a5baf8c8
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-mock-webex@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-mock-webex@npm:3.11.0-next.1"
@@ -11972,6 +11780,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/test-helper-mock-webex@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-mock-webex@npm:3.12.0"
+  dependencies:
+    ampersand-state: "npm:^5.0.3"
+    es6-promise: "npm:^4.2.8"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/685d57a19de7e9b0ea335681466cf11600afb4a0bfbdf11d188a2f4c45872e346ac6b3a9a9053792ab2a096e7d7dac165214f4c08f06bd9aa1c678ad9c37cf9c
+  languageName: node
+  linkType: hard
+
 "@webex/test-helper-refresh-callback@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/test-helper-refresh-callback@npm:2.60.4"
@@ -11979,17 +11798,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-refresh-callback@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-refresh-callback@npm:3.11.0"
-  checksum: 10c0/c3c501fb0e9e955dcbfded4d52cf2bb38f93436e264965b187e9a5fd049124e69e295b3d8e740f5cf4ca5b2c7523df18b724a7eb4ba8977a0551f98ec3dcf4f2
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-refresh-callback@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-refresh-callback@npm:3.11.0-next.1"
   checksum: 10c0/cd2d72d16480a7207e1a0733c2335533e5ee3e94afa13874c2bcffedda45c7ad3104a1c7fc0a052940448d4dd51cd34573bb2786dda5680313197e025e60ab10
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-refresh-callback@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-refresh-callback@npm:3.12.0"
+  checksum: 10c0/603ec7ffee8c4685b4f234788f9d950c65167de8c1ae233ec63d45dfadb2f267e44bea0b33e005c8200e07c4df1e2026857b88d06296fb9801c3b0dc3be49a0a
   languageName: node
   linkType: hard
 
@@ -12002,21 +11821,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-retry@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-retry@npm:3.11.0"
-  dependencies:
-    es6-promise: "npm:^4.2.8"
-  checksum: 10c0/6d4a901e805cbafcdb43dae9d8d8b4ddabf2f8319d6b82970697a8347a8e5e7addb3cb00af19baff74b1b62637fecfe6a6a6e6dbd543047309d07f75fa9c4af4
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-retry@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-retry@npm:3.11.0-next.1"
   dependencies:
     es6-promise: "npm:^4.2.8"
   checksum: 10c0/7e4ecef8519140a1974d77c0e300747f8e8b13c767a328c95a07d19417635db20b29da5f7dddcca41bb2abd8000c176190366f1c267b5fdf8044ee22b5838c46
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-retry@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-retry@npm:3.12.0"
+  dependencies:
+    es6-promise: "npm:^4.2.8"
+  checksum: 10c0/d88a6dbfd44bd440eff4ed878079096d972ed750d45c9efa108f87490fae8a9c9e067bf04731b058fa5d2639e470dcac78fb418b2e61afac31af23ae964f7c22
   languageName: node
   linkType: hard
 
@@ -12035,21 +11854,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-helper-test-users@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-helper-test-users@npm:3.11.0"
-  dependencies:
-    "@ciscospark/test-users-legacy": "npm:^1.0.2"
-    "@webex/test-helper-retry": "npm:3.11.0"
-    "@webex/test-users": "npm:3.11.0"
-    lodash: "npm:^4.17.21"
-  dependenciesMeta:
-    "@ciscospark/test-users-legacy":
-      optional: true
-  checksum: 10c0/844bae94e776a37c500c98a94f3c2774c28589ecf81c6ae1c5eff75a0386096006feee7232d0f3fce845dbf02173081d0861723051348e10d8036e3a16147db0
-  languageName: node
-  linkType: hard
-
 "@webex/test-helper-test-users@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-helper-test-users@npm:3.11.0-next.1"
@@ -12058,6 +11862,17 @@ __metadata:
     "@webex/test-users": "npm:3.11.0-next.1"
     lodash: "npm:^4.17.21"
   checksum: 10c0/82147f47cb6bfa9179a04fb8769378644f8e55cee9196e5772aeb827348e13b2e9c076ba8abefb7bc8416d775f923d7f45bbaedc6498e8af3e20609048da9fe8
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-test-users@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-helper-test-users@npm:3.12.0"
+  dependencies:
+    "@webex/test-helper-retry": "npm:3.12.0"
+    "@webex/test-users": "npm:3.12.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/3df3a32a93f0a13b9563518dce5581e22ba816c3a09b98d72ddc403faa70d1c4ffc7dd421e676fd852ded0a181d37814d74c696c2d873c7a43ce26f480be6f2f
   languageName: node
   linkType: hard
 
@@ -12075,20 +11890,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/test-users@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/test-users@npm:3.11.0"
-  dependencies:
-    "@webex/http-core": "npm:3.11.0"
-    "@webex/test-helper-mocha": "npm:3.11.0"
-    btoa: "npm:^1.2.1"
-    lodash: "npm:^4.17.21"
-    node-random-name: "npm:^1.0.1"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/914e199d686e7a07d571bdc584dfb13fd90eb35bd90d3df15fd330678f9f19c3bd71ac31a2cb14dfa83a202c30f6fa0312a7290df8f12a8ea99eaba63ac10b5e
-  languageName: node
-  linkType: hard
-
 "@webex/test-users@npm:3.11.0-next.1":
   version: 3.11.0-next.1
   resolution: "@webex/test-users@npm:3.11.0-next.1"
@@ -12100,6 +11901,20 @@ __metadata:
     node-random-name: "npm:^1.0.1"
     uuid: "npm:^3.3.2"
   checksum: 10c0/b507ae2adf311a380939ac0eaafe4fd8f652489059f959b7502bf637573cff0d7180510906bb9f7c8e86d17daf97ab431f9c66f1f9aac71d78420ae57b2c38b2
+  languageName: node
+  linkType: hard
+
+"@webex/test-users@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/test-users@npm:3.12.0"
+  dependencies:
+    "@webex/http-core": "npm:3.12.0"
+    "@webex/test-helper-mocha": "npm:3.12.0"
+    btoa: "npm:^1.2.1"
+    lodash: "npm:^4.17.21"
+    node-random-name: "npm:^1.0.1"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/7fe06d6e4600e46b97c0d4b1baf2289a693b95b493d9e4aa8628a700ef6e7d09e1ee26440ed7b9668eb2c99b445dce680977519d094665d763834c1c50525ceb
   languageName: node
   linkType: hard
 
@@ -12177,40 +11992,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/web-capabilities@npm:^1.7.1":
-  version: 1.8.0
-  resolution: "@webex/web-capabilities@npm:1.8.0"
-  dependencies:
-    bowser: "npm:^2.11.0"
-  checksum: 10c0/4746918b207bebe55fed8f3b7a483f52baf5675bff1c0221678aeea1da7f645966c2d35492ac2f66bddeb55b5894361e6ad6b7a90fedc6dec1d5a4932b69f772
-  languageName: node
-  linkType: hard
-
-"@webex/web-capabilities@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@webex/web-capabilities@npm:1.9.0"
-  dependencies:
-    bowser: "npm:^2.11.0"
-  checksum: 10c0/06353622a1f05f9a89523d619840d1ffb2614bb3fa07ce434217e484009c6ecbb1362f2f337ff5d30f84ca964ad63739cf76eceef60ecd2386b6ff66e6234c6b
-  languageName: node
-  linkType: hard
-
-"@webex/web-client-media-engine@npm:3.37.1":
-  version: 3.37.1
-  resolution: "@webex/web-client-media-engine@npm:3.37.1"
+"@webex/web-client-media-engine@npm:3.39.1":
+  version: 3.39.1
+  resolution: "@webex/web-client-media-engine@npm:3.39.1"
   dependencies:
     "@webex/json-multistream": "npm:^2.4.3"
     "@webex/rtcstats": "npm:^1.5.5"
     "@webex/ts-events": "npm:^1.2.1"
     "@webex/ts-sdp": "npm:1.8.2"
-    "@webex/web-capabilities": "npm:^1.7.1"
+    "@webex/web-capabilities": "npm:^1.10.0"
     "@webex/web-media-effects": "npm:2.33.0"
     "@webex/webrtc-core": "npm:2.13.5"
     async: "npm:^3.2.4"
     js-logger: "npm:^1.6.1"
     typed-emitter: "npm:^2.1.0"
     uuid: "npm:^8.3.2"
-  checksum: 10c0/eb24a7abe82ca5dbd96c862f0659dd08d563069273d7f1d5a1c3543bab65f3479b920caf4f3e68585970ba08785f5c547933ef6025e6e017a975a301a29f4744
+  checksum: 10c0/26585ae9d354e80c3c852a9b8d36d3b610526213995e1747530d5fd5b62f60f79e0aaefa85581b68507073f055c0e7cab6ad70dd1d5f6adaf1dc91b6c30b6246
   languageName: node
   linkType: hard
 
@@ -12285,14 +12082,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/webex-core@npm:3.11.0":
-  version: 3.11.0
-  resolution: "@webex/webex-core@npm:3.11.0"
+"@webex/webex-core@npm:3.12.0":
+  version: 3.12.0
+  resolution: "@webex/webex-core@npm:3.12.0"
   dependencies:
-    "@webex/common": "npm:3.11.0"
-    "@webex/common-timers": "npm:3.11.0"
-    "@webex/http-core": "npm:3.11.0"
-    "@webex/storage-adapter-spec": "npm:3.11.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/common-timers": "npm:3.12.0"
+    "@webex/http-core": "npm:3.12.0"
+    "@webex/storage-adapter-spec": "npm:3.12.0"
     ampersand-collection: "npm:^2.0.2"
     ampersand-events: "npm:^2.0.2"
     ampersand-state: "npm:^5.0.3"
@@ -12301,27 +12098,7 @@ __metadata:
     jsonwebtoken: "npm:^9.0.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/d81d8ab72801d2bf81c5711336ac60b0eaa2f4bf6717b480a2101a70ec2a53da1711a23e48f59a1e157effaca00300091a6b8744bf3aa76627eca65b88b318cd
-  languageName: node
-  linkType: hard
-
-"@webex/webex-core@npm:3.11.0-next.7":
-  version: 3.11.0-next.7
-  resolution: "@webex/webex-core@npm:3.11.0-next.7"
-  dependencies:
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/common-timers": "npm:3.11.0-next.1"
-    "@webex/http-core": "npm:3.11.0-next.1"
-    "@webex/storage-adapter-spec": "npm:3.11.0-next.1"
-    ampersand-collection: "npm:^2.0.2"
-    ampersand-events: "npm:^2.0.2"
-    ampersand-state: "npm:^5.0.3"
-    core-decorators: "npm:^0.20.0"
-    crypto-js: "npm:^4.1.1"
-    jsonwebtoken: "npm:^9.0.0"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^3.3.2"
-  checksum: 10c0/f78b1a17822e58f774d84339ca77671fe27af83b828cd07cc4b5ced8de4265f6ed4519332d5c267a88a5a52792b5665d608a2ec4e3628902e306e6ad30cc3a94
+  checksum: 10c0/5fa0b0530d00426068bfbf0b8763e9d4d2b1f6c0ae874f5b9b72938a1853473f04c0287c9519be0d20ef4641f4dde66eb2d517699e40efab223f9bac797a9114
   languageName: node
   linkType: hard
 
@@ -12787,7 +12564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:6.12.6, ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.12.2, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
+"ajv@npm:^6.1.0, ajv@npm:^6.10.0, ajv@npm:^6.10.2, ajv@npm:^6.12.2, ajv@npm:^6.12.3, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -12796,18 +12573,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
-  languageName: node
-  linkType: hard
-
-"ajv@npm:6.5.2":
-  version: 6.5.2
-  resolution: "ajv@npm:6.5.2"
-  dependencies:
-    fast-deep-equal: "npm:^2.0.1"
-    fast-json-stable-stringify: "npm:^2.0.0"
-    json-schema-traverse: "npm:^0.4.1"
-    uri-js: "npm:^4.2.1"
-  checksum: 10c0/d96866cb0ff52699d41c494c6329c57895cef92f5e70af039522777f12fd44bfcb35fd6cfcae39225ac0f2ffada770a9ae1e4b2728783d9242e4222ee2db9f9b
   languageName: node
   linkType: hard
 
@@ -12827,19 +12592,6 @@ __metadata:
   version: 0.0.9
   resolution: "alea@npm:0.0.9"
   checksum: 10c0/6dbbfcd35616d83fc7d261704a567fe2702ae872f3f98c6d43e19bb57bf5c86aa3d4824b196f39fa7f9267ec42339fae80731c2f93ac149d6b7ca8ce80ba0b91
-  languageName: node
-  linkType: hard
-
-"amf-client-js@npm:^5.2.6":
-  version: 5.10.0
-  resolution: "amf-client-js@npm:5.10.0"
-  dependencies:
-    "@aml-org/amf-antlr-parsers": "npm:0.8.34"
-    ajv: "npm:6.12.6"
-    avro-js: "npm:1.11.3"
-  bin:
-    amf: bin/amf
-  checksum: 10c0/50f7b9d546a719df4ddb2ae40dbf3721849c3be9a2544db3bf133c2336cb047a95057bbaf3c89df539d9c6ec0609a4f6ac934cb82e53ca404aa1407f3032a714
   languageName: node
   linkType: hard
 
@@ -13601,15 +13353,6 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: 10c0/d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
-  languageName: node
-  linkType: hard
-
-"avro-js@npm:1.11.3":
-  version: 1.11.3
-  resolution: "avro-js@npm:1.11.3"
-  dependencies:
-    underscore: "npm:^1.13.2"
-  checksum: 10c0/aff6a5fe67528267d0b1510949fc788db5554b0f083c8c191c0ed81ec5e6266b2f5ff97ddaf1d6ed046988917895fc972962829d362d45d845857eb54df37d9e
   languageName: node
   linkType: hard
 
@@ -15282,19 +15025,6 @@ __metadata:
   peerDependencies:
     webpack: ">=4.0.0 <6.0.0"
   checksum: 10c0/55fe230dddb9fdf2b3cbffa7fab4e47570c84d524f9ae81a3fa1f58ec4077349e9aabf6a2b5bcf4915f1e4205d2dd6b945e633146fccb21dd59989260527615f
-  languageName: node
-  linkType: hard
-
-"cli-color@npm:^2.0.2":
-  version: 2.0.4
-  resolution: "cli-color@npm:2.0.4"
-  dependencies:
-    d: "npm:^1.0.1"
-    es5-ext: "npm:^0.10.64"
-    es6-iterator: "npm:^2.0.3"
-    memoizee: "npm:^0.4.15"
-    timers-ext: "npm:^0.1.7"
-  checksum: 10c0/49a0078fa3517cdfb3ad919a05ab2fe7352d9c9f0617937c38fc6245a38101632d9a23f40a53b2818773d2694b8ae814ff760801a702a26d76b297990ce8d399
   languageName: node
   linkType: hard
 
@@ -18187,7 +17917,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.46, es5-ext@npm:^0.10.62, es5-ext@npm:^0.10.64, es5-ext@npm:~0.10.14, es5-ext@npm:~0.10.2":
+"es5-ext@npm:^0.10.35, es5-ext@npm:^0.10.62, es5-ext@npm:^0.10.64, es5-ext@npm:~0.10.14":
   version: 0.10.64
   resolution: "es5-ext@npm:0.10.64"
   dependencies:
@@ -18241,18 +17971,6 @@ __metadata:
     recast: "npm:~0.11.12"
     through: "npm:~2.3.6"
   checksum: 10c0/64ff711f9ee1768f4cf872ed6fb83c7212281b4a7dd8ed973bad1e0a33defcc49d94421283af13e52ec5f417214d8eb27ae96640b61a8ceef92f7405ca8d5259
-  languageName: node
-  linkType: hard
-
-"es6-weak-map@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "es6-weak-map@npm:2.0.3"
-  dependencies:
-    d: "npm:1"
-    es5-ext: "npm:^0.10.46"
-    es6-iterator: "npm:^2.0.3"
-    es6-symbol: "npm:^3.1.1"
-  checksum: 10c0/460932be9542473dbbddd183e21c15a66cfec1b2c17dae2b514e190d6fb2896b7eb683783d4b36da036609d2e1c93d2815f21b374dfccaf02a8978694c2f7b67
   languageName: node
   linkType: hard
 
@@ -20420,13 +20138,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stdin@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "get-stdin@npm:8.0.0"
-  checksum: 10c0/b71b72b83928221052f713b3b6247ebf1ceaeb4ef76937778557537fd51ad3f586c9e6a7476865022d9394b39b74eed1dc7514052fa74d80625276253571b76f
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^4.0.0":
   version: 4.1.0
   resolution: "get-stream@npm:4.1.0"
@@ -20584,17 +20295,6 @@ __metadata:
   dependencies:
     is-glob: "npm:^4.0.3"
   checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
-  languageName: node
-  linkType: hard
-
-"glob-promise@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "glob-promise@npm:4.2.2"
-  dependencies:
-    "@types/glob": "npm:^7.1.3"
-  peerDependencies:
-    glob: ^7.1.6
-  checksum: 10c0/3eb01bed2901539365df6a4d27800afb8788840647d01f9bf3500b3de756597f2ff4b8c823971ace34db228c83159beca459dc42a70968d4e9c8200ed2cc96bd
   languageName: node
   linkType: hard
 
@@ -22717,13 +22417,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-promise@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "is-promise@npm:2.2.2"
-  checksum: 10c0/2dba959812380e45b3df0fb12e7cb4d4528c989c7abb03ececb1d1fd6ab1cbfee956ca9daa587b9db1d8ac3c1e5738cf217bdb3dfd99df8c691be4c00ae09069
-  languageName: node
-  linkType: hard
-
 "is-regex@npm:^1.1.2, is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
@@ -23919,6 +23612,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^5.8.0":
+  version: 5.10.0
+  resolution: "jose@npm:5.10.0"
+  checksum: 10c0/e20d9fc58d7e402f2e5f04e824b8897d5579aae60e64cb88ebdea1395311c24537bf4892f7de413fab1acf11e922797fb1b42269bc8fc65089a3749265ccb7b0
+  languageName: node
+  linkType: hard
+
 "js-cookie@npm:^3.0.1":
   version: 3.0.5
   resolution: "js-cookie@npm:3.0.5"
@@ -24089,30 +23789,6 @@ __metadata:
   version: 3.0.2
   resolution: "json-parse-even-better-errors@npm:3.0.2"
   checksum: 10c0/147f12b005768abe9fab78d2521ce2b7e1381a118413d634a40e6d907d7d10f5e9a05e47141e96d6853af7cc36d2c834d0a014251be48791e037ff2f13d2b94b
-  languageName: node
-  linkType: hard
-
-"json-schema-to-typescript@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "json-schema-to-typescript@npm:12.0.0"
-  dependencies:
-    "@bcherny/json-schema-ref-parser": "npm:10.0.5-fork"
-    "@types/json-schema": "npm:^7.0.11"
-    "@types/lodash": "npm:^4.14.182"
-    "@types/prettier": "npm:^2.6.1"
-    cli-color: "npm:^2.0.2"
-    get-stdin: "npm:^8.0.0"
-    glob: "npm:^7.1.6"
-    glob-promise: "npm:^4.2.2"
-    is-glob: "npm:^4.0.3"
-    lodash: "npm:^4.17.21"
-    minimist: "npm:^1.2.6"
-    mkdirp: "npm:^1.0.4"
-    mz: "npm:^2.7.0"
-    prettier: "npm:^2.6.2"
-  bin:
-    json2ts: dist/src/cli.js
-  checksum: 10c0/b1e78a6d87694c226b316e65a7e1bcc1db6e145e63d1f005bf680d341e5ae948c35f5ab62dc486f87c213a4b426c2ceba583f4a431d79c8d96ae97b60f2cabcb
   languageName: node
   linkType: hard
 
@@ -25308,15 +24984,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-queue@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "lru-queue@npm:0.1.0"
-  dependencies:
-    es5-ext: "npm:~0.10.2"
-  checksum: 10c0/83517032b46843601c4528be65e8aaf85f5a7860a9cfa3e4f2b5591da436e7cd748d95b450c91434c4ffb75d3ae4c069ddbdd9f71ada56a99a00c03088c51b4d
-  languageName: node
-  linkType: hard
-
 "luxon@npm:^1.23.0":
   version: 1.28.1
   resolution: "luxon@npm:1.28.1"
@@ -25680,22 +25347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"memoizee@npm:^0.4.15":
-  version: 0.4.17
-  resolution: "memoizee@npm:0.4.17"
-  dependencies:
-    d: "npm:^1.0.2"
-    es5-ext: "npm:^0.10.64"
-    es6-weak-map: "npm:^2.0.3"
-    event-emitter: "npm:^0.3.5"
-    is-promise: "npm:^2.2.2"
-    lru-queue: "npm:^0.1.0"
-    next-tick: "npm:^1.1.0"
-    timers-ext: "npm:^0.1.7"
-  checksum: 10c0/19821d055f0f641e79b718f91d6d89a6c92840643234a6f4e91d42aa330e8406f06c47d3828931e177c38830aa9b959710e5b7f0013be452af46d0f9eae4baf4
-  languageName: node
-  linkType: hard
-
 "memoizerific@npm:^1.11.3":
   version: 1.11.3
   resolution: "memoizerific@npm:1.11.3"
@@ -26043,7 +25694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.1, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6, minimist@npm:^1.2.8":
+"minimist@npm:^1.1.1, minimist@npm:^1.2.0, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -26385,7 +26036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mz@npm:^2.4.0, mz@npm:^2.7.0":
+"mz@npm:^2.4.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
   dependencies:
@@ -29026,15 +28677,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.6.2":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
-  bin:
-    prettier: bin-prettier.js
-  checksum: 10c0/463ea8f9a0946cd5b828d8cf27bd8b567345cf02f56562d5ecde198b91f47a76b7ac9eae0facd247ace70e927143af6135e8cf411986b8cb8478784a4d6d724a
-  languageName: node
-  linkType: hard
-
 "prettier@npm:^3.5.1":
   version: 3.5.1
   resolution: "prettier@npm:3.5.1"
@@ -31037,7 +30679,7 @@ __metadata:
     ts-loader: "npm:^9.5.1"
     typescript: "npm:^5.6.3"
     typescript-eslint: "npm:^8.24.1"
-    webex: "npm:3.11.0-next.50"
+    webex: "npm:3.12.0"
     webpack: "npm:^5.94.0"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^5.1.0"
@@ -33390,16 +33032,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timers-ext@npm:^0.1.7":
-  version: 0.1.8
-  resolution: "timers-ext@npm:0.1.8"
-  dependencies:
-    es5-ext: "npm:^0.10.64"
-    next-tick: "npm:^1.1.0"
-  checksum: 10c0/d0222d0c171d08df69e51462e3fa2085744d13f8ac82b27597db05db1a09bc4244e03ea3cebe89ba279fd43f45daa39156acbe5b6ae5a9b9d62d300543312533
-  languageName: node
-  linkType: hard
-
 "timespan@npm:2.x":
   version: 2.3.0
   resolution: "timespan@npm:2.3.0"
@@ -34195,13 +33827,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"underscore@npm:^1.13.2":
-  version: 1.13.8
-  resolution: "underscore@npm:1.13.8"
-  checksum: 10c0/6677688daeda30484823e77c0b89ce4dcf29964a77d5a06f37299c007ab4bb1c66a0ff75e0d274620b62a1fe2a6ba29879f8214533ca611d71a1ae504f2bfc9b
-  languageName: node
-  linkType: hard
-
 "undici-types@npm:~5.26.4":
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
@@ -34569,7 +34194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uri-js@npm:^4.2.1, uri-js@npm:^4.2.2":
+"uri-js@npm:^4.2.2":
   version: 4.4.1
   resolution: "uri-js@npm:4.4.1"
   dependencies:
@@ -35010,15 +34635,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webapi-parser@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "webapi-parser@npm:0.5.0"
-  dependencies:
-    ajv: "npm:6.5.2"
-  checksum: 10c0/a6ad4ad78c81422cb35a7cae5f189deaacc17395e4b72632cd81c8f4363a89c636b28a215ffc16de126ccb4c10c0c1cf39d50ec417ababfe900a4554b5a14430
-  languageName: node
-  linkType: hard
-
 "webcrypto-core@npm:^1.8.0":
   version: 1.8.1
   resolution: "webcrypto-core@npm:1.8.1"
@@ -35162,42 +34778,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webex@npm:3.11.0-next.50":
-  version: 3.11.0-next.50
-  resolution: "webex@npm:3.11.0-next.50"
+"webex@npm:3.12.0":
+  version: 3.12.0
+  resolution: "webex@npm:3.12.0"
   dependencies:
     "@babel/polyfill": "npm:^7.12.1"
     "@babel/runtime-corejs2": "npm:^7.14.8"
-    "@webex/calling": "npm:3.11.0-next.13"
-    "@webex/common": "npm:3.11.0-next.1"
-    "@webex/contact-center": "npm:3.11.0-next.20"
-    "@webex/internal-plugin-calendar": "npm:3.11.0-next.9"
-    "@webex/internal-plugin-device": "npm:3.11.0-next.7"
-    "@webex/internal-plugin-dss": "npm:3.11.0-next.9"
-    "@webex/internal-plugin-llm": "npm:3.11.0-next.9"
-    "@webex/internal-plugin-mercury": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-presence": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-support": "npm:3.11.0-next.8"
-    "@webex/internal-plugin-task": "npm:^3.11.0-next.8"
-    "@webex/internal-plugin-voicea": "npm:3.11.0-next.9"
-    "@webex/plugin-attachment-actions": "npm:3.11.0-next.8"
-    "@webex/plugin-authorization": "npm:3.11.0-next.7"
-    "@webex/plugin-device-manager": "npm:3.11.0-next.9"
-    "@webex/plugin-encryption": "npm:3.11.0-next.8"
-    "@webex/plugin-logger": "npm:3.11.0-next.7"
-    "@webex/plugin-meetings": "npm:3.11.0-next.37"
-    "@webex/plugin-memberships": "npm:3.11.0-next.8"
-    "@webex/plugin-messages": "npm:3.11.0-next.8"
-    "@webex/plugin-people": "npm:3.11.0-next.8"
-    "@webex/plugin-rooms": "npm:3.11.0-next.8"
-    "@webex/plugin-team-memberships": "npm:3.11.0-next.7"
-    "@webex/plugin-teams": "npm:3.11.0-next.7"
-    "@webex/plugin-webhooks": "npm:3.11.0-next.7"
-    "@webex/storage-adapter-local-storage": "npm:3.11.0-next.7"
-    "@webex/webex-core": "npm:3.11.0-next.7"
+    "@webex/calling": "npm:3.12.0"
+    "@webex/common": "npm:3.12.0"
+    "@webex/contact-center": "npm:3.12.0"
+    "@webex/internal-plugin-calendar": "npm:3.12.0"
+    "@webex/internal-plugin-device": "npm:3.12.0"
+    "@webex/internal-plugin-dss": "npm:3.12.0"
+    "@webex/internal-plugin-llm": "npm:3.12.0"
+    "@webex/internal-plugin-mercury": "npm:3.12.0"
+    "@webex/internal-plugin-presence": "npm:3.12.0"
+    "@webex/internal-plugin-support": "npm:3.12.0"
+    "@webex/internal-plugin-task": "npm:^3.12.0"
+    "@webex/internal-plugin-voicea": "npm:3.12.0"
+    "@webex/plugin-attachment-actions": "npm:3.12.0"
+    "@webex/plugin-authorization": "npm:3.12.0"
+    "@webex/plugin-device-manager": "npm:3.12.0"
+    "@webex/plugin-encryption": "npm:3.12.0"
+    "@webex/plugin-logger": "npm:3.12.0"
+    "@webex/plugin-meetings": "npm:3.12.0"
+    "@webex/plugin-memberships": "npm:3.12.0"
+    "@webex/plugin-messages": "npm:3.12.0"
+    "@webex/plugin-people": "npm:3.12.0"
+    "@webex/plugin-rooms": "npm:3.12.0"
+    "@webex/plugin-team-memberships": "npm:3.12.0"
+    "@webex/plugin-teams": "npm:3.12.0"
+    "@webex/plugin-webhooks": "npm:3.12.0"
+    "@webex/storage-adapter-local-storage": "npm:3.12.0"
+    "@webex/webex-core": "npm:3.12.0"
     lodash: "npm:^4.17.21"
     safe-buffer: "npm:^5.2.0"
-  checksum: 10c0/450eb11fbc7d5d68dcb5a5be48a11a3b431e0a89fcad24be4a07702586f2247b80cc72cb2a4fb644aeae8dbbcd737cba89aea9533491c8d7538661635f3dfed4
+  checksum: 10c0/efbc4b9780d518670de5db26f55ed85a3fc5404c011e6a11121c8947dd6e7275e56abcfb95d7af48ba835e01e2deaf5792d18e7ce44e3b2f2acd13582e2e69b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Diagnostic / test-only PR. Do **not** merge.

Opened to verify whether the CI cancellations seen on #665 are branch-specific or reflect a broader infra/workflow issue. The only change is a one-line webex SDK version bump (`3.11.0-next.50` → `3.12.0`) in the react sample app.

Previous attempt (#680) was closed because the PR title didn't match the conventional-commit validator; retitled to `fix(ci): ...`.

## Test plan

- [ ] Observe whether Pull Request CI completes or is cancelled on this PR
- [ ] If it completes, the issue is localized to #665
- [ ] Close without merging once signal is collected