### PR TITLE
fix(store): fixes after bug bash

### DIFF
--- a/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/src/components/task/CallControlCAD/call-control-cad.tsx
@@ -63,6 +63,7 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
   const isTelephony = mediaChannel === MediaChannelType.TELEPHONY;
   const participantsCount = conferenceParticipants?.length || 1;
   const participantsLabel = participantsCount === 1 ? 'Participant' : 'Participants';
+  const shouldShowParticipantsList = (conferenceParticipants?.length || 0) > 1;
 
   const customerName = currentTask?.data?.interaction?.callAssociatedDetails?.customerName;
 
@@ -188,7 +189,7 @@ const CallControlCADComponent: React.FC<CallControlComponentProps> = (props) => 
                     </>
                   )}
                 </Text>
-                {controls?.main?.exitConference?.isVisible && !controls?.main?.wrapup?.isVisible && (
+                {shouldShowParticipantsList && !controls?.main?.wrapup?.isVisible && (
                   <>
                     <div className="vertical-divider"></div>
                     <div className="participants-section">

--- a/packages/contact-center/cc-components/tests/components/task/CallControlCAD/call-control-cad.tsx
+++ b/packages/contact-center/cc-components/tests/components/task/CallControlCAD/call-control-cad.tsx
@@ -379,4 +379,33 @@ describe('CallControlCADComponent', () => {
       expect(screen.queryByText(/On hold/)).not.toBeInTheDocument();
     });
   });
+
+  describe('conference participants list visibility', () => {
+    it('shows participants list when there are more than two participants total', () => {
+      const screen = render(
+        <CallControlCADComponent
+          {...defaultProps}
+          controls={createEnabledMainTaskUIControls({exitConference: {isVisible: false, isEnabled: false}})}
+          conferenceParticipants={[
+            {id: 'agent-2', name: 'Agent Two', pType: 'Agent'},
+            {id: 'agent-3', name: 'Agent Three', pType: 'Agent'},
+          ]}
+        />
+      );
+
+      expect(screen.getByTestId('call-control:participants-trigger')).toBeInTheDocument();
+    });
+
+    it('hides participants list when two or fewer participants are present in total', () => {
+      const screen = render(
+        <CallControlCADComponent
+          {...defaultProps}
+          controls={createEnabledMainTaskUIControls({exitConference: {isVisible: true, isEnabled: true}})}
+          conferenceParticipants={[{id: 'agent-2', name: 'Agent Two', pType: 'Agent'}]}
+        />
+      );
+
+      expect(screen.queryByTestId('call-control:participants-trigger')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/contact-center": "3.12.0-task-refactor.6",
+    "@webex/contact-center": "3.12.0-task-refactor.7",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/packages/contact-center/store/src/task-utils.ts
+++ b/packages/contact-center/store/src/task-utils.ts
@@ -109,13 +109,49 @@ export const setmTypeForEPDN = (task: ITask, mType: string) => {
   return mType;
 };
 export const findMediaResourceId = (task: ITask, mType: string) => {
-  for (const key in task.data.interaction.media) {
-    if (task.data.interaction.media[key].mType === mType) {
-      return task.data.interaction.media[key].mediaResourceId;
-    }
+  if (!task?.data?.interaction?.media) {
+    return '';
   }
 
-  return '';
+  const matchingMedia = Object.values(task.data.interaction.media).filter((media) => media.mType === mType);
+
+  if (matchingMedia.length === 0) {
+    return '';
+  }
+
+  if (matchingMedia.length === 1) {
+    return matchingMedia[0].mediaResourceId;
+  }
+
+  // In some consult flows, stale consult legs are retained in media. Prefer the
+  // latest snapshot to avoid resolving an older consulted agent.
+  const getMediaRecencyScore = (media: Record<string, unknown>, fallbackIndex: number): number => {
+    const candidateTimestamps = [
+      media.lastUpdated,
+      media.joinTimestamp,
+      media.consultTimestamp,
+      media.holdTimestamp,
+      media.eventTime,
+      media.createdAt,
+    ];
+
+    for (const value of candidateTimestamps) {
+      if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+        return value;
+      }
+    }
+
+    // Fall back to the object traversal order if no timestamp exists.
+    return fallbackIndex;
+  };
+
+  const latestMedia = matchingMedia.reduce((latest, media, index) => {
+    const latestScore = getMediaRecencyScore(latest as Record<string, unknown>, index - 1);
+    const currentScore = getMediaRecencyScore(media as Record<string, unknown>, index);
+    return currentScore >= latestScore ? media : latest;
+  });
+
+  return latestMedia.mediaResourceId || '';
 };
 
 /**

--- a/packages/contact-center/task/src/helper.ts
+++ b/packages/contact-center/task/src/helper.ts
@@ -322,6 +322,9 @@ export const useCallControl = (props: useCallControlProps) => {
   const prevIsConsultingRef = useRef(
     !!(initialControls?.consult?.endConsult?.isVisible || initialControls?.main?.endConsult?.isVisible)
   );
+  const consultVisibilityRef = useRef(
+    !!(initialControls?.consult?.endConsult?.isVisible || initialControls?.main?.endConsult?.isVisible)
+  );
   const [lastTargetType, setLastTargetType] = useState<TargetType>(TARGET_TYPE.AGENT);
   const [conferenceParticipants, setConferenceParticipants] = useState<Participant[]>([]);
   const lastWrapupAuxCodeIdRef = useRef<string | null>(null);
@@ -416,6 +419,24 @@ export const useCallControl = (props: useCallControlProps) => {
   const holdTime = useHoldTimer(currentTask, controls);
 
   useEffect(() => {
+    const isConsulting = !!(controls?.consult?.endConsult?.isVisible || controls?.main?.endConsult?.isVisible);
+    const wasConsulting = consultVisibilityRef.current;
+
+    if (wasConsulting && !isConsulting) {
+      setConsultAgentName('Consult Agent');
+      setConsultTimerLabel(TIMER_LABEL_CONSULTING);
+      setConsultTimerTimestamp(0);
+      setLastTargetType(TARGET_TYPE.AGENT);
+      store.setIsQueueConsultInProgress(false);
+      store.setCurrentConsultQueueId(null);
+      store.setLastConsultDestination(null);
+      store.setConsultStartTimeStamp(null);
+    }
+
+    consultVisibilityRef.current = isConsulting;
+  }, [controls?.consult?.endConsult?.isVisible, controls?.main?.endConsult?.isVisible]);
+
+  useEffect(() => {
     if (currentTask && store?.cc?.agentConfig?.agentId) {
       const participants = getConferenceParticipants(currentTask, store.cc.agentConfig.agentId);
       setConferenceParticipants(participants);
@@ -424,9 +445,13 @@ export const useCallControl = (props: useCallControlProps) => {
   // Function to extract consulting agent information
   const extractConsultingAgent = useCallback(() => {
     try {
-      if (!currentTask?.data?.interaction?.participants) return;
+      // currentTask.data can briefly lag behind the freshest state-machine snapshot.
+      // Prefer the latest taskData so consult UI always reflects the newest consult leg.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const latestTaskData = (currentTask as any)?.state?.context?.taskData;
+      const interaction = latestTaskData?.interaction ?? currentTask?.data?.interaction;
+      if (!interaction?.participants) return;
 
-      const {interaction} = currentTask.data;
       const myAgentId = store.cc.agentConfig?.agentId;
       const currentDestination = store.lastConsultDestination;
       const destinationType = currentDestination?.destinationType;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9544,7 +9544,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/contact-center": "npm:3.12.0-task-refactor.6"
+    "@webex/contact-center": "npm:3.12.0-task-refactor.7"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
@@ -9937,9 +9937,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/contact-center@npm:3.12.0-task-refactor.6":
-  version: 3.12.0-task-refactor.6
-  resolution: "@webex/contact-center@npm:3.12.0-task-refactor.6"
+"@webex/contact-center@npm:3.12.0-task-refactor.7":
+  version: 3.12.0-task-refactor.7
+  resolution: "@webex/contact-center@npm:3.12.0-task-refactor.7"
   dependencies:
     "@types/platform": "npm:1.3.4"
     "@webex/calling": "npm:3.12.0-task-refactor.1"
@@ -9953,7 +9953,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     xstate: "npm:5.24.0"
-  checksum: 10c0/e529d6ca11cec201e116cb655407a26c88f5c4c08d8b5b2c0a603e6b9c029fc893945c8035ec8d6fdd5d5e87d600483246aa87d66999a5348064fabbe9110322
+  checksum: 10c0/663407a7eb7003f46c9b8efaa3c8a711a2e883a94b341810d8d7a5e2fc106e88f311824ed0dff6e5a03fea0da814298bc5ea184fee14470bdf09d42f810cdfef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7994 (Bug Bash fixes)

## This pull request addresses

Task-refactor regressions found during bug bash in consult/conference flows:
- stale consult leg data could show an older consulted agent
- consult state data was not fully cleared after consult ended
- participants list could disappear in conference+consult transitions
- on-hold banner/timer could appear incorrectly when main leg should not be treated as held

## by making the following changes

- Updated consult media resolution to prefer the latest consult leg instead of the first matching media entry.
- Added consult-end cleanup to reset consult-specific state (destination, queue consult state, consult timer/name context).
- Updated call-control hold-state derivation in conference/consult flows to avoid false hold state for consulted agents.
- Updated hold-timer derivation to avoid showing hold timer from active-leg signal for consulted-agent scenarios.
- Updated CallControlCAD participants list visibility to be driven by participant count (>2 total participants), not exitConference control visibility.
- Added/updated CallControlCAD tests for participant-list visibility behavior.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- Manual validation with task payload reproduction (`taskData.json`) for consult/conference hold-state behavior.
- `yarn workspace @webex/cc-store test:styles`
- `yarn workspace @webex/cc-task test:styles`
- `yarn workspace @webex/cc-components test:styles`
- `yarn workspace @webex/cc-components test:unit` (currently fails due existing test-fixture issue: `createEnabledMainTaskUIControls`/`createMockTaskUIControls` not exported as expected in this environment)

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
    - Cursor AI Assistant
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.