### PR TITLE
fix(cc-store): hydrate engaged state on multi-login events

### DIFF
--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/contact-center": "3.12.0-next.42",
+    "@webex/contact-center": "3.12.0-next.68",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -206,6 +206,7 @@ enum TASK_EVENTS {
   TASK_WRAPUP = 'task:wrapup',
   TASK_REJECT = 'task:rejected',
   TASK_HYDRATE = 'task:hydrate',
+  TASK_MULTI_LOGIN_HYDRATE = 'task:multiLoginHydrate',
   TASK_CONSULTING = 'task:consulting',
   TASK_CONSULT_QUEUE_CANCELLED = 'task:consultQueueCancelled',
   AGENT_CONTACT_ASSIGNED = 'AgentContactAssigned',

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -678,6 +678,27 @@ class StoreWrapper implements IStoreWrapper {
     this.refreshTaskList();
   };
 
+  handleMultiLoginHydrate = (event) => {
+    const task = event as ITask;
+    const interactionId = task?.data?.interactionId;
+    const interactionState = task?.data?.interaction?.state;
+    if (interactionId && this.store.taskList[interactionId] && interactionState === 'new') {
+      return;
+    }
+
+    if (!task) {
+      this.store.logger.warn('CC-Widgets: handleMultiLoginHydrate(): task payload missing', {
+        module: 'storeEventsWrapper.ts',
+        method: 'handleMultiLoginHydrate',
+      });
+      return;
+    }
+
+    this.registerTaskEventListeners(task);
+    this.refreshTaskList();
+    this.handleTaskAssigned(task);
+  };
+
   handleTaskHydrate = (event) => {
     const task = event;
 
@@ -884,6 +905,7 @@ class StoreWrapper implements IStoreWrapper {
         method: 'setupIncomingTaskHandler#addEventListeners',
       });
       ccSDK.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
+      ccSDK.on(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, this.handleMultiLoginHydrate);
       ccSDK.on(CC_EVENTS.AGENT_STATE_CHANGE, this.handleStateChange);
       ccSDK.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
       ccSDK.on(TASK_EVENTS.TASK_MERGED, this.handleTaskMerged);
@@ -897,6 +919,7 @@ class StoreWrapper implements IStoreWrapper {
         method: 'setupIncomingTaskHandler#removeEventListeners',
       });
       ccSDK.off(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
+      ccSDK.off(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, this.handleMultiLoginHydrate);
       ccSDK.off(CC_EVENTS.AGENT_STATE_CHANGE, this.handleStateChange);
       ccSDK.off(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
       ccSDK.off(TASK_EVENTS.TASK_MERGED, this.handleTaskMerged);

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -1615,13 +1615,11 @@ describe('storeEventsWrapper', () => {
 
       storeWrapper['store'].taskList = {[interactionId]: task};
 
-      const registerSpy = jest.spyOn(storeWrapper as any, 'registerTaskEventListeners');
       const refreshSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
       const assignedSpy = jest.spyOn(storeWrapper, 'handleTaskAssigned');
 
       storeWrapper.handleMultiLoginHydrate(task);
 
-      expect(registerSpy).not.toHaveBeenCalled();
       expect(refreshSpy).not.toHaveBeenCalled();
       expect(assignedSpy).not.toHaveBeenCalled();
     });
@@ -1639,17 +1637,14 @@ describe('storeEventsWrapper', () => {
 
       storeWrapper['store'].taskList = {[interactionId]: task};
 
-      const registerSpy = jest.spyOn(storeWrapper as any, 'registerTaskEventListeners');
       const refreshSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
       const assignedSpy = jest.spyOn(storeWrapper, 'handleTaskAssigned');
 
       storeWrapper.handleMultiLoginHydrate(task);
 
-      expect(registerSpy).toHaveBeenCalledWith(task);
       expect(refreshSpy).toHaveBeenCalled();
       expect(assignedSpy).toHaveBeenCalledWith(task);
     });
-
 
     it('should handle hydrating the store with correct data', async () => {
       const setCurrentTaskSpy = jest.spyOn(storeWrapper, 'setCurrentTask');

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -1182,6 +1182,7 @@ describe('storeEventsWrapper', () => {
       });
 
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, expect.any(Function));
+      expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, expect.any(Function));
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, expect.any(Function));
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_MERGED, expect.any(Function));
       expect(onSpy).toHaveBeenCalledWith(CC_EVENTS.AGENT_STATE_CHANGE, expect.any(Function));
@@ -1607,6 +1608,55 @@ describe('storeEventsWrapper', () => {
       });
     });
 
+    it('should skip multiLoginHydrate when interaction already exists in taskList with new state', () => {
+      const interactionId = 'multi-hydrate-skip-1';
+      const task = {
+        data: {
+          interactionId,
+          interaction: {state: 'new'},
+        },
+        on: jest.fn(),
+        off: jest.fn(),
+      } as unknown as ITask;
+
+      storeWrapper['store'].taskList = {[interactionId]: task};
+
+      const registerSpy = jest.spyOn(storeWrapper as any, 'registerTaskEventListeners');
+      const refreshSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
+      const assignedSpy = jest.spyOn(storeWrapper, 'handleTaskAssigned');
+
+      storeWrapper.handleMultiLoginHydrate(task);
+
+      expect(registerSpy).not.toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(assignedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should process multiLoginHydrate when interaction state is connected', () => {
+      const interactionId = 'multi-hydrate-connected-1';
+      const task = {
+        data: {
+          interactionId,
+          interaction: {state: 'connected'},
+        },
+        on: jest.fn(),
+        off: jest.fn(),
+      } as unknown as ITask;
+
+      storeWrapper['store'].taskList = {[interactionId]: task};
+
+      const registerSpy = jest.spyOn(storeWrapper as any, 'registerTaskEventListeners');
+      const refreshSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
+      const assignedSpy = jest.spyOn(storeWrapper, 'handleTaskAssigned');
+
+      storeWrapper.handleMultiLoginHydrate(task);
+
+      expect(registerSpy).toHaveBeenCalledWith(task);
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(assignedSpy).toHaveBeenCalledWith(task);
+    });
+
+
     it('should handle hydrating the store with correct data', async () => {
       const setCurrentTaskSpy = jest.spyOn(storeWrapper, 'setCurrentTask');
       const refreshTaskListSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
@@ -1671,6 +1721,7 @@ describe('storeEventsWrapper', () => {
       });
 
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, expect.any(Function));
+      expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_MULTI_LOGIN_HYDRATE, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_MERGED, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(CC_EVENTS.AGENT_STATE_CHANGE, expect.any(Function));

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -90,6 +90,14 @@ function App() {
     const savedAllowInternationalDn = window.localStorage.getItem('allowInternationalDn');
     return savedAllowInternationalDn === 'true';
   });
+  const [disableWebRTCRegistration, setDisableWebRTCRegistration] = useState(() => {
+    const savedDisableWebRTCRegistration = window.localStorage.getItem('disableWebRTCRegistration');
+    return savedDisableWebRTCRegistration === 'true';
+  });
+
+  const WEBRTC_DEPENDENT_WIDGETS = ['incomingTask', 'taskList', 'callControl', 'callControlCAD'];
+  const isWidgetDisabledByWebRTC = (widget: string) =>
+    disableWebRTCRegistration && WEBRTC_DEPENDENT_WIDGETS.includes(widget);
 
   const handleSaveStart = () => {
     setShowLoader(true);
@@ -138,6 +146,7 @@ function App() {
     },
     cc: {
       allowMultiLogin: isMultiLoginEnabled,
+      disableWebRTCRegistration,
     },
     ...(integrationEnv && {
       services: {
@@ -221,6 +230,17 @@ function App() {
       setIsMultiLoginEnabled(false);
     } else {
       setIsMultiLoginEnabled(true);
+    }
+  };
+
+  const toggleDisableWebRTCRegistration = () => {
+    const newValue = !disableWebRTCRegistration;
+    setDisableWebRTCRegistration(newValue);
+    if (newValue) {
+      setSelectedWidgets((prev) => ({
+        ...prev,
+        ...WEBRTC_DEPENDENT_WIDGETS.reduce((acc, w) => ({...acc, [w]: false}), {}),
+      }));
     }
   };
 
@@ -328,6 +348,9 @@ function App() {
           redirect_uri: redirectUri,
           scope: requestedScopes,
         },
+        cc: {
+          disableWebRTCRegistration,
+        },
       },
     };
 
@@ -365,6 +388,9 @@ function App() {
   useEffect(() => {
     window.localStorage.setItem('hideDesktopLogin', JSON.stringify(hideDesktopLogin));
   }, [hideDesktopLogin]);
+  useEffect(() => {
+    window.localStorage.setItem('disableWebRTCRegistration', JSON.stringify(disableWebRTCRegistration));
+  }, [disableWebRTCRegistration]);
 
   useEffect(() => {
     store.setIncomingTaskCb(onIncomingTaskCB);
@@ -526,6 +552,7 @@ function App() {
                               name={widget}
                               checked={selectedWidgets[widget]}
                               onChange={handleCheckboxChange}
+                              disabled={isWidgetDisabledByWebRTC(widget)}
                               data-testid={`samples:widget-${widget}`}
                             />
                             &nbsp;
@@ -633,11 +660,50 @@ function App() {
                         <Text>
                           <div
                             className="warning-note"
-                            style={{color: 'var(--mds-color-theme-text-error-normal)', marginBottom: '10px'}}
+                            style={{
+                              color: 'var(--mds-color-theme-text-error-normal)',
+                              marginBottom: '10px',
+                              maxWidth: '320px',
+                            }}
                           >
                             <strong>Note:</strong> The "Enable Multi Login" option must be set before initializing the
                             SDK. Changes to this setting after SDK initialization will not take effect. Please ensure
                             you configure this option before clicking the "Init Widgets" button.
+                          </div>
+                        </Text>
+                      </PopoverNext>
+                    </label>
+                    <label style={{display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '10px'}}>
+                      <input
+                        data-testid="samples:disable-webrtc-registration-checkbox"
+                        type="checkbox"
+                        id="disableWebRTCRegistrationFlag"
+                        name="disableWebRTCRegistrationFlag"
+                        onChange={toggleDisableWebRTCRegistration}
+                        checked={disableWebRTCRegistration}
+                      />{' '}
+                      &nbsp; Disable WebRTC Registration
+                      <PopoverNext
+                        trigger="mouseenter"
+                        triggerComponent={<Icon name="info-badge-filled" />}
+                        placement="auto-end"
+                        closeButtonPlacement="top-left"
+                        closeButtonProps={{'aria-label': 'Close'}}
+                      >
+                        <Text>
+                          <div
+                            className="warning-note"
+                            style={{
+                              color: 'var(--mds-color-theme-text-error-normal)',
+                              marginBottom: '10px',
+                              maxWidth: '320px',
+                            }}
+                          >
+                            <strong>Note:</strong> Disabling WebRTC registration prevents browser-based calling. When
+                            enabled, the "Incoming Task", "Task List", "Call Control", and "Call Control with CAD"
+                            widgets will be unchecked and disabled because they depend on call handling. Set this
+                            option before clicking the "Init Widgets" button — changes after SDK initialization will
+                            not take effect.
                           </div>
                         </Text>
                       </PopoverNext>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9552,6 +9552,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/calling@npm:3.12.0-next.59":
+  version: 3.12.0-next.59
+  resolution: "@webex/calling@npm:3.12.0-next.59"
+  dependencies:
+    "@types/platform": "npm:1.3.4"
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/common-timers": "npm:3.12.0-next.4"
+    "@webex/internal-media-core": "npm:2.26.1"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-feature": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.22"
+    "@webex/media-helpers": "npm:3.12.0-next.8"
+    async-mutex: "npm:0.4.0"
+    backoff: "npm:2.5.0"
+    buffer: "npm:6.0.3"
+    lodash: "npm:^4.17.21"
+    platform: "npm:1.3.6"
+    uuid: "npm:8.3.2"
+    ws: "npm:8.17.1"
+    xstate: "npm:4.30.6"
+  checksum: 10c0/b2fd12bd77581da296b555bb268ead544577ec4de435f2299e52b04e7c30b4f08c4736b2d9bdee29c9e64a5b22713cbb9e133ff8090ceee9d037fc94ef5d8857
+  languageName: node
+  linkType: hard
+
 "@webex/cc-components@workspace:*, @webex/cc-components@workspace:packages/contact-center/cc-components":
   version: 0.0.0-use.local
   resolution: "@webex/cc-components@workspace:packages/contact-center/cc-components"
@@ -9709,7 +9733,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/contact-center": "npm:3.12.0-next.42"
+    "@webex/contact-center": "npm:3.12.0-next.68"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
@@ -9941,6 +9965,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/common-timers@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/common-timers@npm:3.12.0-next.4"
+  checksum: 10c0/4c1f481ff52b2ed39f3c3916e63d9f0ac81c26b8d960ab82600f5481c4677ab536717b0dc37dd26e19e78b431c682761f811219659def6fed560138628db700b
+  languageName: node
+  linkType: hard
+
 "@webex/common@npm:1.161.0":
   version: 1.161.0
   resolution: "@webex/common@npm:1.161.0"
@@ -10004,6 +10035,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/common@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/common@npm:3.12.0-next.4"
+  dependencies:
+    backoff: "npm:^2.5.0"
+    bowser: "npm:^2.11.0"
+    core-decorators: "npm:^0.20.0"
+    global: "npm:^4.4.0"
+    lodash: "npm:^4.17.21"
+    safe-buffer: "npm:^5.2.0"
+    urlsafe-base64: "npm:^1.0.0"
+  checksum: 10c0/73d54e5825977c4894b9a5b0eb7f5c271302f4065b1e73d61940e08f31fe4ec80a2e5984ebec527d168b28ce84a12dd4e20431435e2174d32f50348013a56931
+  languageName: node
+  linkType: hard
+
 "@webex/component-adapter-interfaces@npm:^1.28.0, @webex/component-adapter-interfaces@npm:^1.30.5":
   version: 1.30.18
   resolution: "@webex/component-adapter-interfaces@npm:1.30.18"
@@ -10058,6 +10104,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/contact-center@npm:3.12.0-next.68":
+  version: 3.12.0-next.68
+  resolution: "@webex/contact-center@npm:3.12.0-next.68"
+  dependencies:
+    "@types/platform": "npm:1.3.4"
+    "@webex/calling": "npm:3.12.0-next.59"
+    "@webex/internal-plugin-mercury": "npm:3.12.0-next.23"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-support": "npm:3.12.0-next.24"
+    "@webex/plugin-authorization": "npm:3.12.0-next.22"
+    "@webex/plugin-logger": "npm:3.12.0-next.22"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    jest-html-reporters: "npm:3.0.11"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/aee161d890c2ade208bfd3e0e62e2bebdf368c34386c52ba1aa32b631d66e39b665401e11c90a862bbfa10514d4e12fa91d4a3b73f44588187952b7c1ab31c67
+  languageName: node
+  linkType: hard
+
 "@webex/helper-html@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/helper-html@npm:2.60.4"
@@ -10082,6 +10146,15 @@ __metadata:
   dependencies:
     lodash: "npm:^4.17.21"
   checksum: 10c0/cf325224593d4f2b52d0542828ef60bc22343721aa84047e97b3c12bc133f1e105db06c01ae9fb6f32bef6cae2a8f2e8b6c4aecae5083ffc72fad811dc6f88be
+  languageName: node
+  linkType: hard
+
+"@webex/helper-html@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/helper-html@npm:3.12.0-next.4"
+  dependencies:
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/a06af34d30f604c99ad8e05a25e769cbc73a50faffd5145046616729582accc9751a7be66c98b3655e05d896580cd7e257d3707a7850d2ffacfde22bb6822c67
   languageName: node
   linkType: hard
 
@@ -10133,6 +10206,23 @@ __metadata:
     mime: "npm:^2.4.4"
     safe-buffer: "npm:^5.2.0"
   checksum: 10c0/1ab6b056cf208541876299b6ba984856c2f65ccf1f2f2c34b3e2eb0eb963b14eba4759178dbb99e86dfbbaa6e515ec958d591450ac16902339f138b86a78a461
+  languageName: node
+  linkType: hard
+
+"@webex/helper-image@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/helper-image@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/http-core": "npm:3.12.0-next.4"
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+    "@webex/test-helper-file": "npm:3.12.0-next.4"
+    "@webex/test-helper-mocha": "npm:3.12.0-next.4"
+    exifr: "npm:^5.0.3"
+    gm: "npm:^1.23.1"
+    lodash: "npm:^4.17.21"
+    mime: "npm:^2.4.4"
+    safe-buffer: "npm:^5.2.0"
+  checksum: 10c0/7741d8e691d6a16c7737d18f30c76d456a46ee3f081603fa2f69b3b7175229cac59f1a54375dc419732b6c569532a33c7351a782377aca61bfe210422ae133c4
   languageName: node
   linkType: hard
 
@@ -10213,6 +10303,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/http-core@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/http-core@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    file-type: "npm:^16.0.1"
+    global: "npm:^4.4.0"
+    is-function: "npm:^1.0.1"
+    lodash: "npm:^4.17.21"
+    parse-headers: "npm:^2.0.2"
+    qs: "npm:^6.7.3"
+    request: "npm:^2.88.0"
+    safe-buffer: "npm:^5.2.0"
+    xtend: "npm:^4.0.2"
+  checksum: 10c0/c2b5b9957c61452fcb7133202bc4c6fab3a5ad3579107212870d1a4cc8d49dfa986246f59cfa6b413d2b69ef182e0a178fe6424bfd9f731313b01fa4d3255a7a
+  languageName: node
+  linkType: hard
+
 "@webex/internal-media-core@npm:0.0.7-beta":
   version: 0.0.7-beta
   resolution: "@webex/internal-media-core@npm:0.0.7-beta"
@@ -10247,6 +10355,26 @@ __metadata:
     webrtc-adapter: "npm:^8.1.2"
     xstate: "npm:^4.30.6"
   checksum: 10c0/7a726f3226c1a0d4a1b60abccbeae8d5a60560bb11d5f0877c8411fbdb91f2f86f56ac83fad1bc5ace21d45afdbc20f810340e74b1986d785fd9bfb8cee04eb1
+  languageName: node
+  linkType: hard
+
+"@webex/internal-media-core@npm:2.26.1":
+  version: 2.26.1
+  resolution: "@webex/internal-media-core@npm:2.26.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.18.9"
+    "@babel/runtime-corejs2": "npm:^7.25.0"
+    "@webex/rtcstats": "npm:^1.5.5"
+    "@webex/ts-sdp": "npm:1.8.2"
+    "@webex/web-capabilities": "npm:^1.10.0"
+    "@webex/web-client-media-engine": "npm:3.40.2"
+    events: "npm:^3.3.0"
+    ip-anonymize: "npm:^0.1.0"
+    typed-emitter: "npm:^2.1.0"
+    uuid: "npm:^8.3.2"
+    webrtc-adapter: "npm:^8.1.2"
+    xstate: "npm:^4.30.6"
+  checksum: 10c0/b04e55649b06852d27d7d02254af66f9a2254e1ec755276bb233511bc902c5db475e32b148830f99b335b3496f9377f036dc1daabadefd8398d3483bcaf8f5c3
   languageName: node
   linkType: hard
 
@@ -10332,6 +10460,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-conversation@npm:3.12.0-next.24":
+  version: 3.12.0-next.24
+  resolution: "@webex/internal-plugin-conversation@npm:3.12.0-next.24"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/helper-html": "npm:3.12.0-next.4"
+    "@webex/helper-image": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-encryption": "npm:3.12.0-next.23"
+    "@webex/internal-plugin-user": "npm:3.12.0-next.23"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    crypto-js: "npm:^4.1.1"
+    lodash: "npm:^4.17.21"
+    node-scr: "npm:^0.3.0"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/f5a7cd910cfb5302e5dddc15740dd062c403f19391b4bb668f37e6f50640521b5fc2898bcae3c34257bcb91e196d5dfd5bc5a3b125cbae1b9b77cbe8b1098476
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-device@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-device@npm:2.60.4"
@@ -10379,6 +10525,23 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/c9bef045a01429c75ef55eee0fcdc08e6d647e4a35a81217963157a24c7e454093419a9a68203bdd3fb3f1081ba269d96d410b870e1eae5f4154691f40dfb8ed
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-device@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/internal-plugin-device@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/common-timers": "npm:3.12.0-next.4"
+    "@webex/http-core": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.22"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    ampersand-collection: "npm:^2.0.2"
+    ampersand-state: "npm:^5.0.3"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/39e68ba42ee49ef8c6971d61013a378dff42b30ca1fb308ff6b8740b7f4b880f7fbc866c6d0e46c45513e72176fe9efdf111a88e67b094e7d4717b6ae2c8c63c
   languageName: node
   linkType: hard
 
@@ -10474,6 +10637,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-encryption@npm:3.12.0-next.23":
+  version: 3.12.0-next.23
+  resolution: "@webex/internal-plugin-encryption@npm:3.12.0-next.23"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/common-timers": "npm:3.12.0-next.4"
+    "@webex/http-core": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-mercury": "npm:3.12.0-next.23"
+    "@webex/test-helper-file": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    asn1js: "npm:^2.0.26"
+    debug: "npm:^4.3.4"
+    isomorphic-webcrypto: "npm:^2.3.8"
+    lodash: "npm:^4.17.21"
+    node-jose: "npm:^2.2.0"
+    node-kms: "npm:^0.4.1"
+    node-scr: "npm:^0.3.0"
+    pkijs: "npm:^2.1.84"
+    safe-buffer: "npm:^5.2.0"
+    uuid: "npm:^3.3.2"
+    valid-url: "npm:^1.0.9"
+  checksum: 10c0/146c9b696d21d5d174a52a62217db98bcd37f06396ab8b6eac7a8c602e46d8752692cd17a55ff73ce43050ebee4c16b2f503e6fdc1ef91cb7b3fd57a6c62f73b
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-feature@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-feature@npm:2.60.4"
@@ -10505,6 +10694,17 @@ __metadata:
     "@webex/webex-core": "npm:3.12.0-next.15"
     lodash: "npm:^4.17.21"
   checksum: 10c0/c6d99e9b93ac300ec601c8d1da5a33e5249aadf49aec14166f5a14000045fcf07b28bf55890691680dab219f7f5291e9b2b74af56bf6473121eb862d402c439b
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-feature@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/internal-plugin-feature@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/155ab68bc1648bacae3da55f472267db1902ec40fe94c1a18bd085c3c4dfb657b764b58dc750fb38a91908e86e7ae459aac3a07cc7e952df4e8f4de26a49248d
   languageName: node
   linkType: hard
 
@@ -10651,6 +10851,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-mercury@npm:3.12.0-next.23":
+  version: 3.12.0-next.23
+  resolution: "@webex/internal-plugin-mercury@npm:3.12.0-next.23"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/common-timers": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-feature": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.22"
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+    "@webex/test-helper-mocha": "npm:3.12.0-next.4"
+    "@webex/test-helper-mock-web-socket": "npm:3.12.0-next.4"
+    "@webex/test-helper-mock-webex": "npm:3.12.0-next.4"
+    "@webex/test-helper-refresh-callback": "npm:3.12.0-next.4"
+    "@webex/test-helper-test-users": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    backoff: "npm:^2.5.0"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+    ws: "npm:^8.17.1"
+  checksum: 10c0/2ecfb0ef70596ea0502ffff9e4ad260a44b5c4aa2bfea2328ec13dcf0abf4ee89a465f28cc4d361ffedddaa1c071c66520b23f8605d71fe11c51559d4e371f92
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-metrics@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-metrics@npm:2.60.4"
@@ -10693,6 +10917,22 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/d8b1d3f1b1f34589f57e9a30030cd8922a95d009f3e2d0b57dd57ade34c439a371d38bb4c0960ccab65498c55b9b0f3d12451e3b0d66a95a0f59757b23c55a83
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-metrics@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/internal-plugin-metrics@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/common-timers": "npm:3.12.0-next.4"
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+    "@webex/test-helper-mock-webex": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    ip-anonymize: "npm:^0.1.0"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/eb7b5190b297d295279df20b0b8af0fcd869bacb45d18a1a04682e1ec9e35a5b48b6adb125f9d5dc068628d483b779522b0c6ed5d6d83a74f49a13f21050bc28
   languageName: node
   linkType: hard
 
@@ -10758,6 +10998,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-search@npm:3.12.0-next.24":
+  version: 3.12.0-next.24
+  resolution: "@webex/internal-plugin-search@npm:3.12.0-next.24"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-conversation": "npm:3.12.0-next.24"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-encryption": "npm:3.12.0-next.23"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/70d35f70210afd92ac2f13fd147e46631a18ebca9fe7afda76aa4e2e4908ea972b76655c07b1c9c44097d1604d46a5e7b64fc701a158b3d890160a3ef9560012
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-support@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/internal-plugin-support@npm:2.60.4"
@@ -10789,6 +11044,23 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
   checksum: 10c0/e2d792681c264c646d47187a3a7a8f995fc63b1c724f78762d2e019db8798ae5b7ca6a7a516cf8938e66915f8c969c08a400806ffb51edf787397629bacc3c1c
+  languageName: node
+  linkType: hard
+
+"@webex/internal-plugin-support@npm:3.12.0-next.24":
+  version: 3.12.0-next.24
+  resolution: "@webex/internal-plugin-support@npm:3.12.0-next.24"
+  dependencies:
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/internal-plugin-search": "npm:3.12.0-next.24"
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+    "@webex/test-helper-file": "npm:3.12.0-next.4"
+    "@webex/test-helper-mock-webex": "npm:3.12.0-next.4"
+    "@webex/test-helper-test-users": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/2f48cf13013b7f8c218c4cdbc790210b37aff75577aa0782fa3472247880b098733e8ce7617dd8226d267ff12587a5df769acccee5f7533f9b9414a5eb0a198e
   languageName: node
   linkType: hard
 
@@ -10854,6 +11126,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/internal-plugin-user@npm:3.12.0-next.23":
+  version: 3.12.0-next.23
+  resolution: "@webex/internal-plugin-user@npm:3.12.0-next.23"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+    "@webex/test-helper-mock-webex": "npm:3.12.0-next.4"
+    "@webex/test-helper-test-users": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/940851b1ecc76fe7ba942c1a682f2b0f2598f97dd07c8f428841654f19bc8d3d277276879c0cbbff0522a855d71b59dfc3c213cfebc73861874985f0b7cf2364
+  languageName: node
+  linkType: hard
+
 "@webex/internal-plugin-voicea@npm:3.12.0-next.18":
   version: 3.12.0-next.18
   resolution: "@webex/internal-plugin-voicea@npm:3.12.0-next.18"
@@ -10894,6 +11182,17 @@ __metadata:
     "@webex/ts-events": "npm:^1.1.0"
     "@webex/web-media-effects": "npm:2.33.5"
   checksum: 10c0/9ac15b19c7c450f4831b4d6afafc7873c86781670ea0fcd468f25b193f50d13d2c0b13a70b927a94b4d372ebe03f2ecad141df32cb0836dbcdb604c7de9f9799
+  languageName: node
+  linkType: hard
+
+"@webex/media-helpers@npm:3.12.0-next.8":
+  version: 3.12.0-next.8
+  resolution: "@webex/media-helpers@npm:3.12.0-next.8"
+  dependencies:
+    "@webex/internal-media-core": "npm:2.26.1"
+    "@webex/ts-events": "npm:^1.1.0"
+    "@webex/web-media-effects": "npm:2.33.5"
+  checksum: 10c0/1aef4289f705db6a9bb1db9734d2b6fba35908aa4ef89cabbbdf704e1318512479cb67f56ec3e27ccb0f00adc2eb500c73e15c5c87ae5749f844112494f64e94
   languageName: node
   linkType: hard
 
@@ -10979,6 +11278,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/plugin-authorization-browser@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/plugin-authorization-browser@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/plugin-authorization-node": "npm:3.12.0-next.22"
+    "@webex/storage-adapter-local-storage": "npm:3.12.0-next.22"
+    "@webex/storage-adapter-spec": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    jsonwebtoken: "npm:^9.0.2"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/375491ac54a3bdddb84360c1ab9b3562d1988b4348f7ef28c365b79731b7dfb2e02dda9005addb755b0d796cf07e894a7ddb181ddeb5447049be789437274c1a
+  languageName: node
+  linkType: hard
+
 "@webex/plugin-authorization-node@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/plugin-authorization-node@npm:2.60.4"
@@ -11005,6 +11321,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/plugin-authorization-node@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/plugin-authorization-node@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.22"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    jsonwebtoken: "npm:^9.0.0"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/391578e2ac4b85688186be46380a2a4dc28dcd5540f1ab040f46cbdefde14a124eaba9d6ebfc6ea22fa631780ae22c187e13deaee956ec901eac1066af798a63
+  languageName: node
+  linkType: hard
+
 "@webex/plugin-authorization@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/plugin-authorization@npm:2.60.4"
@@ -11022,6 +11351,16 @@ __metadata:
     "@webex/plugin-authorization-browser": "npm:3.12.0-next.15"
     "@webex/plugin-authorization-node": "npm:3.12.0-next.15"
   checksum: 10c0/97f50fb9b111628ea46be900e6f69ca61a7220c9dcc1b66a705f452178ecb9622ebdcb6f442139da09141fc34111b503035e38ce005d5ca5adff3cb86766148c
+  languageName: node
+  linkType: hard
+
+"@webex/plugin-authorization@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/plugin-authorization@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/plugin-authorization-browser": "npm:3.12.0-next.22"
+    "@webex/plugin-authorization-node": "npm:3.12.0-next.22"
+  checksum: 10c0/949b48e0bef8d22f4220d0e9389ed28158fa9881743313308eb9ad7de4b8f6ac77950cf0c5489be5de22361e1ce876ee81a6ac85438c4341a44abd9cfeeb05f4
   languageName: node
   linkType: hard
 
@@ -11096,6 +11435,20 @@ __metadata:
     "@webex/webex-core": "npm:3.12.0-next.15"
     lodash: "npm:^4.17.21"
   checksum: 10c0/3db9830fb48a66caa3ed0c9a2a3548f6bf9c3b9b07cfd0eeda0cb090c71db42399bbbfc5747848a7069a1d75cf34f072a08adf277caa76e50fc490afeeb833af
+  languageName: node
+  linkType: hard
+
+"@webex/plugin-logger@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/plugin-logger@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+    "@webex/test-helper-mocha": "npm:3.12.0-next.4"
+    "@webex/test-helper-mock-webex": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/cb8ce169d8e67c1e65cc209fef8b91f024cf8d4f12b3a30a6ac70d0a18b00debdecd74b9ffc7b7d0b517f85e07d0d8a4dfbcc3ba4e6eb8dcda59d048881875f2
   languageName: node
   linkType: hard
 
@@ -11424,6 +11777,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/storage-adapter-local-storage@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/storage-adapter-local-storage@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/storage-adapter-spec": "npm:3.12.0-next.4"
+    "@webex/test-helper-mocha": "npm:3.12.0-next.4"
+    "@webex/webex-core": "npm:3.12.0-next.22"
+  checksum: 10c0/b6ccb3feba77743e1dc8392e4e19ff748dd8f4594b7dd8ec222af1b01f2af66f40c3ee2d464c73e542e19b99cf65a510386325ea73b23253eca31a222917c8ef
+  languageName: node
+  linkType: hard
+
 "@webex/storage-adapter-spec@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/storage-adapter-spec@npm:2.60.4"
@@ -11448,6 +11812,15 @@ __metadata:
   dependencies:
     "@webex/test-helper-chai": "npm:3.12.0-next.1"
   checksum: 10c0/daaf7fa3eeae4749485d1f64eba9f2c20bbdaec1870873f6b393ec0f3dc6a8728c0dbf46c8969bb49c34208ad0cf56cbc5fde0575d3e1a786e8a744be2c57ea5
+  languageName: node
+  linkType: hard
+
+"@webex/storage-adapter-spec@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/storage-adapter-spec@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/test-helper-chai": "npm:3.12.0-next.4"
+  checksum: 10c0/87e3155ab26fec3646653044a4d0f1fec568aa78d51a26299457c45b2ae47044fa51aa4caac14c7d2776fcf7f5795c849888ab23457960d89c47fab9f8d398e8
   languageName: node
   linkType: hard
 
@@ -11515,6 +11888,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/test-helper-chai@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-chai@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/test-helper-file": "npm:3.12.0-next.4"
+    check-error: "npm:^1.0.2"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/105d23b1f251d79551f3941b0540268f21308911ff22560c564d21a7b0a52f018fba6bf6176a35f9463caf08ac7e8a48cbe839d0b307c4b4fdf727abcb11f840
+  languageName: node
+  linkType: hard
+
 "@webex/test-helper-file@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/test-helper-file@npm:2.60.4"
@@ -11554,6 +11938,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/test-helper-file@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-file@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/test-helper-make-local-url": "npm:3.12.0-next.4"
+    es6-promise: "npm:^4.2.8"
+    file-type: "npm:^16.0.1"
+    xhr: "npm:^2.5.0"
+  checksum: 10c0/c9e6366777f091dc892e362915ff1ca5a754221f9e6858990851ff9ace5efaaba06408fcd7670853e6fbc1793ba0f2496295dc8b3ed879715e0cea418df33e57
+  languageName: node
+  linkType: hard
+
 "@webex/test-helper-make-local-url@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/test-helper-make-local-url@npm:2.60.4"
@@ -11572,6 +11969,13 @@ __metadata:
   version: 3.12.0-next.1
   resolution: "@webex/test-helper-make-local-url@npm:3.12.0-next.1"
   checksum: 10c0/13dd73a17c3d241b02affcabf831828dcef0df8850240142159ce15b0970a66ca2caf5d4c40cf54d9fde27b61abcf86d40a0895069e3f8d0f79f769f5c952ab4
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-make-local-url@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-make-local-url@npm:3.12.0-next.4"
+  checksum: 10c0/c8a0e1d7ffca9d18c0395d3a105cdc88760676ad58847bfd7edccebfe46805d43aaf6edd2b8eee0d2917ee3e47bd0a314b2e2b5047c2bf6a1ede5e1e0fac53e4
   languageName: node
   linkType: hard
 
@@ -11602,6 +12006,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/test-helper-mocha@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-mocha@npm:3.12.0-next.4"
+  dependencies:
+    bowser: "npm:^2.11.0"
+  checksum: 10c0/2946781a3e6a62286d3e20eb8b9010afd0960b528077f28d4b08e093bef188f832d3be28b7f3982028cf9e730c6f4f12cbdd25f67c3043009e981ddcff246e74
+  languageName: node
+  linkType: hard
+
 "@webex/test-helper-mock-web-socket@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/test-helper-mock-web-socket@npm:2.60.4"
@@ -11620,6 +12033,13 @@ __metadata:
   version: 3.12.0-next.1
   resolution: "@webex/test-helper-mock-web-socket@npm:3.12.0-next.1"
   checksum: 10c0/a572fa41d1420a36d57fc57b9705297dff5c62fb479ef6b7433ce56102b3e331f894dad679a04ec98cf4c45f8007cbc4129a07036dc9d4f5a11b0f40a18adc5c
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-mock-web-socket@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-mock-web-socket@npm:3.12.0-next.4"
+  checksum: 10c0/b3a697ba8eb966228db6116518e4f8862f7ce9996ba0f41b7eaed97cbfda8a0e66960629d2d62258ca381ae38f6d7b1e57205fdb73378da656e3d8fcc9767275
   languageName: node
   linkType: hard
 
@@ -11656,6 +12076,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/test-helper-mock-webex@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-mock-webex@npm:3.12.0-next.4"
+  dependencies:
+    ampersand-state: "npm:^5.0.3"
+    es6-promise: "npm:^4.2.8"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/411bdb843f0983a2da76ddb956ee958154eabb13c25b58c5df31310a8b4c9f473cfcc92ee87e43fd663375a8cbc8f34901b5b315ea29f1ae4bd5019e39a75c46
+  languageName: node
+  linkType: hard
+
 "@webex/test-helper-refresh-callback@npm:2.60.4":
   version: 2.60.4
   resolution: "@webex/test-helper-refresh-callback@npm:2.60.4"
@@ -11674,6 +12105,13 @@ __metadata:
   version: 3.12.0-next.1
   resolution: "@webex/test-helper-refresh-callback@npm:3.12.0-next.1"
   checksum: 10c0/3144709abb36533e76891052e8d805c8377129a099a5972f2f2dad99cff163b555d683babc5a5cb1316fe92d6ba9588e890121c67df3355e47137dab5d7829a0
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-refresh-callback@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-refresh-callback@npm:3.12.0-next.4"
+  checksum: 10c0/bb4fb04f25fe2e0fdf273092fba962aa46f0c9773088b4ec35fe6078d4f8e9095723e55469329bc582e84e2bb770cffbe654dc8d53f4bd777aa8893b7ef82407
   languageName: node
   linkType: hard
 
@@ -11701,6 +12139,15 @@ __metadata:
   dependencies:
     es6-promise: "npm:^4.2.8"
   checksum: 10c0/0a94cef8493b53a43c42187ca4cfa6e4fefd569203c97018b59f93c99225f9ff07e24ecce150f231e552c948789925c82abc7aa68a9a96e8aa59967f162126fc
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-retry@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-retry@npm:3.12.0-next.4"
+  dependencies:
+    es6-promise: "npm:^4.2.8"
+  checksum: 10c0/a517b42959872d39d0bfeb5e0fc2aa9edcbd8c9b33d26567d02182259b97ac4654bd770ff95315b5027a33f8e43d10354eb6855c763aaa303496889d1670c0d7
   languageName: node
   linkType: hard
 
@@ -11738,6 +12185,17 @@ __metadata:
     "@webex/test-users": "npm:3.12.0-next.1"
     lodash: "npm:^4.17.21"
   checksum: 10c0/e4f9f44c1cc88042fa6b8b5d1f0b8379158fac09cb5cdc4abd2d5c656b0f4bc863b16baea885f0f4aaea9aa7aa8e10663268490d85528f9e0fa1d3e819d11198
+  languageName: node
+  linkType: hard
+
+"@webex/test-helper-test-users@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-helper-test-users@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/test-helper-retry": "npm:3.12.0-next.4"
+    "@webex/test-users": "npm:3.12.0-next.4"
+    lodash: "npm:^4.17.21"
+  checksum: 10c0/3fc6a451df2a1f99d9fbb2145bba3fa47ac463b4d865e80d4eb05d856b7d538a18943e3aa8e82ff7739f6dda7fb4955277f364e9fede740b16f3354ee941bad7
   languageName: node
   linkType: hard
 
@@ -11780,6 +12238,20 @@ __metadata:
     node-random-name: "npm:^1.0.1"
     uuid: "npm:^3.3.2"
   checksum: 10c0/29ba5766b6c150ec3d1ec908dc4078816dedae21a773b056102fafe7ff474856573dfb53885e63475fdac3a35900827224578e24588d75127ebde5f00405ba68
+  languageName: node
+  linkType: hard
+
+"@webex/test-users@npm:3.12.0-next.4":
+  version: 3.12.0-next.4
+  resolution: "@webex/test-users@npm:3.12.0-next.4"
+  dependencies:
+    "@webex/http-core": "npm:3.12.0-next.4"
+    "@webex/test-helper-mocha": "npm:3.12.0-next.4"
+    btoa: "npm:^1.2.1"
+    lodash: "npm:^4.17.21"
+    node-random-name: "npm:^1.0.1"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/b4234d4452480b597de58b514f8319e278ca161435dedebd385c7eb5da8939ae27d1720bae38b0bca716831f64e73663bc84b1bdd6b317f2c1e8d77b434e27bd
   languageName: node
   linkType: hard
 
@@ -11876,6 +12348,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/web-client-media-engine@npm:3.40.2":
+  version: 3.40.2
+  resolution: "@webex/web-client-media-engine@npm:3.40.2"
+  dependencies:
+    "@webex/json-multistream": "npm:^2.4.3"
+    "@webex/rtcstats": "npm:^1.5.5"
+    "@webex/ts-events": "npm:^1.2.1"
+    "@webex/ts-sdp": "npm:1.8.2"
+    "@webex/web-capabilities": "npm:^1.10.0"
+    "@webex/web-media-effects": "npm:2.33.5"
+    "@webex/webrtc-core": "npm:2.14.0"
+    async: "npm:^3.2.4"
+    js-logger: "npm:^1.6.1"
+    typed-emitter: "npm:^2.1.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10c0/4054a7295c8e8c7c530a175bf19b999891b5d519dd11ef56cb0e5b35560771e3520cd5760e4ea49ab709a374fa4f1bbd980746b9e9aa54d86e41f8f0d09d4790
+  languageName: node
+  linkType: hard
+
 "@webex/web-media-effects@npm:2.33.5":
   version: 2.33.5
   resolution: "@webex/web-media-effects@npm:2.33.5"
@@ -11953,6 +12444,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@webex/webex-core@npm:3.12.0-next.22":
+  version: 3.12.0-next.22
+  resolution: "@webex/webex-core@npm:3.12.0-next.22"
+  dependencies:
+    "@webex/common": "npm:3.12.0-next.4"
+    "@webex/common-timers": "npm:3.12.0-next.4"
+    "@webex/http-core": "npm:3.12.0-next.4"
+    "@webex/storage-adapter-spec": "npm:3.12.0-next.4"
+    ampersand-collection: "npm:^2.0.2"
+    ampersand-events: "npm:^2.0.2"
+    ampersand-state: "npm:^5.0.3"
+    core-decorators: "npm:^0.20.0"
+    crypto-js: "npm:^4.1.1"
+    jsonwebtoken: "npm:^9.0.0"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^3.3.2"
+  checksum: 10c0/f4b2cc9739260934b939ba99de766dc233276ea2a116987f4713fb18f71d6fc4ae96854d21dce2d9570c0c42340716cc431bf886487a24330c180af5a8560428
+  languageName: node
+  linkType: hard
+
 "@webex/webrtc-core@npm:2.13.7":
   version: 2.13.7
   resolution: "@webex/webrtc-core@npm:2.13.7"
@@ -11965,6 +12476,21 @@ __metadata:
     typed-emitter: "npm:^2.1.0"
     webrtc-adapter: "npm:^8.1.2"
   checksum: 10c0/48f781ca9d57330b6498e155e2b46bd914773dfc8ce21df80d0d79bf902a224ca4961f848999a3d1b779b49aef8ce7e797374e9c42eec016f88cd2fdc433895a
+  languageName: node
+  linkType: hard
+
+"@webex/webrtc-core@npm:2.14.0":
+  version: 2.14.0
+  resolution: "@webex/webrtc-core@npm:2.14.0"
+  dependencies:
+    "@webex/ts-events": "npm:^1.2.1"
+    "@webex/web-capabilities": "npm:^1.6.1"
+    "@webex/web-media-effects": "npm:2.33.5"
+    events: "npm:^3.3.0"
+    js-logger: "npm:^1.6.1"
+    typed-emitter: "npm:^2.1.0"
+    webrtc-adapter: "npm:^8.1.2"
+  checksum: 10c0/0302ea8b41e9b44635fb0b79999782462f340bef37f0d61bed930662d1de052c2439f955960677fe4b4343c779534cb214b00ecfe39138025a6ed6bfeb39b186
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7899

## This pull request addresses

Multi-login mirrored widget sessions were not consistently hydrating `ENGAGED` custom state when task updates arrived through multi-login event flow.

## by making the following changes

- add `TASK_MULTI_LOGIN_HYDRATE` event support in store event types and SDK listener wiring
- handle `task:multiLoginHydrate` in `storeEventsWrapper` with dedupe guard for already-known `new` interactions
- add/adjust unit tests in `storeEventsWrapper` to verify listener registration/removal and multi-login hydrate behavior
- include existing branch commit `docs(samples): disableWebRTCRegistration toggle`

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested
Uploading Screen Recording 2026-06-04 at 10.01.51 AM.mov…

- [ ] The testing is done with the amplify link

- Automated: `yarn workspace @webex/cc-store exec jest tests/storeEventsWrapper.ts --runInBand`

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor/Codex
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

Made with [Cursor](https://cursor.com)