### PR TITLE
fix(widgets): bump sdk-component-adapter to 1.113.3 and components to 1.277.1

### DIFF
--- a/packages/@webex/widgets/ai-docs/widgets-spec.md
+++ b/packages/@webex/widgets/ai-docs/widgets-spec.md
@@ -135,9 +135,9 @@ Compatibility notes:
 ## Requires (dependencies)
 - `webex` `2.60.4` (pinned, also peer) — the JS SDK; constructed in the `adapterFactory`
   (`WebexMeetings.jsx:260`). No fallback: an invalid/expired token leaves the widget on a loading state.
-- `@webex/sdk-component-adapter` `1.112.12` (pinned) — RxJS adapter wrapping the SDK; constructed via
+- `@webex/sdk-component-adapter` `1.113.3` (pinned) — RxJS adapter wrapping the SDK; constructed via
   `new WebexSDKAdapter(webex)` (`WebexMeetings.jsx:277`).
-- `@webex/components` `1.275.2` (pinned) — supplies `WebexMeeting`, `WebexMediaAccess`, and the
+- `@webex/components` `1.277.1` (pinned) — supplies `WebexMeeting`, `WebexMediaAccess`, and the
   `withAdapter`/`withMeeting` HOCs (`WebexMeetings.jsx:4`) plus the `webex-components.css`.
 - `@webex/component-adapter-interfaces` `^1.30.5` — meeting-state enum (`MeetingState`) and adapter
   interfaces used by the adapter/components layers.

--- a/packages/@webex/widgets/package.json
+++ b/packages/@webex/widgets/package.json
@@ -40,8 +40,8 @@
   ],
   "dependencies": {
     "@webex/component-adapter-interfaces": "^1.30.5",
-    "@webex/components": "1.275.2",
-    "@webex/sdk-component-adapter": "1.112.12",
+    "@webex/components": "1.277.1",
+    "@webex/sdk-component-adapter": "1.113.3",
     "webex": "2.60.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10148,9 +10148,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/components@npm:1.275.2":
-  version: 1.275.2
-  resolution: "@webex/components@npm:1.275.2"
+"@webex/components@npm:1.277.1":
+  version: 1.277.1
+  resolution: "@webex/components@npm:1.277.1"
   dependencies:
     "@juggle/resize-observer": "npm:^3.2.0"
     "@webex/component-adapter-interfaces": "npm:^1.28.0"
@@ -10166,7 +10166,7 @@ __metadata:
     react: 18.3.1
     react-dom: 18.3.1
     rxjs: ^6.6.2
-  checksum: 10c0/b1e20cae9e4bc6d82cf497ad9e12e02d5d73850f2ac6b92819919ef5bfcb93d9bdc32f7772eccdfea1fa5cdba8902374773920de75075e6680a65bf3e4378d2b
+  checksum: 10c0/6a9050d5af0f38e29161edc845ec5156f18df893fe51ec8bd625a4495147a75f902dd50331a2a0fd57840ce9017c8cd52991420dbcfd13b94bcffcf7b8c8ad11
   languageName: node
   linkType: hard
 
@@ -11852,9 +11852,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/sdk-component-adapter@npm:1.112.12":
-  version: 1.112.12
-  resolution: "@webex/sdk-component-adapter@npm:1.112.12"
+"@webex/sdk-component-adapter@npm:1.113.3":
+  version: 1.113.3
+  resolution: "@webex/sdk-component-adapter@npm:1.113.3"
   dependencies:
     "@babel/plugin-transform-runtime": "npm:^7.16.0"
     "@webex/common": "npm:^2.60.4"
@@ -11864,7 +11864,7 @@ __metadata:
   peerDependencies:
     rxjs: ^6.5.4
     webex: ^2.60.4
-  checksum: 10c0/c9c9bec529705dfa49bd92e5a3abd44edaa28aebcfb569e5259454c05d8946a6724839d980df7be1a47ce8dc5bd01ec0d6575cd517257123fe0800513fd2d1d2
+  checksum: 10c0/2a32e4d78a54a873a3a92eaeca8bcf570cc83cc02a15f6bd0eaa00774faba109daff0948158bdfc795c779071ac0ab58d7b67f43d8da78903a0d0d82e40dae6f
   languageName: node
   linkType: hard
 
@@ -12641,8 +12641,8 @@ __metadata:
     "@wdio/spec-reporter": "npm:^7.4.3"
     "@wdio/static-server-service": "npm:^7.5.7"
     "@webex/component-adapter-interfaces": "npm:^1.30.5"
-    "@webex/components": "npm:1.275.2"
-    "@webex/sdk-component-adapter": "npm:1.112.12"
+    "@webex/components": "npm:1.277.1"
+    "@webex/sdk-component-adapter": "npm:1.113.3"
     "@webex/test-users": "npm:^1.157.0"
     babel-eslint: "npm:^10.0.3"
     babel-loader: "npm:^8.0.6"


### PR DESCRIPTION
# COMPLETES https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-824300

## This pull request addresses

Meetings Widget **device switching** and **meeting controls** (⋯ menu, roster, mute, join, etc.) broke after `@webex/sdk-component-adapter@1.113.0` shipped with [sdk-component-adapter#346](https://github.com/webex/sdk-component-adapter/pull/346). The adapter expected control `action({ meetingID })` context objects, but `@webex/components@1.277.1` still calls `action(meetingID)` (string) and `action(meetingID, deviceId)` for device switches — causing `Could not find meeting with ID "undefined"` and failed mic/speaker/camera selection.

**Fix landed in adapter:** [sdk-component-adapter#350](https://github.com/webex/sdk-component-adapter/pull/350), published as **`@webex/sdk-component-adapter@1.113.3`** on npm.

**Customer-reported stack:** `@webex/widgets` ^1.28.2, `@webex/components` 1.277.1, `@webex/sdk-component-adapter` 1.113.0, Chrome on macOS.

**Demo recordings:**
- Issue: https://app.vidcast.io/share/0fcf6564-b341-4ea2-8462-0c25121b6e93
- Fix verification: https://app.vidcast.io/share/512f16af-f8a8-4fdb-8d9b-d3badc858743

## by making the following changes

Dependency bump in `packages/@webex/widgets/package.json` (and `yarn.lock`):

| Package | Before | After |
|---------|--------|-------|
| `@webex/sdk-component-adapter` | 1.112.12 | **1.113.3** |
| `@webex/components` | 1.275.2 | **1.277.1** |

No widget source code changes — consumers of `@webex/widgets` get the adapter fix via the updated pinned dependencies.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link
- [x] **Automated:** `yarn test:meetings-widget` — 30/30 unit tests pass (`WebexMeetings.test.jsx`)
- [x] **Manual (local demo):** `yarn workspace @webex/widgets start` with npm packages (no portal link)
  - Join meeting — no `meetingID undefined` errors
  - Narrow screen → ⋯ menu → Show participants — works
  - Wide screen → Settings → switch microphone / speaker / camera — selected device applies
  - Mute/unmute audio and video — works

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [ ] GAI was used to create a draft that was subsequently customized or modified
- [x] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [ ] Other - Please Specify
- [ ] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [x] I have not skipped any automated checks
- [x] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.