### PR TITLE
fix(store,samples): support multi-login hydrate and WebRTC gating

### DIFF
--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/contact-center": "3.12.0-task-refactor.8",
+    "@webex/contact-center": "3.12.0-task-refactor.11",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/packages/contact-center/store/src/storeEventsWrapper.ts
+++ b/packages/contact-center/store/src/storeEventsWrapper.ts
@@ -33,6 +33,8 @@ import {
 import {runInAction} from 'mobx';
 import {isIncomingTask} from './task-utils';
 
+const TASK_MULTI_LOGIN_HYDRATE = 'task:multiLoginHydrate';
+
 class StoreWrapper implements IStoreWrapper {
   store: IStore;
   onIncomingTask: ({task}: {task: ITask}) => void;
@@ -238,7 +240,7 @@ class StoreWrapper implements IStoreWrapper {
       // Determine if the new task is the same as the current task
       let isSameTask = false;
       if (task && this.currentTask) {
-        isSameTask = task.data.interactionId === this.currentTask.data.interactionId;
+        isSameTask = this.getTaskInteractionId(task) === this.getTaskInteractionId(this.currentTask);
       }
 
       // Update the current task
@@ -694,6 +696,46 @@ class StoreWrapper implements IStoreWrapper {
     this.refreshTaskList();
   };
 
+  private getTaskInteractionId = (task: ITask | null | undefined): string | undefined => {
+    return (
+      task?.data?.interactionId ??
+      // SDK task-class mode compatibility
+      (task as ITask & {getInteractionId?: () => string})?.getInteractionId?.() ??
+      (task as ITask & {getInteraction?: () => {id?: string}})?.getInteraction?.()?.id
+    );
+  };
+
+  private getTaskInteractionState = (task: ITask | null | undefined): string | undefined => {
+    return (
+      task?.data?.interaction?.state ??
+      // SDK task-class mode compatibility
+      (task as ITask & {getInteractionState?: () => string})?.getInteractionState?.() ??
+      (task as ITask & {getInteraction?: () => {state?: string}})?.getInteraction?.()?.state
+    );
+  };
+
+  handleMultiLoginHydrate = (event) => {
+    const task = event as ITask;
+    if (!task) {
+      this.store.logger.warn('CC-Widgets: handleMultiLoginHydrate(): task payload missing', {
+        module: 'storeEventsWrapper.ts',
+        method: 'handleMultiLoginHydrate',
+      });
+      return;
+    }
+
+    const interactionId = this.getTaskInteractionId(task);
+    const interactionState = this.getTaskInteractionState(task);
+
+    if (interactionId && this.store.taskList[interactionId] && interactionState === 'new') {
+      return;
+    }
+
+    this.registerTaskEventListeners(task);
+    this.refreshTaskList();
+    this.handleTaskAssigned(task);
+  };
+
   handleTaskHydrate = (event) => {
     const task = event;
 
@@ -866,6 +908,7 @@ class StoreWrapper implements IStoreWrapper {
         method: 'setupIncomingTaskHandler#addEventListeners',
       });
       ccSDK.on(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
+      ccSDK.on(TASK_MULTI_LOGIN_HYDRATE, this.handleMultiLoginHydrate);
       ccSDK.on(CC_EVENTS.AGENT_STATE_CHANGE, this.handleStateChange);
       ccSDK.on(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
       ccSDK.on(TASK_EVENTS.TASK_MERGED, this.handleTaskMerged);
@@ -879,6 +922,7 @@ class StoreWrapper implements IStoreWrapper {
         method: 'setupIncomingTaskHandler#removeEventListeners',
       });
       ccSDK.off(TASK_EVENTS.TASK_HYDRATE, this.handleTaskHydrate);
+      ccSDK.off(TASK_MULTI_LOGIN_HYDRATE, this.handleMultiLoginHydrate);
       ccSDK.off(CC_EVENTS.AGENT_STATE_CHANGE, this.handleStateChange);
       ccSDK.off(TASK_EVENTS.TASK_INCOMING, this.handleIncomingTask);
       ccSDK.off(TASK_EVENTS.TASK_MERGED, this.handleTaskMerged);

--- a/packages/contact-center/store/tests/storeEventsWrapper.ts
+++ b/packages/contact-center/store/tests/storeEventsWrapper.ts
@@ -33,6 +33,8 @@ import {
   mockQueueDetails,
 } from '@webex/test-fixtures';
 
+const TASK_MULTI_LOGIN_HYDRATE = 'task:multiLoginHydrate';
+
 jest.mock('../src/store', () => ({
   getInstance: jest.fn().mockReturnValue({
     teams: 'mockTeams',
@@ -1093,6 +1095,7 @@ describe('storeEventsWrapper', () => {
       });
 
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, expect.any(Function));
+      expect(onSpy).toHaveBeenCalledWith(TASK_MULTI_LOGIN_HYDRATE, expect.any(Function));
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, expect.any(Function));
       expect(onSpy).toHaveBeenCalledWith(TASK_EVENTS.TASK_MERGED, expect.any(Function));
       expect(onSpy).toHaveBeenCalledWith(CC_EVENTS.AGENT_STATE_CHANGE, expect.any(Function));
@@ -1518,6 +1521,60 @@ describe('storeEventsWrapper', () => {
       });
     });
 
+    it('should skip multiLoginHydrate when interaction already exists in taskList with new state', () => {
+      const interactionId = 'multi-hydrate-skip-1';
+      const task = {
+        data: {
+          interactionId,
+          interaction: {state: 'new'},
+        },
+        on: jest.fn(),
+        off: jest.fn(),
+      } as unknown as ITask;
+
+      storeWrapper['store'].taskList = {[interactionId]: task};
+
+      const registerSpy = jest.spyOn(
+        storeWrapper as unknown as {registerTaskEventListeners: (task: ITask) => void},
+        'registerTaskEventListeners'
+      );
+      const refreshSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
+      const assignedSpy = jest.spyOn(storeWrapper, 'handleTaskAssigned');
+
+      storeWrapper.handleMultiLoginHydrate(task);
+
+      expect(registerSpy).not.toHaveBeenCalled();
+      expect(refreshSpy).not.toHaveBeenCalled();
+      expect(assignedSpy).not.toHaveBeenCalled();
+    });
+
+    it('should process multiLoginHydrate when interaction state is connected', () => {
+      const interactionId = 'multi-hydrate-connected-1';
+      const task = {
+        data: {
+          interactionId,
+          interaction: {state: 'connected'},
+        },
+        on: jest.fn(),
+        off: jest.fn(),
+      } as unknown as ITask;
+
+      storeWrapper['store'].taskList = {[interactionId]: task};
+
+      const registerSpy = jest.spyOn(
+        storeWrapper as unknown as {registerTaskEventListeners: (task: ITask) => void},
+        'registerTaskEventListeners'
+      );
+      const refreshSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
+      const assignedSpy = jest.spyOn(storeWrapper, 'handleTaskAssigned');
+
+      storeWrapper.handleMultiLoginHydrate(task);
+
+      expect(registerSpy).toHaveBeenCalledWith(task);
+      expect(refreshSpy).toHaveBeenCalled();
+      expect(assignedSpy).toHaveBeenCalledWith(task);
+    });
+
     it('should handle hydrating the store with correct data', async () => {
       const setCurrentTaskSpy = jest.spyOn(storeWrapper, 'setCurrentTask');
       const refreshTaskListSpy = jest.spyOn(storeWrapper, 'refreshTaskList');
@@ -1582,6 +1639,7 @@ describe('storeEventsWrapper', () => {
       });
 
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_HYDRATE, expect.any(Function));
+      expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_MULTI_LOGIN_HYDRATE, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_INCOMING, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(TASK_EVENTS.TASK_MERGED, expect.any(Function));
       expect(storeWrapper['cc'].off).toHaveBeenCalledWith(CC_EVENTS.AGENT_STATE_CHANGE, expect.any(Function));

--- a/widgets-samples/cc/samples-cc-react-app/src/App.tsx
+++ b/widgets-samples/cc/samples-cc-react-app/src/App.tsx
@@ -88,6 +88,18 @@ function App() {
     const savedAllowInternationalDn = window.localStorage.getItem('allowInternationalDn');
     return savedAllowInternationalDn === 'true';
   });
+  const [disableWebRTCRegistration, setDisableWebRTCRegistration] = useState(() => {
+    const savedDisableWebRTCRegistration = window.localStorage.getItem('disableWebRTCRegistration');
+    return savedDisableWebRTCRegistration === 'true';
+  });
+  const [isWebRTCWidgetSelectionLocked, setIsWebRTCWidgetSelectionLocked] = useState(() => {
+    const savedDisableWebRTCRegistration = window.localStorage.getItem('disableWebRTCRegistration');
+    return savedDisableWebRTCRegistration === 'true';
+  });
+
+  const WEBRTC_DEPENDENT_WIDGETS = ['incomingTask', 'taskList', 'callControl', 'callControlCAD'];
+  const isWidgetDisabledByWebRTC = (widget: string) =>
+    isWebRTCWidgetSelectionLocked && WEBRTC_DEPENDENT_WIDGETS.includes(widget);
 
   const handleSaveStart = () => {
     setShowLoader(true);
@@ -136,6 +148,7 @@ function App() {
     },
     cc: {
       allowMultiLogin: isMultiLoginEnabled,
+      disableWebRTCRegistration,
     },
     ...(integrationEnv && {
       services: {
@@ -220,6 +233,26 @@ function App() {
     } else {
       setIsMultiLoginEnabled(true);
     }
+  };
+
+  const toggleDisableWebRTCRegistration = () => {
+    const newValue = !disableWebRTCRegistration;
+
+    if (!newValue) {
+      setDisableWebRTCRegistration(false);
+      return;
+    }
+
+    // Ensure dependent widgets are unchecked first, then lock their selection.
+    setIsWebRTCWidgetSelectionLocked(false);
+    setSelectedWidgets((prev) => {
+      const next = {...prev};
+      WEBRTC_DEPENDENT_WIDGETS.forEach((widget) => {
+        next[widget] = false;
+      });
+      return next;
+    });
+    setDisableWebRTCRegistration(true);
   };
 
   function playNotificationSound() {
@@ -326,6 +359,9 @@ function App() {
           redirect_uri: redirectUri,
           scope: requestedScopes,
         },
+        cc: {
+          disableWebRTCRegistration,
+        },
       },
     };
 
@@ -363,6 +399,36 @@ function App() {
   useEffect(() => {
     window.localStorage.setItem('hideDesktopLogin', JSON.stringify(hideDesktopLogin));
   }, [hideDesktopLogin]);
+  useEffect(() => {
+    window.localStorage.setItem('disableWebRTCRegistration', JSON.stringify(disableWebRTCRegistration));
+  }, [disableWebRTCRegistration]);
+
+  useEffect(() => {
+    if (!disableWebRTCRegistration) {
+      setIsWebRTCWidgetSelectionLocked(false);
+      return;
+    }
+
+    const hasDependentWidgetChecked = WEBRTC_DEPENDENT_WIDGETS.some((widget) => selectedWidgets[widget]);
+    if (hasDependentWidgetChecked) {
+      setSelectedWidgets((prev) => {
+        const next = {...prev};
+        let changed = false;
+
+        WEBRTC_DEPENDENT_WIDGETS.forEach((widget) => {
+          if (next[widget]) {
+            next[widget] = false;
+            changed = true;
+          }
+        });
+
+        return changed ? next : prev;
+      });
+      return;
+    }
+
+    setIsWebRTCWidgetSelectionLocked(true);
+  }, [disableWebRTCRegistration, selectedWidgets]);
 
   useEffect(() => {
     store.setIncomingTaskCb(onIncomingTaskCB);
@@ -524,6 +590,7 @@ function App() {
                               name={widget}
                               checked={selectedWidgets[widget]}
                               onChange={handleCheckboxChange}
+                              disabled={isWidgetDisabledByWebRTC(widget)}
                               data-testid={`samples:widget-${widget}`}
                             />
                             &nbsp;
@@ -542,7 +609,7 @@ function App() {
                                       style={{color: 'var(--mds-color-theme-text-error-normal)', marginBottom: '10px'}}
                                     >
                                       <strong>Note:</strong> When a number is dialed, the agent gets an incoming task to
-                                      accept via an Extension, Dial Number, or Browser. It's recommended to have the
+                                      accept via an Extension, Dial Number, or Browser. It is recommended to have the
                                       incoming task/task list widget and call controls widget according to your needs.
                                     </div>
                                   </Text>
@@ -631,11 +698,50 @@ function App() {
                         <Text>
                           <div
                             className="warning-note"
-                            style={{color: 'var(--mds-color-theme-text-error-normal)', marginBottom: '10px'}}
+                            style={{
+                              color: 'var(--mds-color-theme-text-error-normal)',
+                              marginBottom: '10px',
+                              maxWidth: '320px',
+                            }}
                           >
-                            <strong>Note:</strong> The "Enable Multi Login" option must be set before initializing the
+                            <strong>Note:</strong> The Enable Multi Login option must be set before initializing the
                             SDK. Changes to this setting after SDK initialization will not take effect. Please ensure
-                            you configure this option before clicking the "Init Widgets" button.
+                            you configure this option before clicking the Init Widgets button.
+                          </div>
+                        </Text>
+                      </PopoverNext>
+                    </label>
+                    <label style={{display: 'flex', flexDirection: 'row', alignItems: 'center', marginTop: '10px'}}>
+                      <input
+                        data-testid="samples:disable-webrtc-registration-checkbox"
+                        type="checkbox"
+                        id="disableWebRTCRegistrationFlag"
+                        name="disableWebRTCRegistrationFlag"
+                        onChange={toggleDisableWebRTCRegistration}
+                        checked={disableWebRTCRegistration}
+                      />{' '}
+                      &nbsp; Disable WebRTC Registration
+                      <PopoverNext
+                        trigger="mouseenter"
+                        triggerComponent={<Icon name="info-badge-filled" />}
+                        placement="auto-end"
+                        closeButtonPlacement="top-left"
+                        closeButtonProps={{'aria-label': 'Close'}}
+                      >
+                        <Text>
+                          <div
+                            className="warning-note"
+                            style={{
+                              color: 'var(--mds-color-theme-text-error-normal)',
+                              marginBottom: '10px',
+                              maxWidth: '320px',
+                            }}
+                          >
+                            <strong>Note:</strong> Disabling WebRTC registration prevents browser-based calling. When
+                            enabled, the Incoming Task, Task List, Call Control, and Call Control with CAD
+                            widgets will be unchecked and disabled because they depend on call handling. Set this
+                            option before clicking the Init Widgets button - changes after SDK initialization will
+                            not take effect.
                           </div>
                         </Text>
                       </PopoverNext>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9544,7 +9544,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/contact-center": "npm:3.12.0-task-refactor.8"
+    "@webex/contact-center": "npm:3.12.0-task-refactor.11"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
     babel-loader: "npm:9.2.1"
@@ -9937,9 +9937,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/contact-center@npm:3.12.0-task-refactor.8":
-  version: 3.12.0-task-refactor.8
-  resolution: "@webex/contact-center@npm:3.12.0-task-refactor.8"
+"@webex/contact-center@npm:3.12.0-task-refactor.11":
+  version: 3.12.0-task-refactor.11
+  resolution: "@webex/contact-center@npm:3.12.0-task-refactor.11"
   dependencies:
     "@types/platform": "npm:1.3.4"
     "@webex/calling": "npm:3.12.0-task-refactor.1"
@@ -9953,7 +9953,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     xstate: "npm:5.24.0"
-  checksum: 10c0/3bca6eccf570e65f27ef2a17f7574b871de23a975f2541943a69452a03b7eeddf7a9e529315586672e789b2a56e3a5936139ddc3931250d9febdd1daef569689
+  checksum: 10c0/e8a280310ec0ecbaae3d60a6cad67062c4d3a7866402ec7c1b5fada89b4cd5fb9f73fcd4687d620daa1453ea1658cda492bb94268560ae8151ac95ccc128af0c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES #https://jira-eng-sjc12.cisco.com/jira/browse/CAI-7899

## This pull request addresses

Multi-login mirrored widget sessions were not consistently hydrating `ENGAGED` custom state, and the sample React app did not expose or enforce the `disableWebRTCRegistration` behavior for WebRTC-dependent widgets.

## by making the following changes

- add `task:multiLoginHydrate` handling in `cc-store` event wiring, including listener registration/removal and dedupe for already-known `new` interactions
- add SDK task-class compatibility accessors when resolving interaction id/state in store event handling
- update store tests to cover multi-login hydrate listener wiring, skip-path, and process-path behavior
- update `samples-cc-react-app` to pass `disableWebRTCRegistration` in SDK config, add UI toggle, and uncheck WebRTC-dependent widgets before locking their selection

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- Automated: `yarn workspace @webex/cc-store exec jest tests/storeEventsWrapper.ts --runInBand`
- Automated: `yarn workspace samples-cc-react-app build`
- Automated (hook validation): repository pre-commit checks executed during commit

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify
    - Cursor/Codex
- [x] This PR is related to
  - [x] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.

Made with [Cursor](https://cursor.com)