### PR TITLE
fix(cc-widgets): bump SDK for EP-DN blind transfer fix (CAI-8329)

### DIFF
--- a/packages/contact-center/store/ai-docs/store-spec.md
+++ b/packages/contact-center/store/ai-docs/store-spec.md
@@ -44,7 +44,7 @@ A maintainer should start at `src/store.ts` to understand the observable shape a
 Owns Contact Center client-side state and the SDK boundary: initialize/register with `@webex/contact-center`, subscribe to CC and task events, expose reactive observables and mutators, fetch domain lists (buddy agents, queues, entry points, address book), and centralize the error callback. It does NOT own UI rendering, business validation, or any direct network protocol beyond delegating to the SDK.
 
 ## Stack
-TypeScript 5.6.3, MobX 6.13.5 (`makeAutoObservable`, `observable.ref`, `runInAction`). Consumed in React 18 via `mobx-react-lite` `observer()` in downstream packages (not a dependency of this package itself). SDK peer `@webex/contact-center` 3.12.0-next.82. Tests: Jest 29 + ts compile (`tsc --project tsconfig.test.json && jest --coverage`). Build target: `dist/index.js` (Webpack). Evidence: `packages/contact-center/store/package.json`.
+TypeScript 5.6.3, MobX 6.13.5 (`makeAutoObservable`, `observable.ref`, `runInAction`). Consumed in React 18 via `mobx-react-lite` `observer()` in downstream packages (not a dependency of this package itself). SDK peer `@webex/contact-center` 3.12.0-next.96. Tests: Jest 29 + ts compile (`tsc --project tsconfig.test.json && jest --coverage`). Build target: `dist/index.js` (Webpack). Evidence: `packages/contact-center/store/package.json`.
 
 ## Folder / Package Structure
 ```
@@ -83,7 +83,7 @@ Compatibility notes:
 - The `CC_EVENTS` / `TASK_EVENTS` enums are locally declared until the SDK exports them (see `// TODO: remove this once cc sdk exports this enum`, `store.types.ts:247`). They must stay byte-identical to the SDK's emitted event strings.
 
 ## Requires (dependencies)
-- `@webex/contact-center` SDK (peer, floor pinned in `package.json` at `3.12.0-next.82`) — the entire CC runtime: `Webex.init()`, `webex.cc.*` methods, the CC/task event stream, agent `Profile`, `webex.credentials.getUserToken()`. Consumed ONLY through the store. Fallback on unavailability: `Store.init()` rejects after a 6000ms timeout (`src/store.ts:140-142`); the wrapper wraps the rejection and invokes `onErrorCallback('Store', err)` (`src/storeEventsWrapper.ts:442-452`).
+- `@webex/contact-center` SDK (peer, floor pinned in `package.json` at `3.12.0-next.96`) — the entire CC runtime: `Webex.init()`, `webex.cc.*` methods, the CC/task event stream, agent `Profile`, `webex.credentials.getUserToken()`. Consumed ONLY through the store. Fallback on unavailability: `Store.init()` rejects after a 6000ms timeout (`src/store.ts:140-142`); the wrapper wraps the rejection and invokes `onErrorCallback('Store', err)` (`src/storeEventsWrapper.ts:442-452`).
 - `mobx` ^6.13.5 — observable state and `runInAction` for all mutations.
 - Internal: none upstream. The store is the lowest widget-layer dependency (`cc-components → widget packages → store → SDK`); it imports no widget package.
 

--- a/packages/contact-center/store/package.json
+++ b/packages/contact-center/store/package.json
@@ -23,7 +23,7 @@
     "deploy:npm": "yarn npm publish"
   },
   "dependencies": {
-    "@webex/contact-center": "3.12.0-next.87",
+    "@webex/contact-center": "3.12.0-next.96",
     "mobx": "6.13.5",
     "typescript": "5.6.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9584,17 +9584,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/calling@npm:3.12.0-next.75":
-  version: 3.12.0-next.75
-  resolution: "@webex/calling@npm:3.12.0-next.75"
+"@webex/calling@npm:3.12.0-next.81":
+  version: 3.12.0-next.81
+  resolution: "@webex/calling@npm:3.12.0-next.81"
   dependencies:
     "@types/platform": "npm:1.3.4"
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/common-timers": "npm:3.12.0-next.5"
     "@webex/internal-media-core": "npm:2.26.2"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-feature": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-feature": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.37"
     "@webex/media-helpers": "npm:3.12.0-next.10"
     async-mutex: "npm:0.4.0"
     backoff: "npm:2.5.0"
@@ -9604,7 +9604,7 @@ __metadata:
     uuid: "npm:8.3.2"
     ws: "npm:8.17.1"
     xstate: "npm:4.30.6"
-  checksum: 10c0/3863d78b32216fa1165b9307c117dccabb3eab04ecf233b9f945c8e73d1b93bc122f43694582f986fb3e98f38be212db9ce7db0f6f1a0738cc7f898486fb6eac
+  checksum: 10c0/e61387d5ea986dede59aa7f13a2a2f4d76bcf2eb2c893756554f06c46317950bcd77c247de7226d01e16690cb0520ea8e5f63da376a97c9c79ca4d9a13ae5d71
   languageName: node
   linkType: hard
 
@@ -9815,7 +9815,7 @@ __metadata:
     "@testing-library/react": "npm:16.0.1"
     "@types/jest": "npm:29.5.14"
     "@types/react-test-renderer": "npm:18"
-    "@webex/contact-center": "npm:3.12.0-next.87"
+    "@webex/contact-center": "npm:3.12.0-next.96"
     "@webex/event-dictionary-ts": "npm:^1.0.2191"
     "@webex/test-fixtures": "workspace:*"
     babel-jest: "npm:29.7.0"
@@ -10188,23 +10188,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/contact-center@npm:3.12.0-next.87":
-  version: 3.12.0-next.87
-  resolution: "@webex/contact-center@npm:3.12.0-next.87"
+"@webex/contact-center@npm:3.12.0-next.96":
+  version: 3.12.0-next.96
+  resolution: "@webex/contact-center@npm:3.12.0-next.96"
   dependencies:
     "@types/platform": "npm:1.3.4"
-    "@webex/calling": "npm:3.12.0-next.75"
-    "@webex/internal-plugin-mercury": "npm:3.12.0-next.33"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-support": "npm:3.12.0-next.34"
-    "@webex/plugin-authorization": "npm:3.12.0-next.32"
-    "@webex/plugin-logger": "npm:3.12.0-next.32"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/calling": "npm:3.12.0-next.81"
+    "@webex/internal-plugin-mercury": "npm:3.12.0-next.40"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-support": "npm:3.12.0-next.41"
+    "@webex/plugin-authorization": "npm:3.12.0-next.37"
+    "@webex/plugin-logger": "npm:3.12.0-next.37"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     jest-html-reporters: "npm:3.0.11"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     xstate: "npm:5.24.0"
-  checksum: 10c0/632e38ecd1254d4b45c9e162a0a5dc222e5578d4e3b6a73d21cc100a7353816a2ccad55e260449dc1a13f1245295114b7c9abb1cfa4f4aa7b9e4c7f7a5819c87
+  checksum: 10c0/db2ca28f278a1e3fccd6ba4365e948ac35f9e2a260ec55c98ac504460a75a65b4507a4e23a622c7f898b6a8332cfc5c3604cfac2b2a471a4a2094a0f1530f073
   languageName: node
   linkType: hard
 
@@ -10572,21 +10572,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-conversation@npm:3.12.0-next.34":
-  version: 3.12.0-next.34
-  resolution: "@webex/internal-plugin-conversation@npm:3.12.0-next.34"
+"@webex/internal-plugin-conversation@npm:3.12.0-next.41":
+  version: 3.12.0-next.41
+  resolution: "@webex/internal-plugin-conversation@npm:3.12.0-next.41"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/helper-html": "npm:3.12.0-next.5"
     "@webex/helper-image": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-encryption": "npm:3.12.0-next.33"
-    "@webex/internal-plugin-user": "npm:3.12.0-next.33"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-encryption": "npm:3.12.0-next.40"
+    "@webex/internal-plugin-user": "npm:3.12.0-next.38"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     crypto-js: "npm:^4.1.1"
     lodash: "npm:^4.17.21"
     node-scr: "npm:^0.3.0"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/0486231e5cb329936404d79091e8dd9e3fa4567b0e513b0e6b5c028c49e0f60e6e2660b757000857491e83dd6181c1503ac6096f4e0dee123a79da2305d67fdd
+  checksum: 10c0/a1f8acdb0848d72294d65a80a4be4fed1a233568ad8ac72e6bd2dff8a59aaef781a74703e9fa25c01822da84d63500b642d317492b2c2ff4b83d53eb9b74cc89
   languageName: node
   linkType: hard
 
@@ -10640,20 +10640,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-device@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/internal-plugin-device@npm:3.12.0-next.32"
+"@webex/internal-plugin-device@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/internal-plugin-device@npm:3.12.0-next.37"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/common-timers": "npm:3.12.0-next.5"
     "@webex/http-core": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.32"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.37"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     ampersand-collection: "npm:^2.0.2"
     ampersand-state: "npm:^5.0.3"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/c34da19c01ba560d9400954e2c086606720500ef1782aa2fa3b41c2e46a6b26b4959d013d0c1265e853c3b79bea6b45dddd53abda3282b02b66afda0ab6d89fb
+  checksum: 10c0/7266fcc15e013067b4f879684ebbbb0a5f763e67d00e390f46eed70a9586c5467c6638b37abc10da58349904a45600390c3fa1b36769d51aae358cffc145348d
   languageName: node
   linkType: hard
 
@@ -10749,17 +10749,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-encryption@npm:3.12.0-next.33":
-  version: 3.12.0-next.33
-  resolution: "@webex/internal-plugin-encryption@npm:3.12.0-next.33"
+"@webex/internal-plugin-encryption@npm:3.12.0-next.40":
+  version: 3.12.0-next.40
+  resolution: "@webex/internal-plugin-encryption@npm:3.12.0-next.40"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/common-timers": "npm:3.12.0-next.5"
     "@webex/http-core": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-mercury": "npm:3.12.0-next.33"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-mercury": "npm:3.12.0-next.40"
     "@webex/test-helper-file": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     asn1js: "npm:^2.0.26"
     debug: "npm:^4.3.4"
     isomorphic-webcrypto: "npm:^2.3.8"
@@ -10771,7 +10771,7 @@ __metadata:
     safe-buffer: "npm:^5.2.0"
     uuid: "npm:^3.3.2"
     valid-url: "npm:^1.0.9"
-  checksum: 10c0/125eeb93206b0ff307c8ca1ec0b90f139eae8a92c95a177b6418c81bbc83419ee6de05e17aee3363c4cdeae0712216c197127e9aba23823b040d32b8596ac6d8
+  checksum: 10c0/a1c7926e9c572cc3741ecc70a640f50380fd6d4dd9621abfcf45b01c1ee8c9e1408878f8cd09bd8fd1ff040470ce3101ac14a63b3a0c1b2b1927dff0168ddf28
   languageName: node
   linkType: hard
 
@@ -10809,14 +10809,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-feature@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/internal-plugin-feature@npm:3.12.0-next.32"
+"@webex/internal-plugin-feature@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/internal-plugin-feature@npm:3.12.0-next.37"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/cee7cf1596a74d5c716067bf82a2415c68a74604f1eccafd8f6f28a7c3f746abca10e684892dec07ef2236307d2ecaf74b28670cc505efef790fc1196d8a587b
+  checksum: 10c0/b530f2805e123cd8b902d4eaf1aafbf01a20e75829f048b68493f31ce973a3604a396f18a550aa723ceb06890c3b415c8d92b44d3b93124bb634142ba5097c38
   languageName: node
   linkType: hard
 
@@ -10963,27 +10963,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-mercury@npm:3.12.0-next.33":
-  version: 3.12.0-next.33
-  resolution: "@webex/internal-plugin-mercury@npm:3.12.0-next.33"
+"@webex/internal-plugin-mercury@npm:3.12.0-next.40":
+  version: 3.12.0-next.40
+  resolution: "@webex/internal-plugin-mercury@npm:3.12.0-next.40"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/common-timers": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-feature": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-metrics": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-feature": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-metrics": "npm:3.12.0-next.37"
     "@webex/test-helper-chai": "npm:3.12.0-next.5"
     "@webex/test-helper-mocha": "npm:3.12.0-next.5"
     "@webex/test-helper-mock-web-socket": "npm:3.12.0-next.5"
     "@webex/test-helper-mock-webex": "npm:3.12.0-next.5"
     "@webex/test-helper-refresh-callback": "npm:3.12.0-next.5"
     "@webex/test-helper-test-users": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     backoff: "npm:^2.5.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
     ws: "npm:^8.17.1"
-  checksum: 10c0/600faa2f12a85a628cd2aaac4167cdff2b8238e59a10445279070608c8f281bf9d68c81d3ba677f3f51086a8f1e42cf693ca373f56afa4673011727d2e2876eb
+  checksum: 10c0/361bcbf838101447a9838b83682ab1abcff151d74cf3927f6a8c72c58644b2dcab2722593467cbdbe78880b94c904e23aa823afcbc9b4e3a8728cf5fff12078f
   languageName: node
   linkType: hard
 
@@ -11032,20 +11032,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-metrics@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/internal-plugin-metrics@npm:3.12.0-next.32"
+"@webex/internal-plugin-metrics@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/internal-plugin-metrics@npm:3.12.0-next.37"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/common-timers": "npm:3.12.0-next.5"
     "@webex/event-dictionary-ts": "npm:^1.0.2215"
     "@webex/test-helper-chai": "npm:3.12.0-next.5"
     "@webex/test-helper-mock-webex": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     ip-anonymize: "npm:^0.1.0"
+    isbot: "npm:5.2.1"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/c125b2d06de6eb250831cdc4b1e472c73aa82ff026e2a427d6171d1d11640c5879eca52c9c6078728d77e4232e2ee102be4eb51abdb37d518f05f3ac9448bab0
+  checksum: 10c0/09e291ac15c7c00d9b14d14be03ccf6e58a5178dd1e30c89affc0d2e533ecfaced2b12f5bec17622fa7fd8fe23f5557db042b6fc00adc930fdd0c682a38f3e61
   languageName: node
   linkType: hard
 
@@ -11111,18 +11112,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-search@npm:3.12.0-next.34":
-  version: 3.12.0-next.34
-  resolution: "@webex/internal-plugin-search@npm:3.12.0-next.34"
+"@webex/internal-plugin-search@npm:3.12.0-next.41":
+  version: 3.12.0-next.41
+  resolution: "@webex/internal-plugin-search@npm:3.12.0-next.41"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-conversation": "npm:3.12.0-next.34"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-encryption": "npm:3.12.0-next.33"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-conversation": "npm:3.12.0-next.41"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-encryption": "npm:3.12.0-next.40"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/754a545ceadd421b858c6e59a932c1a3cc7e77ebf42d6e22bef8b5f3a8f20358f7740074833e3098fe7d79928917c94a02b8e5db822cc100700b7f05bc7e94f5
+  checksum: 10c0/9c3621b38e09b5c842eb02ce993ce50b3a19c442643d18a72f8bee0206f982a6af376c028181af223a471eeabb1fa8132a4d3359208a7bbf83dccea655cd44f1
   languageName: node
   linkType: hard
 
@@ -11160,20 +11161,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-support@npm:3.12.0-next.34":
-  version: 3.12.0-next.34
-  resolution: "@webex/internal-plugin-support@npm:3.12.0-next.34"
+"@webex/internal-plugin-support@npm:3.12.0-next.41":
+  version: 3.12.0-next.41
+  resolution: "@webex/internal-plugin-support@npm:3.12.0-next.41"
   dependencies:
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/internal-plugin-search": "npm:3.12.0-next.34"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/internal-plugin-search": "npm:3.12.0-next.41"
     "@webex/test-helper-chai": "npm:3.12.0-next.5"
     "@webex/test-helper-file": "npm:3.12.0-next.5"
     "@webex/test-helper-mock-webex": "npm:3.12.0-next.5"
     "@webex/test-helper-test-users": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/61c76ca76d4230d6904b6c26a8ab3a6d932360bd41e8dbcbc6831fa7f820cdeedbc83414e4331c5011309a548013a446da6ae853fdc24eaa28ece6f448043a06
+  checksum: 10c0/fbf43bfe6ffc790cba8f25a8f513708990d74b432c8fdd0768fe5716dadbf65b48a5bd4a9202c3c0597a7b8ccf9210a047e91ec2580b451fba3ae250fd42bd70
   languageName: node
   linkType: hard
 
@@ -11239,19 +11240,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/internal-plugin-user@npm:3.12.0-next.33":
-  version: 3.12.0-next.33
-  resolution: "@webex/internal-plugin-user@npm:3.12.0-next.33"
+"@webex/internal-plugin-user@npm:3.12.0-next.38":
+  version: 3.12.0-next.38
+  resolution: "@webex/internal-plugin-user@npm:3.12.0-next.38"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
     "@webex/test-helper-chai": "npm:3.12.0-next.5"
     "@webex/test-helper-mock-webex": "npm:3.12.0-next.5"
     "@webex/test-helper-test-users": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/944cd0c95c0bc765dcf1d18cf63809bfc6ca5dd8c427c451ad1d4166db235767256500f783b8f2c31f2ce691e019532fedde16596e24c10aad99424ca5294cc1
+  checksum: 10c0/e102da9efed09275128c16cf6312dfcd89c123aef27fb32ceb6f46120378b47c58b832984f952c2bcfca96db111a7228a86b5a2e1de2b7c88fad682651b64e8d
   languageName: node
   linkType: hard
 
@@ -11391,20 +11392,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization-browser@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/plugin-authorization-browser@npm:3.12.0-next.32"
+"@webex/plugin-authorization-browser@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/plugin-authorization-browser@npm:3.12.0-next.37"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/plugin-authorization-node": "npm:3.12.0-next.32"
-    "@webex/storage-adapter-local-storage": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/plugin-authorization-node": "npm:3.12.0-next.37"
+    "@webex/storage-adapter-local-storage": "npm:3.12.0-next.37"
     "@webex/storage-adapter-spec": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     jsonwebtoken: "npm:^9.0.2"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/7f79fab1b4d2981eb30cf13a0ebbc7ff34fd8f9a268a48f565a5a1e1cd76123affa1c802f2852a48c706409cadc1412a684014c8668e5211bbc4da1d12411ceb
+  checksum: 10c0/02d8e0e3e78e86a4231c938822df7387008bd1921d330806b36688c9e493a6c88e761deaecd12fb1a6a05764d4f69dd3350f32514a005c268354a53188c017e2
   languageName: node
   linkType: hard
 
@@ -11434,16 +11435,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization-node@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/plugin-authorization-node@npm:3.12.0-next.32"
+"@webex/plugin-authorization-node@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/plugin-authorization-node@npm:3.12.0-next.37"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
-    "@webex/internal-plugin-device": "npm:3.12.0-next.32"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/internal-plugin-device": "npm:3.12.0-next.37"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     jsonwebtoken: "npm:^9.0.0"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/4f74b07c6cfd5685f77e6a80d24fffe2e84921ac89a2d9ba98cb663df77925f594ef030c4b5924178013d62a2b9346c2330e8cc980745f7db7665fd1aad4f4ac
+  checksum: 10c0/1b65965ebd7b8fb666af3726a9081c585e1e628d85a9d26e5356f0ebcd749076d5bcdafef11c7a6d5e15d440159a09cd5b7b5116ebfb9045a8cdcfc5bc167cca
   languageName: node
   linkType: hard
 
@@ -11467,13 +11468,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-authorization@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/plugin-authorization@npm:3.12.0-next.32"
+"@webex/plugin-authorization@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/plugin-authorization@npm:3.12.0-next.37"
   dependencies:
-    "@webex/plugin-authorization-browser": "npm:3.12.0-next.32"
-    "@webex/plugin-authorization-node": "npm:3.12.0-next.32"
-  checksum: 10c0/55a37e73ac57b1f369d2113b65948d6e9fd1a294eccccb27c44e8621849bb090a341d441dfbba80e5a8730f10ab26fc4766d7f282eaa19fc09ff472b5aafbaa3
+    "@webex/plugin-authorization-browser": "npm:3.12.0-next.37"
+    "@webex/plugin-authorization-node": "npm:3.12.0-next.37"
+  checksum: 10c0/28db9bb063a7e65b36d68dfa4ab0d035bb8af10030358a43c7d718e858328524078c14ed76d9d07f56b65806667b541cabb0d9a87cb9a6ce499ffa430b7c5c9f
   languageName: node
   linkType: hard
 
@@ -11551,17 +11552,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/plugin-logger@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/plugin-logger@npm:3.12.0-next.32"
+"@webex/plugin-logger@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/plugin-logger@npm:3.12.0-next.37"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/test-helper-chai": "npm:3.12.0-next.5"
     "@webex/test-helper-mocha": "npm:3.12.0-next.5"
     "@webex/test-helper-mock-webex": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
+    "@webex/webex-core": "npm:3.12.0-next.37"
     lodash: "npm:^4.17.21"
-  checksum: 10c0/710db76b3516afca2d6d33bc7324c026c31281b7c71b37add9066e55587dee6245444546a3d89da587efd7dab4c0ad0f59fb45ad1ebecda5dc215782e355f834
+  checksum: 10c0/934712e278a23c1c627d56338b9d9797a8463738434363f0e590696fe64459c493d73d622a7907eae8a9a4b44b3f30e83dc26b4d2379e645e175b27e7a4d84ba
   languageName: node
   linkType: hard
 
@@ -11890,14 +11891,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/storage-adapter-local-storage@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/storage-adapter-local-storage@npm:3.12.0-next.32"
+"@webex/storage-adapter-local-storage@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/storage-adapter-local-storage@npm:3.12.0-next.37"
   dependencies:
     "@webex/storage-adapter-spec": "npm:3.12.0-next.5"
     "@webex/test-helper-mocha": "npm:3.12.0-next.5"
-    "@webex/webex-core": "npm:3.12.0-next.32"
-  checksum: 10c0/cd41fa79657e7d29d4fbd654daab128be784f38e2c806a2d02a373d1d58276a7946139d64f7068ad41d8fc0d4e5bfc392b491a995a78109f1e21711ba1491fa7
+    "@webex/webex-core": "npm:3.12.0-next.37"
+  checksum: 10c0/b09e54bb1a4b461734dfec7defc45d058256d76c015af5b004959eb8408fb92718e3c6e941574463e2a36fc526b35f3536d032e250ec32458a2bcd63f411c052
   languageName: node
   linkType: hard
 
@@ -12557,9 +12558,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webex/webex-core@npm:3.12.0-next.32":
-  version: 3.12.0-next.32
-  resolution: "@webex/webex-core@npm:3.12.0-next.32"
+"@webex/webex-core@npm:3.12.0-next.37":
+  version: 3.12.0-next.37
+  resolution: "@webex/webex-core@npm:3.12.0-next.37"
   dependencies:
     "@webex/common": "npm:3.12.0-next.5"
     "@webex/common-timers": "npm:3.12.0-next.5"
@@ -12573,7 +12574,7 @@ __metadata:
     jsonwebtoken: "npm:^9.0.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^3.3.2"
-  checksum: 10c0/28401f99fa20819fa106f5ca84dafa8707d9ae9fd3230a4eefac5832d9d2eb979778754aba93e65e6f9905a9fbfc199b87cce047cbe0fb3880e3580aa4213953
+  checksum: 10c0/2867f42a96cf8aa5b8423b0036111b4de41e19f27657bf9c9a0762d8600855a2d6e60e0bbd3c10c692977eb2cefee96760a7ecc65ea6ba6495a6e19981aaea15
   languageName: node
   linkType: hard
 
@@ -23198,6 +23199,13 @@ __metadata:
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
   checksum: 10c0/4199f14a7a13da2177c66c31080008b7124331956f47bca57dd0b6ea9f11687aa25e565a2c7a2b519bc86988d10398e3049a1f5df13c9f6b7664154690ae79fd
+  languageName: node
+  linkType: hard
+
+"isbot@npm:5.2.1":
+  version: 5.2.1
+  resolution: "isbot@npm:5.2.1"
+  checksum: 10c0/83bf2852897694f28e46d742dc9a9e722fb650a7412d9288f4eab17247a706d242e98b5794caf93804d6566df54fbe4be9e38cc2604dba04a5018d69a6abe252
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# COMPLETES https://jira-eng-sjc12.cisco.com/jira/browse/CAI-8329

## This pull request addresses

Customers reported that **blind transfer remains enabled** when Agent 1 merges an **EP-DN consult into conference before Agent 2 accepts**. Performing blind transfer in that state can leave Agent 2 stuck ringing (production issue, 17+ hours).

The **SDK fix** is already merged in [webex-js-sdk#5121](https://github.com/webex/webex-js-sdk/pull/5121). CC widgets consume transfer/consult visibility from SDK `uiControls` via the MobX store — no widget-layer logic change is required for this defect. This PR bumps the linked `@webex/contact-center` SDK version so cc-widgets consumers pick up the corrected UI control computation.

**Repro flow (Agent 1):**
1. Inbound call with customer
2. Consult to EP-DN (Agent 2)
3. Merge to conference **before** Agent 2 answers (Agent 2 still ringing)
4. **Before fix:** Blind transfer visible on main leg → using it causes stuck ringing
5. **After fix:** Blind transfer hidden; Exit Conference and main-leg controls shown correctly

## by making the following changes

- Bump `@webex/contact-center` in `@webex/cc-store` from `3.12.0-next.87` → `3.12.0-next.96` (includes SDK PR #5121)
- Refresh `yarn.lock` for the dependency update

**SDK behavior consumed by widgets (no cc-components / cc-task code changes):**
- Hides `main.transfer` when EP-DN consult is merged to conference before a second agent joins main
- Shows Exit Conference immediately after merge on the main leg
- Restores main-leg mute, end, and recording controls

**Related SDK PR:** https://github.com/webex/webex-js-sdk/pull/5121

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling change
- [ ] Internal code refactor

## The following scenarios were tested

- [ ] The testing is done with the amplify link

**Automated**
- [ ] `yarn workspace @webex/cc-store test:unit` (pending CI)
- [ ] `yarn test:cc-widgets` (pending CI)

**Manual (EP-DN consult → merge before Agent 2 accepts) — to verify after Amplify deploy**
- [ ] Agent 1: blind transfer **not** shown on main leg after conference merge during EP-DN consult
- [ ] Agent 1: Exit Conference visible and enabled immediately after merge
- [ ] Agent 1: main-leg mute, end, and recording controls visible and enabled
- [ ] Agent 1: no consult card / active leg remains main
- [ ] Agent 2: no stuck ringing when Agent 1 does not perform blind transfer

## The GAI Coding Policy And Copyright Annotation Best Practices ##

- [ ] GAI was not used (or, no additional notation is required)
- [ ] Code was generated entirely by GAI
- [x] GAI was used to create a draft that was subsequently customized or modified
- [ ] Coder created a draft manually that was non-substantively modified by GAI (e.g., refactoring was performed by GAI on manually written code)
- [ ] Tool used for AI assistance (GitHub Copilot / Other - specify)
  - [ ] Github Copilot
  - [x] Other - Cursor
- [x] This PR is related to
  - [ ] Feature
  - [x] Defect fix
  - [ ] Tech Debt
  - [ ] Automation

### Checklist before merging

- [ ] I have not skipped any automated checks
- [ ] All existing and new tests passed
- [ ] I have updated the testing document
- [ ] I have tested the functionality with amplify link

---

Make sure to have followed the [contributing guidelines](https://github.com/webex/webex-js-sdk/blob/master/CONTRIBUTING.md#submitting-a-pull-request) before submitting.