### PR TITLE
fix(store):  attach SDK listeners on stationLoginSuccess

### DIFF
--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -923,6 +923,13 @@ class StoreWrapper implements IStoreWrapper {
         // @ts-expect-error To be fixed in SDK - https://jira-eng-sjc12.cisco.com/jira/browse/CAI-6762
         this.setTeamId(payload.teamId);
       });
+      // CAI-7899: Ensure CC SDK listeners (incl. agent:stateChange) are attached even when
+      // Mobius registration is skipped (non-WebRTC tabs e.g. Epic Hyperspace secondary windows,
+      // or Extension/AgentDN logins) and silent relogin doesn't run.
+      if (!listenersAdded) {
+        addEventListeners();
+        listenersAdded = true;
+      }
     };
 
     ccSDK.on(CC_EVENTS.AGENT_STATION_LOGIN_SUCCESS, handleLogin);

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -90,6 +90,14 @@ function App() {
     const savedAllowInternationalDn = window.localStorage.getItem('allowInternationalDn');
     return savedAllowInternationalDn === 'true';
   });
+  const [disableWebRTCRegistration, setDisableWebRTCRegistration] = useState(() => {
+    const savedDisableWebRTCRegistration = window.localStorage.getItem('disableWebRTCRegistration');
+    return savedDisableWebRTCRegistration === 'true';
+  });
+
+  const WEBRTC_DEPENDENT_WIDGETS = ['incomingTask', 'taskList', 'callControl', 'callControlCAD'];
+  const isWidgetDisabledByWebRTC = (widget: string) =>
+    disableWebRTCRegistration && WEBRTC_DEPENDENT_WIDGETS.includes(widget);
 
   const handleSaveStart = () => {
     setShowLoader(true);
@@ -138,6 +146,7 @@ function App() {
     },
     cc: {
       allowMultiLogin: isMultiLoginEnabled,
+      disableWebRTCRegistration,
     },
     ...(integrationEnv && {
       services: {
@@ -221,6 +230,17 @@ function App() {
       setIsMultiLoginEnabled(false);
     } else {
       setIsMultiLoginEnabled(true);
+    }
+  };
+
+  const toggleDisableWebRTCRegistration = () => {
+    const newValue = !disableWebRTCRegistration;
+    setDisableWebRTCRegistration(newValue);
+    if (newValue) {
+      setSelectedWidgets((prev) => ({
+        ...prev,
+        ...WEBRTC_DEPENDENT_WIDGETS.reduce((acc, w) => ({...acc, [w]: false}), {}),
+      }));
     }
   };
 
@@ -328,6 +348,9 @@ function App() {
           redirect_uri: redirectUri,
           scope: requestedScopes,
         },
+        cc: {
+          disableWebRTCRegistration,
+        },
       },
     };
 
@@ -365,6 +388,9 @@ function App() {
   useEffect(() => {
     window.localStorage.setItem('hideDesktopLogin', JSON.stringify(hideDesktopLogin));
   }, [hideDesktopLogin]);
+  useEffect(() => {
+    window.localStorage.setItem('disableWebRTCRegistration', JSON.stringify(disableWebRTCRegistration));
+  }, [disableWebRTCRegistration]);
 
   useEffect(() => {
     store.setIncomingTaskCb(onIncomingTaskCB);
@@ -526,6 +552,7 @@ function App() {
                               name={widget}
                               checked={selectedWidgets[widget]}
                               onChange={handleCheckboxChange}
+                              disabled={isWidgetDisabledByWebRTC(widget)}
                               data-testid={`samples:widget-${widget}`}
                             />
                             &nbsp;
@@ -633,11 +660,50 @@ function App() {
                         <Text>
                           <div
                             className="warning-note"
-                            style={{color: 'var(--mds-color-theme-text-error-normal)', marginBottom: '10px'}}
+                            style={{
+                              color: 'var(--mds-color-theme-text-error-normal)',
+                              marginBottom: '10px',
+                              maxWidth: '320px',
+                            }}
                           >
                             <strong>Note:</strong> The "Enable Multi Login" option must be set before initializing the
                             SDK. Changes to this setting after SDK initialization will not take effect. Please ensure
                             you configure this option before clicking the "Init Widgets" button.
+                          </div>
+                        </Text>
+                      </PopoverNext>
+                    </label>
+                    <label style={{display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '10px'}}>
+                      <input
+                        data-testid="samples:disable-webrtc-registration-checkbox"
+                        type="checkbox"
+                        id="disableWebRTCRegistrationFlag"
+                        name="disableWebRTCRegistrationFlag"
+                        onChange={toggleDisableWebRTCRegistration}
+                        checked={disableWebRTCRegistration}
+                      />{' '}
+                      &nbsp; Disable WebRTC Registration
+                      <PopoverNext
+                        trigger="mouseenter"
+                        triggerComponent={<Icon name="info-badge-filled" />}
+                        placement="auto-end"
+                        closeButtonPlacement="top-left"
+                        closeButtonProps={{'aria-label': 'Close'}}
+                      >
+                        <Text>
+                          <div
+                            className="warning-note"
+                            style={{
+                              color: 'var(--mds-color-theme-text-error-normal)',
+                              marginBottom: '10px',
+                              maxWidth: '320px',
+                            }}
+                          >
+                            <strong>Note:</strong> Disabling WebRTC registration prevents browser-based calling. When
+                            enabled, the "Incoming Task", "Task List", "Call Control", and "Call Control with CAD"
+                            widgets will be unchecked and disabled because they depend on call handling. Set this
+                            option before clicking the "Init Widgets" button — changes after SDK initialization will
+                            not take effect.
                           </div>
                         </Text>
                       </PopoverNext>


### PR DESCRIPTION
# COMPLETES https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7899

## This pull request addresses

UserState (and other CC widgets that depend on `agent:stateChange`) freeze in non-WebRTC tabs — e.g. Epic Hyperspace secondary windows that intentionally skip Mobius registration, or any Extension/AgentDN login where Mobius is not registered.

Root cause: `addEventListeners()` in `storeEventsWrapper.setupIncomingTaskHandler` was only invoked from the `AGENT_DN_REGISTERED` and `AGENT_RELOGIN_SUCCESS` handlers. When Mobius registration is skipped and silent relogin does not run, neither event fires, so the `agent:stateChange` (and related) listeners are never attached and the store never receives state updates from the SDK.

## by making the following changes

- Call `addEventListeners()` from the `AGENT_STATION_LOGIN_SUCCESS` handler (`handleLogin`) as well, guarded by the same `listenersAdded` flag so listeners are attached exactly once regardless of which event fires first.

Builds on the sample-app changes from #683 which add a "Disable WebRTC Registration" toggle for repro convenience.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## The following scenarios were tested

- Extension login (Mobius skipped) → `agent:stateChange` listener is attached on `stationLoginSuccess`; UserState updates propagate (no freeze).
- Browser login with Mobius registered → listener attached exactly once (no duplicate via `agent:dnRegistered`).
- Silent relogin path (`agent:reloginSuccess`) → listener attached exactly once.

## The GAI Coding Policy And Copyright Annotation Best Practices

- [x] GAI was used to create a draft that was subsequently customized
- [x] Tool used for AI assistance
  - [x] Other - Please Specify: Cursor (Claude)
- [x] This PR is related to
  - [x] Defect fix

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link
