### PR TITLE
chore(ci): gate docs publish on next only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: # Allow list of deployable tags and branches. Note that all allow-listed branches cannot include any `/` characters
       - next
+      - task-refactor
 
 env:
   rid: ${{ github.run_id }}-${{ github.run_number }}
@@ -157,6 +158,7 @@ jobs:
     name: Publish - Documentation
     needs: [publish-npm,analyze-changes]
     runs-on: ubuntu-latest
+    if: github.ref_name == 'next'
 
     steps:
       - name: Documentation Deploy Steps


### PR DESCRIPTION
## This pull request addresses

This follow-up PR brings the same `publish-documentation` guard onto `next` so the deploy workflow behavior is aligned there as well.

## by making the following changes

- Added `if: github.ref_name == 'next'` to the `publish-documentation` job in `.github/workflows/deploy.yml`
- Kept the rest of the deploy workflow unchanged

## Notes

- This is a small follow-up PR against `next`
- It mirrors the docs-publish guard introduced for `task-refactor`-based work so deployment behavior is consistent once merged