### PR TITLE
fix(tooling): pin NODE_ENV=test on jest invocations

### DIFF
--- a/ai-docs/patterns/testing-patterns.md
+++ b/ai-docs/patterns/testing-patterns.md
@@ -214,6 +214,12 @@ yarn test:styles       # style tests across workspaces
 yarn workspace @webex/cc-user-state test:unit   # a single package
 ```
 
+Each package's `test:unit` (and root `test:tooling`) pins `NODE_ENV=test` on the `jest`
+invocation. Jest only defaults `NODE_ENV` to `test` when it is *unset*; in a CI pod that already
+exports `NODE_ENV=production`, React loads its production build and `act(...)` throws
+(`act(...) is not supported in production builds of React`). Pinning it keeps tests correct
+regardless of the ambient environment.
+
 **Where it appears**
 - Root `package.json` `scripts` block (`test:unit`, `test:cc-widgets`, `test:e2e`, `test:styles`, `test:tooling`, `test:meetings-widget`).
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:unit": "yarn run test:tooling && yarn run test:cc-widgets && yarn run test:meetings-widget",
     "test:e2e": "yarn playwright test",
     "test:styles": "yarn workspaces foreach --all --exclude webex-widgets run test:styles",
-    "test:tooling": "jest --coverage",
+    "test:tooling": "NODE_ENV=test jest --coverage",
     "test:cc-widgets": "yarn workspaces foreach --all --exclude webex-widgets --exclude samples-cc-wc-app --exclude samples-cc-react-app run test:unit",
     "test:meetings-widget": "yarn workspaces foreach --all --verbose --include @webex/widgets run test:unit",
     "build:dev": "NODE_ENV=development yarn build",

--- a/packages/@webex/widgets/package.json
+++ b/packages/@webex/widgets/package.json
@@ -20,7 +20,7 @@
     "release:debug": "semantic-release --debug",
     "release:dry-run": "semantic-release --dry-run",
     "start": "npm run demo:serve",
-    "test:unit": "jest --config jest.config.js --coverage",
+    "test:unit": "NODE_ENV=test jest --config jest.config.js --coverage",
     "test:e2e": "npm run demo:build && wdio wdio.conf.js",
     "test:eslint": "echo 'Broken eslint tests'",
     "test:eslint:broken": "eslint src/"

--- a/packages/contact-center/cc-components/package.json
+++ b/packages/contact-center/cc-components/package.json
@@ -30,7 +30,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "tsc --project tsconfig.test.json && jest --coverage",
+    "test:unit": "tsc --project tsconfig.test.json && NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/cc-digital-channels/package.json
+++ b/packages/contact-center/cc-digital-channels/package.json
@@ -18,7 +18,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && yarn run build && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "jest --coverage",
+    "test:unit": "NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/cc-widgets/package.json
+++ b/packages/contact-center/cc-widgets/package.json
@@ -30,7 +30,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "jest --coverage",
+    "test:unit": "NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/station-login/package.json
+++ b/packages/contact-center/station-login/package.json
@@ -18,7 +18,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "tsc --project tsconfig.test.json && jest --coverage",
+    "test:unit": "tsc --project tsconfig.test.json && NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -18,7 +18,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "tsc --project tsconfig.test.json && jest --coverage",
+    "test:unit": "tsc --project tsconfig.test.json && NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/task/package.json
+++ b/packages/contact-center/task/package.json
@@ -18,7 +18,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "tsc --project tsconfig.test.json && jest --coverage",
+    "test:unit": "tsc --project tsconfig.test.json && NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/ui-logging/package.json
+++ b/packages/contact-center/ui-logging/package.json
@@ -16,7 +16,7 @@
     "build:src": "webpack --mode=development",
     "clean": "rm -rf dist",
     "clean:dist": "rm -rf dist",
-    "test:unit": "jest --coverage",
+    "test:unit": "NODE_ENV=test jest --coverage",
     "test:styles": "echo 'No styles to test'",
     "deploy:npm": "yarn npm publish"
   },

--- a/packages/contact-center/user-state/package.json
+++ b/packages/contact-center/user-state/package.json
@@ -18,7 +18,7 @@
     "build": "yarn run -T tsc",
     "build:src": "yarn run clean:dist && webpack",
     "build:watch": "webpack --watch",
-    "test:unit": "tsc --project tsconfig.test.json && jest --coverage",
+    "test:unit": "tsc --project tsconfig.test.json && NODE_ENV=test jest --coverage",
     "test:styles": "eslint",
     "deploy:npm": "yarn npm publish"
   },


### PR DESCRIPTION
# COMPLETES #< INSERT LINK TO ISSUE >

## This pull request addresses

Unit tests fail in CI/pod environments that already export `NODE_ENV=production`. Jest only defaults `NODE_ENV` to `test` when it is **unset**; when the ambient environment already sets `NODE_ENV=production`, Jest inherits it, React loads its production build, and `act(...)` throws:

```
act(...) is not supported in production builds of React
```

This failed 24 `@webex/cc-user-state` tests (and is latent for every other package). The test commands in the manifest and docs only specified the bare `yarn test:cc-widgets` / `yarn workspace @webex/{pkg} test:unit`, none of which pinned `NODE_ENV`, so the repository contract did not account for running inside a pod with `NODE_ENV=production`.

## by making the following changes

Pin `NODE_ENV=test` directly on the `jest` invocation at the source, so it is correct regardless of the ambient environment and regardless of which invocation path is used (single-package, `test:cc-widgets`, or the aggregate `test:unit`):

- Root `package.json`: `test:tooling`.
- Every package `test:unit` that runs `jest`: `store`, `cc-components`, `cc-widgets`, `cc-digital-channels`, `user-state`, `task`, `station-login`, `ui-logging`, and meetings `@webex/widgets`.
- Documented the rationale in `ai-docs/patterns/testing-patterns.md`.

Follows the repo's existing inline-env convention (`build:dev` / `build:prod` in root `package.json`); `cross-env` is not a workspace dependency. The `.sdd/manifest.json` command stays as the bare `yarn test:cc-widgets` since the fix is now at the source.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- Reproduced the failure: `NODE_ENV=production yarn workspace @webex/cc-user-state test:unit` failed with `act(...) is not supported in production builds of React` before the change.
- After the change, the same command passes (24/24 tests).
- Ran the full pre-commit suite with the ambient failure condition: `NODE_ENV=production yarn run test:unit` → exit 0, all suites pass, zero `not supported in production builds` errors.
- Pre-commit hook (full `test:unit` + `test:styles`) passed on commit.

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [x] GAI was used to create a draft that was subsequently customized or modified
- [x] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Please Specify: Claude Code
- [x] This PR is related to
  - [ ] Feature
  - [ ] Defect fix
  - [x] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [x] I have updated the testing document
- [ ] I have tested the functionality with amplify link
