### PR TITLE
chore(ci): stop publishing docs from task-refactor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: # Allow list of deployable tags and branches. Note that all allow-listed branches cannot include any `/` characters
       - next
+      - task-refactor
 
 env:
   rid: ${{ github.run_id }}-${{ github.run_number }}
@@ -151,6 +152,7 @@ jobs:
     name: Publish - Documentation
     needs: [publish-npm,analyze-changes]
     runs-on: ubuntu-latest
+    if: github.ref_name == 'next'
 
     steps:
       - name: Documentation Deploy Steps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: # Allow list of deployable tags and branches. Note that all allow-listed branches cannot include any `/` characters
       - next
-      - task-refactor
 
 env:
   rid: ${{ github.run_id }}-${{ github.run_number }}
@@ -152,7 +151,6 @@ jobs:
     name: Publish - Documentation
     needs: [publish-npm,analyze-changes]
     runs-on: ubuntu-latest
-    if: github.ref_name == 'next'
 
     steps:
       - name: Documentation Deploy Steps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,7 @@ jobs:
     name: Publish - Documentation
     needs: [publish-npm,analyze-changes]
     runs-on: ubuntu-latest
+    if: github.ref_name == 'next'
 
     steps:
       - name: Documentation Deploy Steps


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

The `task-refactor` branch is currently included in the deploy workflow, and its documentation publish job force-pushes updates to the `documentation` branch. That branch is used for the repository’s GitHub Pages site and sample app content, so changes from `task-refactor` can unintentionally update docs/pages output even though we still want SDK publishing on the `task-refactor` tag path.

## by making the following changes

- Added a branch guard to `.github/workflows/deploy.yml`
- Restricted the `publish-documentation` job to run only when `github.ref_name == 'next'`
- Kept the rest of the deploy pipeline unchanged for `task-refactor`, including SDK/package publish behavior

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- Verified the workflow diff locally
- Confirmed `publish-documentation` is now gated to `next` only
- Ran `git diff --check` successfully

Note:
- Repository pre-commit checks on `task-refactor` currently fail due to unrelated existing TypeScript/Jest issues in other packages, not because of this workflow-only change.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [x] Automation

Tool used for AI assistance:
- OpenAI Codex

### Checklist before merging

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link
