### PR TITLE
chore(ci): add no-op next deploy comment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ run-name: ${{ github.actor }} is running Deploy CD
 on:
   push:
     branches: # Allow list of deployable tags and branches. Note that all allow-listed branches cannot include any `/` characters
-      - next
+      - next # primary deploy branch
 
 env:
   rid: ${{ github.run_id }}-${{ github.run_number }}


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

This is a dummy follow-up PR against `next` to trigger the normal deploy flow after merge without changing workflow behavior.

## by making the following changes

- Added a harmless inline comment to the `next` branch entry in `.github/workflows/deploy.yml`
- Kept workflow behavior unchanged

### Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- Verified the diff is comment-only
- Confirmed there is no functional workflow logic change
- Ran `git diff --check` successfully

Note:
- This PR is intentionally a no-op change used only to get a merge onto `next`.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [ ] Tech Debt
  - [x] Automation

Tool used for AI assistance:
- OpenAI Codex

### Checklist before merging

- [x] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link