### PR TITLE
chore(ci): gate docs publish on next only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: # Allow list of deployable tags and branches. Note that all allow-listed branches cannot include any `/` characters
       - next
+      - task-refactor
 
 env:
   rid: ${{ github.run_id }}-${{ github.run_number }}
@@ -157,6 +158,7 @@ jobs:
     name: Publish - Documentation
     needs: [publish-npm,analyze-changes]
     runs-on: ubuntu-latest
+    if: github.ref_name == 'next'
 
     steps:
       - name: Documentation Deploy Steps


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This follow-up PR aligns `next` with the workflow change needed for `task-refactor`: we still need `task-refactor` to remain in the deploy workflow for SDK/package publishing, but we do not want documentation publishing to run from that branch.

## by making the following changes

- Added `task-refactor` to the deploy workflow branch allowlist in `.github/workflows/deploy.yml`
- Restricted the `publish-documentation` job to run only when `github.ref_name == 'next'`
- Kept the rest of the deploy pipeline unchanged

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- Verified the workflow diff locally
- Confirmed the deploy trigger now includes both `next` and `task-refactor`
- Confirmed `publish-documentation` is gated to `next` only
- Ran `git diff --check` successfully

Note:
- This is a follow-up PR against `next` so the workflow behavior matches the intended `task-refactor` fix after merge.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [x] Automation

Tool used for AI assistance:
- OpenAI Codex

### Checklist before merging

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link
